### PR TITLE
Laravel Prompts (composer.json)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/view": "^10.0|^11.0",
         "symfony/console": "^6.0|^7.0",
         "livewire/livewire": "^3.5",
-        "laravel/prompts": "^0.1|^0.2"
+        "laravel/prompts": "^0.1|^0.2|^0.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
New Laravel installation (Laravel Framework v11.26.0, no starter kit).

```
Problem 1
    - livewire/flux v1.0.0 requires laravel/prompts ^0.1.24 -> found laravel/prompts[v0.1.24, v0.1.25] but the package is fixed to v0.3.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - livewire/flux v1.0.1 requires laravel/prompts ^0.1 -> found laravel/prompts[v0.1.0, ..., v0.1.25] but the package is fixed to v0.3.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - livewire/flux[v1.0.2, ..., v1.0.6] require laravel/prompts ^0.1|^0.2 -> found laravel/prompts[v0.1.0, ..., v0.2.1] but the package is fixed to v0.3.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```