### PR TITLE
add tailwind RTL support

### DIFF
--- a/stubs/resources/views/flux/button/group.blade.php
+++ b/stubs/resources/views/flux/button/group.blade.php
@@ -3,8 +3,8 @@ $classes = Flux::classes()
     ->add('flex group/button')
     ->add([ // Make the first, middle, and last buttons have proper border radiuses...
         '[&>*:not(:last-child):not(:first-child)]:rounded-none',
-        'first:*:rounded-r-none',
-        'last:*:rounded-l-none',
+        'first:*:rounded-e-none',
+        'last:*:rounded-s-none',
     ])
     ;
 @endphp

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -75,7 +75,7 @@ $classes = Flux::classes()
         'outline' => 'group-[]/button:-ms-[1px] group-[]/button:first:ms-0',
         'ghost' => '',
         'subtle' => '',
-        default => 'group-[]/button:ltr:border-e group-[]/button:rtl:border-e group-[]/button:last:border-e-0 group-[]/button:border-black group-[]/button:dark:border-zinc-900/25',
+        default => 'group-[]/button:border-e group-[]/button:rtl:border-e group-[]/button:last:border-e-0 group-[]/button:border-black group-[]/button:dark:border-zinc-900/25',
     });
     
 @endphp

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -32,14 +32,14 @@ $classes = Flux::classes()
     })
     ->add($inset ? match ($size) { // Inset...
         'base' => $square
-            ? Flux::applyInset($inset, top: '-mt-2.5', right: '-mr-2.5', bottom: '-mb-2.5', left: '-ml-2.5')
-            : Flux::applyInset($inset, top: '-mt-2.5', right: '-mr-4', bottom: '-mb-3', left: '-ml-4'),
+            ? Flux::applyInset($inset, top: '-mt-2.5', right: '-me-2.5', bottom: '-mb-2.5', left: '-ms-2.5')
+            : Flux::applyInset($inset, top: '-mt-2.5', right: '-me-4', bottom: '-mb-3', left: '-ms-4'),
         'sm' => $square
-            ? Flux::applyInset($inset, top: '-mt-1.5', right: '-mr-1.5', bottom: '-mb-1.5', left: '-ml-1.5')
-            : Flux::applyInset($inset, top: '-mt-1.5', right: '-mr-3', bottom: '-mb-1.5', left: '-ml-3'),
+            ? Flux::applyInset($inset, top: '-mt-1.5', right: '-me-1.5', bottom: '-mb-1.5', left: '-ms-1.5')
+            : Flux::applyInset($inset, top: '-mt-1.5', right: '-me-3', bottom: '-mb-1.5', left: '-ms-3'),
         'xs' => $square
-            ? Flux::applyInset($inset, top: '-mt-1', right: '-mr-1', bottom: '-mb-1', left: '-ml-1')
-            : Flux::applyInset($inset, top: '-mt-1', right: '-mr-2', bottom: '-mb-1', left: '-ml-2'),
+            ? Flux::applyInset($inset, top: '-mt-1', right: '-me-1', bottom: '-mb-1', left: '-ms-1')
+            : Flux::applyInset($inset, top: '-mt-1', right: '-me-2', bottom: '-mb-1', left: '-ms-2'),
     } : '')
     ->add(match ($variant) { // Background color...
         'primary' => 'bg-zinc-800 hover:bg-zinc-900 dark:bg-white dark:hover:bg-zinc-100',
@@ -72,12 +72,12 @@ $classes = Flux::classes()
         default => '',
     })
     ->add(match ($variant) { // Grouped border treatments...
-        'outline' => 'group-[]/button:-ml-[1px] group-[]/button:first:ml-0',
+        'outline' => 'group-[]/button:-ms-[1px] group-[]/button:first:ms-0',
         'ghost' => '',
         'subtle' => '',
-        default => 'group-[]/button:border-r group-[]/button:last:border-r-0 group-[]/button:border-black group-[]/button:dark:border-zinc-900/25',
-    })
-    ;
+        default => 'group-[]/button:ltr:border-e group-[]/button:rtl:border-e group-[]/button:last:border-e-0 group-[]/button:border-black group-[]/button:dark:border-zinc-900/25',
+    });
+    
 @endphp
 
 <flux:with-tooltip :$attributes>
@@ -95,7 +95,7 @@ $classes = Flux::classes()
         <?php endif; ?>
 
         <?php if (is_string($iconTrailing)): ?>
