### PR TITLE
Remove trailing '/' from button-or-link.blade.php

### DIFF
--- a/stubs/resources/views/flux/button-or-link.blade.php
+++ b/stubs/resources/views/flux/button-or-link.blade.php
@@ -5,7 +5,8 @@
 ])
 
 @php
-$href = $href ? (string) str($href)->after(config('app.url'))->rtrim('/') : $href;
+$appUrl = str(config('app.url'))->rtrim('/');
+$href = $href ? ((string) str($href)->after($appUrl)->rtrim('/') === '' ? '/' : (string) str($href)->after($appUrl)->rtrim('/')) : $href;
 
 $current = $current === null ? ($href ? request()->is($href === '/' ? '/' : trim($href, '/')) : false) : $current;
 @endphp

--- a/stubs/resources/views/flux/button-or-link.blade.php
+++ b/stubs/resources/views/flux/button-or-link.blade.php
@@ -5,7 +5,7 @@
 ])
 
 @php
-$href = $href ? (string) str($href)->after(config('app.url'))->rtrim('/')->finish('/') : $href;
+$href = $href ? (string) str($href)->after(config('app.url'))->rtrim('/') : $href;
 
 $current = $current === null ? ($href ? request()->is($href === '/' ? '/' : trim($href, '/')) : false) : $current;
 @endphp


### PR DESCRIPTION
Related to issue #67 - a trailing slash is getting added to links since pr #26 , which causes unexpected behaviour when query parameters are being set.