### PR TITLE
Allow "current" prop on navlist items

### DIFF
--- a/stubs/resources/views/flux/button-or-link.blade.php
+++ b/stubs/resources/views/flux/button-or-link.blade.php
@@ -19,7 +19,7 @@ $current = $current === null ? ($href ? request()->is($href === '/' ? '/' : trim
         {{ $slot }}
     </a>
 <?php else: ?>
-    <button {{ $attributes->merge(['type' => $type]) }}>
+    <button {{ $attributes->merge(['type' => $type, 'data-current' => $current]) }}>
         {{ $slot }}
     </button>
 <?php endif; ?>


### PR DESCRIPTION
Original issue: https://github.com/livewire/flux/issues/162

This PR allows the use of `current` on a navlist button that triggers a dropdown:

```html
<flux:navbar>
    <flux:dropdown>
        <flux:navbar.item icon-trailing="chevron-down" current>Account</flux:navbar.item>

        <flux:navmenu>
            {{-- ... --}}
        </flux:navmenu>
    </flux:dropdown>
</flux:navbar>
```