### PR TITLE
Fix spelling

### DIFF
--- a/src/FluxManager.php
+++ b/src/FluxManager.php
@@ -62,7 +62,7 @@ class FluxManager
         return $styles ? $builder->add($styles) : $builder;
     }
 
-    public function disalowWireModel($attributes, $componentName)
+    public function disallowWireModel($attributes, $componentName)
     {
         if ($attributes->whereStartsWith('wire:')->isNotEmpty()) {
             throw new \Exception('Cannot use wire:model on <'.$componentName.'>');


### PR DESCRIPTION
This PR fixes the spelling of the method "disallowWireModel"

The method is not called anywhere in the this repo, so the changes will most likely affect the pro package, not available yet.
Possibly also the documentation.

I have purchased a license, and once the other repos become available to me, I'll gladly send matching PRs there as well.