### PR TITLE
bump laravel requirement to 3.5.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/support": "^10.0|^11.0",
         "illuminate/view": "^10.0|^11.0",
         "symfony/console": "^6.0|^7.0",
-        "livewire/livewire": "^3.5",
+        "livewire/livewire": "^3.5.12",
         "laravel/prompts": "^0.1|^0.2|^0.3"
     },
     "autoload": {


### PR DESCRIPTION
with the changes introduced to the checkboxes in 1.0.11 for https://github.com/livewire/flux/issues/336 / https://github.com/livewire/flux/issues/336#issuecomment-2414875926

you'll need to run 3.5.12 otherwise checkboxes and switches will stop working