### PR TITLE
Update FluxTagCompiler.php to fix #620

### DIFF
--- a/src/FluxTagCompiler.php
+++ b/src/FluxTagCompiler.php
@@ -18,7 +18,7 @@ class FluxTagCompiler extends ComponentTagCompiler
     'view' => md5('flux') . '::' . {$component},
     'data' => \$__env->getCurrentComponentData(),
 ])
-<?php \$component->withAttributes(\$attributes->all()); ?>";
+<?php \$component->withAttributes(\$attributes->getAttributes()); ?>";
         }
 
         return parent::componentString($component, $attributes);


### PR DESCRIPTION
this update replaces the use of `$attributes->all()` with `$attributes->getAttributes()` to fix the breaking change from #620