### PR TITLE
Fix `@fluxStyles` rendering

### DIFF
--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -98,8 +98,8 @@ class AssetManager
 
         $nonce = isset($options) && isset($options['nonce']) ? ' nonce="' . $options['nonce'] . '"' : '';
 
-        return <<<'HTML'
-<link rel="stylesheet" href="/flux/flux.css?id='. $versionHash . '"' . $nonce . '>
+        return <<<HTML
+<link rel="stylesheet" href="/flux/flux.css?id=$versionHash"$nonce>
 <script>
     let appearance = window.localStorage.getItem('flux.appearance') || 'system'
 


### PR DESCRIPTION
Correctly render the stylesheet so that the $versionHash and $nonce values actually appear instead of just showing the PHP variables.

Fixes #932