### PR TITLE
Add `toggleable` prop to tooltip

### DIFF
--- a/stubs/resources/views/flux/tooltip/index.blade.php
+++ b/stubs/resources/views/flux/tooltip/index.blade.php
@@ -4,12 +4,23 @@
     'align' => 'center',
     'content' => null,
     'kbd' => null,
+    'toggleable' => null,
 ])
 
-<ui-tooltip position="{{ $position }} {{ $align }}" {{ $attributes }} data-flux-tooltip @if ($interactive) interactive @endif>
-    {{ $slot }}
+<?php if ($toggleable): ?>
+    <ui-dropdown position="{{ $position }} {{ $align }}" {{ $attributes }} data-flux-tooltip>
+        {{ $slot }}
 
-    <?php if ($content !== null): ?>
-        <flux:tooltip.content :$kbd>{{ $content }}</flux:tooltip.content>
-    <?php endif; ?>
-</ui-tooltip>
+        <?php if ($content !== null): ?>
+            <flux:tooltip.content :$kbd>{{ $content }}</flux:tooltip.content>
+        <?php endif; ?>
+    </ui-dropdown>
+<?php else: ?>
+    <ui-tooltip position="{{ $position }} {{ $align }}" {{ $attributes }} data-flux-tooltip @if ($interactive) interactive @endif>
+        {{ $slot }}
+
+        <?php if ($content !== null): ?>
+            <flux:tooltip.content :$kbd>{{ $content }}</flux:tooltip.content>
+        <?php endif; ?>
+    </ui-tooltip>
+<?php endif; ?>


### PR DESCRIPTION
This PR adds a `toggleable` prop to the `<flux:tooltip>` component.

```blade
<flux:tooltip content="Information" toggleable>
    <flux:button icon="information-circle" icon-variant="outline" />
</flux:tooltip>
```
This allows a tooltip to be shown/hidden by a button click/press, instead of on hover/focus as they don't work on mobile.

It's good for creating information "i" buttons next to elements, to add some helpful information.

<img width="151" alt="image" src="https://github.com/user-attachments/assets/de18b2cd-16ba-41bb-874f-5bbd9a297f22" />

See https://github.com/livewire/flux/issues/682#issuecomment-2544689857 for more details on tooltips and mobile compatibility.

I've also submitted a PR to the Flux docs.

Fixes #682