### PR TITLE
Fix extra double quote in flux.menu.item component #121

### DIFF
--- a/stubs/resources/views/flux/menu/item.blade.php
+++ b/stubs/resources/views/flux/menu/item.blade.php
@@ -42,7 +42,7 @@ $suffixClasses = Flux::classes()
 
     <?php if ($suffix): ?>
         <?php if (is_string($suffix)): ?>
-            <div class="{{ $suffixClasses }}"">
+            <div class="{{ $suffixClasses }}">
                 {{ $suffix }}
             </div>
         <?php else: ?>


### PR DESCRIPTION
Removed an extra double quote in the flux:menu.item component on Line 45. 
This resolves issue #121 , which was causing syntax errors in the component.