### PR TITLE
Fix link href extra trailing slash

### DIFF
--- a/stubs/resources/views/flux/button-or-link.blade.php
+++ b/stubs/resources/views/flux/button-or-link.blade.php
@@ -5,7 +5,11 @@
 ])
 
 @php
-$href = $href ? (string) str($href)->after(config('app.url'))->rtrim('/')->finish('/') : $href;
+$href = $href ? (string) str($href)->after(trim(config('app.url'), '/')) : $href;
+
+if ($href === '') {
+    $href = '/';
+}
 
 $current = $current === null ? ($href ? request()->is($href === '/' ? '/' : trim($href, '/')) : false) : $current;
 @endphp


### PR DESCRIPTION
Follow up from PR #26 which fixed links to allow `route()` helper to be passed in as an href.

There is now an issue where some URLs have an extra trailing slash added by mistake. `https://myproject.com/some/route?parameter=value/`

This PR fixes that.

I have manually tested to make sure that the following render correctly:
- `/`
- `app.test`
- `app.test/`
- `route('home')`
- `/some-other-route?with-query=params`

Fixes #67
Fixes #93