### PR TITLE
Fix links querystring '&' being escaped in button, menu.item, and navmenu.item  - fixes livewire/flux#535

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -10,6 +10,7 @@
     'inset' => null,
     'icon' => null,
     'kbd' => null,
+    'href' => null,
 ])
 
 @php
@@ -104,7 +105,7 @@ $classes = Flux::classes()
 @endphp
 
 <flux:with-tooltip :$attributes>
-    <flux:button-or-link :$type :attributes="$attributes->class($classes)" data-flux-button>
+    <flux:button-or-link :$href :$type :attributes="$attributes->class($classes)" data-flux-button>
         <?php if ($loading): ?>
             <div class="absolute inset-0 flex items-center justify-center opacity-0" data-flux-loading-indicator>
                 <flux:icon icon="loading" :variant="$iconVariant" />

--- a/stubs/resources/views/flux/menu/item.blade.php
+++ b/stubs/resources/views/flux/menu/item.blade.php
@@ -4,6 +4,7 @@
     'value' => null,
     'icon' => null,
     'kbd' => null,
+    'href' => null,
 ])
 
 @php
@@ -31,7 +32,7 @@ $suffixClasses = Flux::classes()
     ;
 @endphp
 
-<flux:button-or-link :attributes="$attributes->class($classes)" data-flux-menu-item :data-flux-menu-item-has-icon="!! $icon">
+<flux:button-or-link :$href :attributes="$attributes->class($classes)" data-flux-menu-item :data-flux-menu-item-has-icon="!! $icon">
     <?php if ($icon): ?>
         <flux:icon :$icon variant="mini" class="mr-2" data-flux-menu-item-icon />
     <?php else: ?>

--- a/stubs/resources/views/flux/navmenu/item.blade.php
+++ b/stubs/resources/views/flux/navmenu/item.blade.php
@@ -6,6 +6,7 @@
     'value' => null,
     'icon' => null,
     'kbd' => null,
+    'href' => null,
 ])
 
 @php
@@ -29,7 +30,7 @@ $classes = Flux::classes()
     ;
 @endphp
 
-<flux:button-or-link :attributes="$attributes->class($classes)" data-flux-navmenu-item>
+<flux:button-or-link :$href :attributes="$attributes->class($classes)" data-flux-navmenu-item>
     <?php if ($indent): ?>
         <div class="w-7"></div>
     <?php endif; ?>


### PR DESCRIPTION
Currently when passing a route to a component that accepts a `href` like below, it is escaping the '&' in the querystring.

```blade
<flux:button :href="route('test',['user_id'=>1, 'page_category'=>'category1'])" >
    Something
</flux:button>
```

Generates: `/test?user_id=1&amp;page_category=category1`.

The reason for this is because the AttributeBag escapes data by default.

So to fix this I've added the `href` as a prop to the following components:
- [x] button
- [x] menu.item
- [x] navmenu.item

I've also submitted a corresponding PR to Flux Pro with fixes for these components there too:
- [x] navbar.item
- [x] navlist.item
- [x] tab

Fixes livewire/flux#535