### PR TITLE
Fix link current check to strip the app url

### DIFF
--- a/stubs/resources/views/flux/button-or-link.blade.php
+++ b/stubs/resources/views/flux/button-or-link.blade.php
@@ -5,6 +5,8 @@
 ])
 
 @php
+$href = $href ? (string) str($href)->after(config("app.url"))->rtrim("/")->finish('/') : $href;
+
 $current = $current === null ? ($href ? request()->is($href === '/' ? '/' : trim($href, '/')) : false) : $current;
 @endphp
 

--- a/stubs/resources/views/flux/button-or-link.blade.php
+++ b/stubs/resources/views/flux/button-or-link.blade.php
@@ -5,7 +5,7 @@
 ])
 
 @php
-$href = $href ? (string) str($href)->after(config("app.url"))->rtrim("/")->finish('/') : $href;
+$href = $href ? (string) str($href)->after(config('app.url'))->rtrim('/')->finish('/') : $href;
 
 $current = $current === null ? ($href ? request()->is($href === '/' ? '/' : trim($href, '/')) : false) : $current;
 @endphp


### PR DESCRIPTION
Currently the `button-or-link` component doesn't recognise URLs generated using the `route()` helper as being the current route.

So this won't have the current page highlighting:

```blade
<flux:navlist.item href="{{ route('news') }}">Latest News</flux:navlist.item>
```

This PR fixes that.

Fixes #23