### PR TITLE
Add icons to submenu

### DIFF
--- a/stubs/resources/views/flux/menu/submenu.blade.php
+++ b/stubs/resources/views/flux/menu/submenu.blade.php
@@ -1,9 +1,10 @@
 @props([
     'heading' => '',
+    'icon' => null,
 ])
 
 <ui-submenu data-flux-menu-submenu>
-    <flux:menu.item>
+    <flux:menu.item :$icon>
         {{ $heading }}
 
         <x-slot:suffix>


### PR DESCRIPTION
This PR adds icons to the `<flux:menu.submenu>` component. See "Sort by" in the screenshot below.

```blade
<flux:menu.submenu icon="arrows-up-down" heading="Sort by">
    ...
</flux:menu.submenu>
```

<img width="425" alt="image" src="https://github.com/user-attachments/assets/56575f5f-2d88-4738-8576-de20757278a1" />

Fixes #889