### PR TITLE
Add `wire:target` to buttons with parameters included

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -30,9 +30,9 @@ $loading ??= $loading ?? ($isTypeSubmitAndNotDisabledOnRender || $attributes->wh
 if ($loading && $type !== 'submit') {
     $attributes = $attributes->merge(['wire:loading.attr' => 'data-flux-loading']);
 
-    // We need to add wire:target here because without the loading indicator won't be scoped by
-    // method params, causing multiple buttons with with same method but different params to
-    // trigger each others loading indicators... 
+    // We need to add `wire:target` here because without it the loading indicator won't be scoped
+    // by method params, causing multiple buttons with the same method but different params to
+    // trigger each other's loading indicators...
     if (! $attributes->has('wire:target') && $target = $attributes->get('wire:click')) {
         $attributes = $attributes->merge(['wire:target' => $target]);
     }

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -30,8 +30,9 @@ $loading ??= $loading ?? ($isTypeSubmitAndNotDisabledOnRender || $attributes->wh
 if ($loading && $type !== 'submit') {
     $attributes = $attributes->merge(['wire:loading.attr' => 'data-flux-loading']);
 
-    // A button with `wire:click` will automatically have `wire:target` set, but it doesn't
-    // include parameters. So manually add `wire:target` if there isn't one.
+    // We need to add wire:target here because without the loading indicator won't be scoped by
+    // method params, causing multiple buttons with with same method but different params to
+    // trigger each others loading indicators... 
     if (! $attributes->has('wire:target') && $target = $attributes->get('wire:click')) {
         $attributes = $attributes->merge(['wire:target' => $target]);
     }

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -29,6 +29,12 @@ $loading ??= $loading ?? ($isTypeSubmitAndNotDisabledOnRender || $attributes->wh
 
 if ($loading && $type !== 'submit') {
     $attributes = $attributes->merge(['wire:loading.attr' => 'data-flux-loading']);
+
+    // A button with `wire:click` will automatically have `wire:target` set, but it doesn't
+    // include parameters. So manually add `wire:target` if there isn't one.
+    if (! $attributes->has('wire:target') && $target = $attributes->get('wire:click')) {
+        $attributes = $attributes->merge(['wire:target' => $target]);
+    }
 }
 
 $classes = Flux::classes()


### PR DESCRIPTION
Currently if you have a table each with an action like `delete($userId);` all the delete buttons will show a loading indicator at the same time.

<img width="190" alt="image" src="https://github.com/user-attachments/assets/24aec11b-88c4-43cc-8d8e-b202c2a420f9" />


This is because under the hood, Livewire scopes the buttons loading state to the action called in the `wire:click` but it doesn't take into account any parameters.

This PR adds `wire:target` including parameters to buttons if there isn't already a `wire:target` and it's not a submit button.

<img width="138" alt="image" src="https://github.com/user-attachments/assets/e582e6d6-5954-47f8-a166-218cd57ca1ea" />
