### PR TITLE
Remove focus styles so safari doesn't focus menu on first click

### DIFF
--- a/stubs/resources/views/flux/menu/index.blade.php
+++ b/stubs/resources/views/flux/menu/index.blade.php
@@ -4,6 +4,7 @@ $classes = Flux::classes()
     ->add('rounded-lg shadow-sm')
     ->add('border border-zinc-200 dark:border-zinc-600')
     ->add('bg-white dark:bg-zinc-700')
+    ->add('focus:outline-none')
     ;
 @endphp
 


### PR DESCRIPTION
At the moment if you click on a button that opens a `<flux:menu>` in Safari, on the first click, it adds focus styles to the popover. Any subsequent clicks are fine and no focus styles appear.

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/441914ef-c94a-46a4-b7b6-82a05811bfd3">

As the `<flux:menu>` has a `tabindex="-1"` when rendered, I assume that the menu should not be focusable. Because of that in this PR, I've removed the focus styles from the `<flux:menu>` component which fixes this issue.

<img width="1179" alt="image" src="https://github.com/user-attachments/assets/46b09177-734c-4bb5-8f4e-85c5277b0a9e">

Fixes https://github.com/livewire/flux/issues/51