### PR TITLE
Add --force option to PublishCommand

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -17,7 +17,7 @@ use function Laravel\Prompts\warning;
 #[AsCommand(name: 'flux:publish')]
 class PublishCommand extends Command
 {
-    protected $signature = 'flux:publish {components?*} {--multiple} {--all}';
+    protected $signature = 'flux:publish {components?*} {--multiple} {--all} {--force}';
 
     protected $description = 'Publish individual flux components.';
 
@@ -141,7 +141,7 @@ class PublishCommand extends Command
     {
         $filesystem = (new Filesystem);
 
-        if ($filesystem->exists($destination)) {
+        if ($filesystem->exists($destination) && !$this->option('force')) {
             warning("Skipping [{$component}]. Directory already exists: {$destination}");
 
             return null;
@@ -156,7 +156,7 @@ class PublishCommand extends Command
     {
         $filesystem = (new Filesystem);
 
-        if ($filesystem->exists($destination)) {
+        if ($filesystem->exists($destination) && !$this->option('force')) {
             warning("Skipping [{$component}]. File already exists: {$destination}");
 
             return null;


### PR DESCRIPTION
Introduced a --force option to the PublishCommand to override existing files and directories.

This enhancement allows users to forcefully publish components even if they already exist.

Updated the logic to check this new option before skipping existing paths.