### PR TITLE
Add optional CSP nonce support for Flux script and style directives

### DIFF
--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -19,15 +19,15 @@ class AssetManager
     public function registerAssetDirective()
     {
         Blade::directive('fluxStyles', function ($expression) {
-            return <<<'PHP'
-            {!! app('flux')->styles() !!}
+            return <<<PHP
+            {!! app('flux')->styles($expression) !!}
             PHP;
         });
 
         Blade::directive('fluxScripts', function ($expression) {
-            return <<<'PHP'
+            return <<<PHP
             <?php app('livewire')->forceAssetInjection(); ?>
-            {!! app('flux')->scripts() !!}
+            {!! app('flux')->scripts($expression) !!}
             PHP;
         });
     }
@@ -71,7 +71,7 @@ class AssetManager
         });
     }
 
-    public static function scripts()
+    public static function scripts($options = [])
     {
         $manifest = Flux::pro()
             ? json_decode(file_get_contents(__DIR__.'/../../flux-pro/dist/manifest.json'), true)
@@ -79,14 +79,16 @@ class AssetManager
 
         $versionHash = $manifest['/flux.js'];
 
+        $nonce = isset($options) && isset($options['nonce']) ? 'nonce="' . $options['nonce'] . '"' : '';
+
         if (config('app.debug')) {
-            return '<script src="/flux/flux.js?id='. $versionHash . '" data-navigate-once></script>';
+            return '<script src="/flux/flux.js?id='. $versionHash . '" data-navigate-once ' . $nonce . '></script>';
         } else {
-            return '<script src="/flux/flux.min.js?id='. $versionHash . '" data-navigate-once></script>';
+            return '<script src="/flux/flux.min.js?id='. $versionHash . '" data-navigate-once ' . $nonce . '></script>';
         }
     }
 
-    public static function styles()
+    public static function styles($options = [])
     {
         $manifest = Flux::pro()
             ? json_decode(file_get_contents(__DIR__.'/../../flux-pro/dist/manifest.json'), true)
@@ -94,7 +96,9 @@ class AssetManager
 
         $versionHash = $manifest['/flux.css'];
 
-        return '<link rel="stylesheet" href="/flux/flux.css?id='. $versionHash . '">';
+        $nonce = isset($options) && isset($options['nonce']) ? 'nonce="' . $options['nonce'] . '"' : '';
+
+        return '<link rel="stylesheet" href="/flux/flux.css?id='. $versionHash . '" ' . $nonce . '>';
     }
 
     public static function editorScripts()

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -79,12 +79,12 @@ class AssetManager
 
         $versionHash = $manifest['/flux.js'];
 
-        $nonce = isset($options) && isset($options['nonce']) ? 'nonce="' . $options['nonce'] . '"' : '';
+        $nonce = isset($options) && isset($options['nonce']) ? ' nonce="' . $options['nonce'] . '"' : '';
 
         if (config('app.debug')) {
-            return '<script src="/flux/flux.js?id='. $versionHash . '" data-navigate-once ' . $nonce . '></script>';
+            return '<script src="/flux/flux.js?id='. $versionHash . '" data-navigate-once' . $nonce . '></script>';
         } else {
-            return '<script src="/flux/flux.min.js?id='. $versionHash . '" data-navigate-once ' . $nonce . '></script>';
+            return '<script src="/flux/flux.min.js?id='. $versionHash . '" data-navigate-once' . $nonce . '></script>';
         }
     }
 
@@ -96,9 +96,9 @@ class AssetManager
 
         $versionHash = $manifest['/flux.css'];
 
-        $nonce = isset($options) && isset($options['nonce']) ? 'nonce="' . $options['nonce'] . '"' : '';
+        $nonce = isset($options) && isset($options['nonce']) ? ' nonce="' . $options['nonce'] . '"' : '';
 
-        return '<link rel="stylesheet" href="/flux/flux.css?id='. $versionHash . '" ' . $nonce . '>';
+        return '<link rel="stylesheet" href="/flux/flux.css?id='. $versionHash . '"' . $nonce . '>';
     }
 
     public static function editorScripts()

--- a/src/FluxManager.php
+++ b/src/FluxManager.php
@@ -41,18 +41,18 @@ class FluxManager
         $this->hasRenderedAssets = true;
     }
 
-    public function styles()
+    public function styles($options = [])
     {
         $this->markAssetsRendered();
 
-        return AssetManager::styles();
+        return AssetManager::styles($options);
     }
 
-    public function scripts()
+    public function scripts($options = [])
     {
         $this->markAssetsRendered();
 
-        return AssetManager::scripts();
+        return AssetManager::scripts($options);
     }
 
     public function editorStyles()


### PR DESCRIPTION
### Background
This PR introduces the ability to optionally specify a Content Security Policy (CSP) nonce for the script and style assets injected via the custom Blade directives (`@fluxStyles` and `@fluxScripts`). This is necessary for those using stricter CSP headers in their projects, and I've followed the same implementation as seen in the Livewire package.

### Usage
Simple pass the `nonce` value in an array to the Flux Blade directives:

```
@fluxStyles(['nonce' => 'abcdef'])
```
and
```
@fluxScripts(['nonce' => 'abcdef'])
```

### Outcome
The nonce value will be included in the relevant assets:

```
<link rel="stylesheet" href="/flux/flux.css?id=0e2b9c8b" nonce="abcdef">
```

and
```
<script src="/flux/flux.js?id=4c114991" data-navigate-once nonce="abcdef"></script>
```