### PR TITLE
Fix button and input group styling

### DIFF
--- a/stubs/resources/views/flux/button/group.blade.php
+++ b/stubs/resources/views/flux/button/group.blade.php
@@ -2,9 +2,9 @@
 $classes = Flux::classes()
     ->add('flex group/button')
     ->add([ // Make the first, middle, and last buttons have proper border radiuses...
-        '[&>*:not(:last-child):not(:first-child)]:rounded-none',
-        'first:*:rounded-r-none',
-        'last:*:rounded-l-none',
+        '[&>[data-flux-group-target]:not(:first-child):not(:last-child)]:rounded-none',
+        '[&>[data-flux-group-target]:first-child:not(:last-child)]:rounded-r-none',
+        '[&>[data-flux-group-target]:last-child:not(:first-child)]:rounded-l-none',
     ])
     ;
 @endphp

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -79,10 +79,12 @@ $classes = Flux::classes()
         default => '',
     })
     ->add(match ($variant) { // Grouped border treatments...
-        'outline' => 'group-[]/button:-ml-[1px] group-[]/button:first:ml-0',
         'ghost' => '',
         'subtle' => '',
-        default => 'group-[]/button:border-r group-[]/button:last:border-r-0 group-[]/button:border-black group-[]/button:dark:border-zinc-900/25',
+        'outline' => '[[data-flux-button-group]_&]:border-l-0 [[data-flux-button-group]_&:first-child]:border-l-[1px]',
+        'filled' => '[[data-flux-button-group]_&]:border-r [[data-flux-button-group]_&]:last:border-r-0 [[data-flux-button-group]_&]:border-zinc-200/80 [[data-flux-button-group]_&]:dark:border-zinc-900/50',
+        'danger' => '[[data-flux-button-group]_&]:border-r [[data-flux-button-group]_&]:last:border-r-0 [[data-flux-button-group]_&]:border-red-600 [[data-flux-button-group]_&]:dark:border-red-900/25',
+        default => '[[data-flux-button-group]_&]:border-r [[data-flux-button-group]_&]:last:border-r-0 [[data-flux-button-group]_&]:border-black [[data-flux-button-group]_&]:dark:border-zinc-900/25',
     })
     ->add($loading ? [ // Loading states...
         '*:transition-opacity',
@@ -91,6 +93,11 @@ $classes = Flux::classes()
         $type === 'submit' ? '[&[disabled]]:pointer-events-none' : '[&[data-flux-loading]]:pointer-events-none',
     ] : [])
     ;
+
+    // Exempt subtle and ghost buttons from receiving border roundness overrides from button.group...
+    $attributes = $attributes->merge([
+        'data-flux-group-target' => ! in_array($variant, ['subtle', 'ghost']),
+    ]);
 @endphp
 
 <flux:with-tooltip :$attributes>


### PR DESCRIPTION
We did a deep dive and made sure all button and input variants and combinations look good inside groups:

![CleanShot 2024-10-02 at 11 35 57@2x](https://github.com/user-attachments/assets/96ccaeb9-5a68-4ed2-a0a2-c30d04af1ae5)
