### PR TITLE
Fix publish command

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -23,10 +23,10 @@ class PublishCommand extends Command
 
     protected array $fluxComponents = [
         'free' => [
-            'Button' => ['button'],
+            // 'Button' => ['button'],
             'Dropdown' => ['dropdown', 'menu'],
             'Icon' => ['icon'],
-            'Tooltip' => ['tooltip'],
+            // 'Tooltip' => ['tooltip'],
         ],
         'pro' => [
             'Accordion' => ['accordion'],

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -23,16 +23,15 @@ class PublishCommand extends Command
 
     protected array $fluxComponents = [
         'free' => [
-            // 'Button' => ['button'],
             'Dropdown' => ['dropdown', 'menu'],
             'Icon' => ['icon'],
-            // 'Tooltip' => ['tooltip'],
         ],
         'pro' => [
             'Accordion' => ['accordion'],
             'Autocomplete' => ['autocomplete'],
             'Badge' => ['badge'],
             'Breadcrumbs' => ['breadcrumbs'],
+            'Button' => ['button'],
             'Card' => ['card'],
             'Checkbox' => ['checkbox'],
             'Command' => ['command'],
@@ -50,6 +49,7 @@ class PublishCommand extends Command
             'Table' => ['table', 'columns', 'column', 'rows', 'row', 'cell', 'pagination'],
             'Tabs' => ['tabs'],
             'Textarea' => ['textarea'],
+            'Tooltip' => ['tooltip'],
             'Typography' => ['heading', 'subheading', 'text', 'link'],
         ],
     ];


### PR DESCRIPTION
If you try to publish a button or tooltip, you get an exception. I don't know if they are meant to be free or pro, so I just commented out the option for now.

```
UnhandledMatchError 
Unhandled match case true  at /Users/eserdeniz/Projects/fork-flux/src/Console/PublishCommand.php:135
```