### PR TITLE
Add issue form template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,6 +17,7 @@ body:
         * Delete any previously published Flux components (to avoid usage of old versions)
         * Run `npm run build` to compile all CSS and JS assets
         * Clear the view cache by running `php artisan view:clear`
+        * Make sure you have thoroughly searched the Issues and Discussions to make sure your question/issue has not already been answered
 
   - type: input
     id: flux-version
@@ -71,7 +72,7 @@ body:
       value: |
         **We will close this issue for any of the following reasons**
 
-        * The code snippets contain unrelated code such as left-over Blade variables
+        * The code snippets contain unrelated code and/or external dependencies such as left-over Blade variables or Models
         * We cannot reproduce the issue with the provided code snippets
         * The issue is a duplicate
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: File a report for a bug in Flux.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi there! 👋
+
+        Thank you for using Flux!
+
+        Many of the people who help resolve issues here are enthusiastic Fluxers like yourself who volunteer their time to support fellow community members.
+
+        **To respect everyone's valuable time and help you resolve your issue as quickly as possible, before posting an issue, please**
+
+        * Make sure you have followed each step in the installation instructions: https://fluxui.dev/docs/installation (step 5 is optional)
+        * Update to the latest version of Flux by running `composer update livewire/flux livewire/flux-pro`
+        * Delete any previously published Flux components (to avoid usage of old versions)
+        * Run `npm run build` to compile all CSS and JS assets
+        * Clear the view cache by running `php artisan view:clear`
+
+  - type: input
+    id: flux-version
+    attributes:
+      label: Flux version
+      description: Which version of Flux are you using? Please provide the full version, e.g. v1.0.29.
+      placeholder: v1.0.29
+    validations:
+      required: true
+
+  - type: input
+    id: livewire-version
+    attributes:
+      label: Livewire version
+      description: Which version of Livewire are you using? Please provide the full version, e.g. v3.5.16.
+      placeholder: v3.5.16
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What is the problem?
+      description: Please provide a clear and concise description of what the problem is and include screenshots.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Code snippets
+      description: Please include a code snippet (ideally a Volt component) we can copy and paste into our own apps with steps to reproduce. Be sure to **include any Blade variable definitions** that are used and use as little code as possible to reproduce the issue.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        Include code snippets in triple backticks (\```) with "blade" for better readability. Here's an example:
+
+        \```blade
+        // Your code here
+        \```
+
+  - type: textarea
+    attributes:
+      label: How do you expect it to work?
+      description: Please describe how you expect it to work.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        **We will close this issue for any of the following reasons**
+
+        * The code snippets contain unrelated code such as left-over Blade variables
+        * We cannot reproduce the issue with the provided code snippets
+        * The issue is a duplicate
+
+  - type: checkboxes
+    attributes:
+      label: Please confirm (incomplete submissions will not be addressed)
+      options:
+        - label: I have provided easy and step-by-step instructions to reproduce the bug.
+          required: true
+        - label: I have provided code samples as text and NOT images.
+          required: true
+        - label: I understand my bug report will be closed if I haven't met the criteria above.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: Thank you!


### PR DESCRIPTION
This PR adds an issue form template instead of just the single text box to add more structure for people reporting issues.

<img width="1394" alt="Screenshot 2024-12-03 at 9 46 57 AM" src="https://github.com/user-attachments/assets/d0d26976-23fb-4ec2-9afc-7f7119604fbd">
<img width="1403" alt="Screenshot 2024-12-03 at 9 47 25 AM" src="https://github.com/user-attachments/assets/aa60c6d4-731c-4d97-842f-6d2d4572950f">
