### PR TITLE
Ensure button and link button display the same

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -23,7 +23,7 @@ $iconVariant ??= ($size === 'xs')
     : ($square ? 'mini' : 'micro');
 
 $classes = Flux::classes()
-    ->add('flex items-center font-medium justify-center gap-2 whitespace-nowrap')
+    ->add('inline-flex items-center font-medium justify-center gap-2 whitespace-nowrap')
     ->add('disabled:opacity-50 dark:disabled:opacity-75 disabled:cursor-default disabled:pointer-events-none')
     ->add(match ($size) { // Size...
         'base' => 'h-10 text-sm rounded-lg' . ' ' . ($square ? 'w-10' : 'px-4'),


### PR DESCRIPTION
Currently if you have a standard button and a link button, the standard button will be small but the link button will expand to fill all available space (see first screenshot below).

```blade
<flux:button>Test</flux:button>
<flux:button href="/">Test</flux:button>
```

**Before - button inline-block, link acting like a block**
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/439bf879-9eaf-4a9c-9edd-67afdbf8e616">

The reason for this is buttons are `display:inline-block` by default where as links are `display:block`.

So instead of using `flex` on the button component, we should use `inline-flex`. This PR makes that change (see second screenshot below).

**After - both acting like inline block**
<img width="213" alt="image" src="https://github.com/user-attachments/assets/7ad36403-6880-4367-9082-e22bd91090e5">


Fixes #28.