### PR TITLE
Fix publishing navmenu components

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -24,7 +24,7 @@ class PublishCommand extends Command
     protected array $fluxComponents = [
         'free' => [
             'Button' => ['button'],
-            'Dropdown' => ['dropdown', 'menu'],
+            'Dropdown' => ['dropdown', 'menu', 'navmenu'],
             'Icon' => ['icon'],
             'Separator' => ['separator'],
             'Tooltip' => ['tooltip'],


### PR DESCRIPTION
Currently, the `navmenu` components aren't published when publishing the dropdown.

Fixes #29 