-            <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$square ? '' : '-ml-1'" />
+            <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$square ? '' : '-ms-1'" />
         <?php elseif ($iconTrailing): ?>
             {{ $iconTrailing }}
         <?php endif; ?>

--- a/stubs/resources/views/flux/menu/checkbox/index.blade.php
+++ b/stubs/resources/views/flux/menu/checkbox/index.blade.php
@@ -32,7 +32,7 @@ $classes = Flux::classes()
     {{ $label ?? $slot }}
 
     <?php if ($suffix): ?>
-        <div class="ml-auto opacity-50 text-xs">
+        <div class="ms-auto opacity-50 text-xs">
             {{ $suffix }}
         </div>
     <?php endif; ?>

--- a/stubs/resources/views/flux/menu/item.blade.php
+++ b/stubs/resources/views/flux/menu/item.blade.php
@@ -27,13 +27,13 @@ $classes = Flux::classes()
     ;
 
 $suffixClasses = Flux::classes()
-    ->add('ml-auto text-xs text-zinc-400')
+    ->add('ms-auto text-xs text-zinc-400')
     ;
 @endphp
 
 <flux:button-or-link :attributes="$attributes->class($classes)" data-flux-menu-item :data-flux-menu-item-has-icon="!! $icon">
     <?php if ($icon): ?>
-        <flux:icon :$icon variant="mini" class="mr-2" data-flux-menu-item-icon />
+        <flux:icon :$icon variant="mini" class="me-2" data-flux-menu-item-icon />
     <?php else: ?>
         <div class="w-7 hidden [[data-flux-menu]:has(>[data-flux-menu-item-has-icon])_&]:block"></div>
     <?php endif; ?>

--- a/stubs/resources/views/flux/menu/radio/index.blade.php
+++ b/stubs/resources/views/flux/menu/radio/index.blade.php
@@ -32,7 +32,7 @@ $classes = Flux::classes()
     {{ $label ?? $slot }}
 
     <?php if ($suffix): ?>
-        <div class="ml-auto opacity-50 text-xs">
+        <div class="ms-auto opacity-50 text-xs">
             {{ $suffix }}
         </div>
     <?php endif; ?>

--- a/stubs/resources/views/flux/menu/submenu.blade.php
+++ b/stubs/resources/views/flux/menu/submenu.blade.php
@@ -7,7 +7,7 @@
         {{ $heading }}
 
         <x-slot:suffix>
-            <flux:icon class="ml-auto text-zinc-400 [[data-flux-menu-item]:hover_&]:text-current" icon="chevron-right" variant="mini" />
+            <flux:icon class="ms-auto text-zinc-400 [[data-flux-menu-item]:hover_&]:text-current rtl:rotate-180" icon="chevron-right" variant="mini" />
         </x-slot:suffix>
     </flux:menu.item>
 

--- a/stubs/resources/views/flux/navmenu/item.blade.php
+++ b/stubs/resources/views/flux/navmenu/item.blade.php
@@ -35,14 +35,14 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if ($icon): ?>
-        <flux:icon :$icon variant="mini" class="mr-2" data-navmenu-icon />
+        <flux:icon :$icon variant="mini" class="me-2" data-navmenu-icon />
     <?php endif; ?>
 
     {{ $slot }}
 
     <?php if ($suffix): ?>
         <?php if (is_string($suffix)): ?>
-            <div class="ml-auto opacity-50 text-xs">
+            <div class="ms-auto opacity-50 text-xs">
                 {{ $suffix }}
             </div>
         <?php else: ?>

--- a/stubs/resources/views/flux/tooltip/content.blade.php
+++ b/stubs/resources/views/flux/tooltip/content.blade.php
@@ -16,6 +16,6 @@ $classes = Flux::classes([
     {{ $slot }}
 
     <?php if ($kbd): ?>
-        <span class="pl-1 text-zinc-300">{{ $kbd }}</span>
+        <span class="ps-1 text-zinc-300">{{ $kbd }}</span>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
I added tailwind RTL support. below list of modifications

1. replaced `ml`, `mr`, `pl`, `pr`, `ml-auto` with `ms`, `me`, `ps`, `pe`, `ms-auto`
2. replaced `rounded-r-none`, `rounded-l-none` with `rounded-e-none`, `rounded-s-none`
3. replaced `border-r`, `border-r-0` with `border-e`, `border-e-0`
4. rotate `chevron-right` icon with 180 degrees in case of RTL.


