### PR TITLE
switch to start/end instead of left/right to support RTL layouts

### DIFF
--- a/stubs/resources/views/flux/menu/checkbox/index.blade.php
+++ b/stubs/resources/views/flux/menu/checkbox/index.blade.php
@@ -13,7 +13,7 @@ if ($kbd) $suffix = $kbd;
 $classes = Flux::classes()
     ->add('group/menu-checkbox flex items-center px-2 py-1.5 w-full focus:outline-none')
     ->add('rounded-md')
-    ->add('text-left text-sm font-medium')
+    ->add('text-start text-sm font-medium')
     ->add('[[disabled]_&]:opacity-50 [&[disabled]]:opacity-50')
     ->add([
         'text-zinc-800 data-[active]:bg-zinc-50 dark:text-white data-[active]:dark:bg-zinc-600',
@@ -32,7 +32,7 @@ $classes = Flux::classes()
     {{ $label ?? $slot }}
 
     <?php if ($suffix): ?>
-        <div class="ml-auto opacity-50 text-xs">
+        <div class="ms-auto opacity-50 text-xs">
             {{ $suffix }}
         </div>
     <?php endif; ?>

--- a/stubs/resources/views/flux/menu/heading.blade.php
+++ b/stubs/resources/views/flux/menu/heading.blade.php
@@ -2,7 +2,7 @@
 $classes = Flux::classes([
     'p-2 pb-1 w-full',
     'flex items-center',
-    'text-left text-xs font-medium',
+    'text-start text-xs font-medium',
     'text-zinc-500 font-medium dark:text-zinc-300',
 ]);
 @endphp

--- a/stubs/resources/views/flux/menu/item.blade.php
+++ b/stubs/resources/views/flux/menu/item.blade.php
@@ -12,7 +12,7 @@ if ($kbd) $suffix = $kbd;
 $classes = Flux::classes()
     ->add('flex items-center px-2 py-1.5 w-full focus:outline-none')
     ->add('rounded-md')
-    ->add('text-left text-sm font-medium')
+    ->add('text-start text-sm font-medium')
     ->add('[&[disabled]]:opacity-50')
     ->add(match ($variant) {
         'danger' => [
@@ -27,13 +27,13 @@ $classes = Flux::classes()
     ;
 
 $suffixClasses = Flux::classes()
-    ->add('ml-auto text-xs text-zinc-400')
+    ->add('ms-auto text-xs text-zinc-400')
     ;
 @endphp
 
 <flux:button-or-link :attributes="$attributes->class($classes)" data-flux-menu-item :data-flux-menu-item-has-icon="!! $icon">
     <?php if ($icon): ?>
-        <flux:icon :$icon variant="mini" class="mr-2" data-flux-menu-item-icon />
+        <flux:icon :$icon variant="mini" class="me-2" data-flux-menu-item-icon />
     <?php else: ?>
         <div class="w-7 hidden [[data-flux-menu]:has(>[data-flux-menu-item-has-icon])_&]:block"></div>
     <?php endif; ?>

--- a/stubs/resources/views/flux/menu/radio/index.blade.php
+++ b/stubs/resources/views/flux/menu/radio/index.blade.php
@@ -13,7 +13,7 @@ if ($kbd) $suffix = $kbd;
 $classes = Flux::classes()
     ->add('group/menu-radio flex items-center px-2 py-1.5 w-full focus:outline-none')
     ->add('rounded-md')
-    ->add('text-left text-sm font-medium')
+    ->add('text-start text-sm font-medium')
     ->add('[[disabled]_&]:opacity-50 [&[disabled]]:opacity-50')
     ->add([
         'text-zinc-800 data-[active]:bg-zinc-50 dark:text-white data-[active]:dark:bg-zinc-600',
@@ -32,7 +32,7 @@ $classes = Flux::classes()
     {{ $label ?? $slot }}
 
     <?php if ($suffix): ?>
-        <div class="ml-auto opacity-50 text-xs">
+        <div class="ms-auto opacity-50 text-xs">
             {{ $suffix }}
         </div>
     <?php endif; ?>

--- a/stubs/resources/views/flux/menu/submenu.blade.php
+++ b/stubs/resources/views/flux/menu/submenu.blade.php
@@ -7,7 +7,7 @@
         {{ $heading }}
 
         <x-slot:suffix>
-            <flux:icon class="ml-auto text-zinc-400 [[data-flux-menu-item]:hover_&]:text-current" icon="chevron-right" variant="mini" />
+            <flux:icon class="ms-auto text-zinc-400 [[data-flux-menu-item]:hover_&]:text-current" icon="chevron-right" variant="mini" />
         </x-slot:suffix>
     </flux:menu.item>
 

--- a/stubs/resources/views/flux/navmenu/item.blade.php
+++ b/stubs/resources/views/flux/navmenu/item.blade.php
@@ -14,7 +14,7 @@ if ($kbd) $suffix = $kbd;
 $classes = Flux::classes()
     ->add('group flex items-center px-2 py-2 lg:py-1.5 w-full')
     ->add('rounded-md')
-    ->add('text-left text-sm font-medium')
+    ->add('text-start text-sm font-medium')
     ->add(match ($variant) {
         'danger' => [
             'text-zinc-800 hover:text-red-600 hover:bg-red-50 dark:text-white dark:hover:bg-red-400/20 dark:hover:text-red-400',
@@ -35,14 +35,14 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if ($icon): ?>
-        <flux:icon :$icon variant="mini" class="mr-2" data-navmenu-icon />
+        <flux:icon :$icon variant="mini" class="me-2" data-navmenu-icon />
     <?php endif; ?>
 
     {{ $slot }}
 
     <?php if ($suffix): ?>
         <?php if (is_string($suffix)): ?>
-            <div class="ml-auto opacity-50 text-xs">
+            <div class="ms-auto opacity-50 text-xs">
                 {{ $suffix }}
             </div>
         <?php else: ?>

--- a/stubs/resources/views/flux/tooltip/content.blade.php
+++ b/stubs/resources/views/flux/tooltip/content.blade.php
@@ -16,6 +16,6 @@ $classes = Flux::classes([
     {{ $slot }}
 
     <?php if ($kbd): ?>
-        <span class="pl-1 text-zinc-300">{{ $kbd }}</span>
+        <span class="ps-1 text-zinc-300">{{ $kbd }}</span>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
This PR makes some changes to the tailwind classes used to support RTL layouts.

I'm applying similar changes to my local version of the pro files.