### PR TITLE
Fix outline icon sizes on buttons to ensure they match default icon sizes

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -23,6 +23,11 @@ $iconVariant ??= ($size === 'xs')
     ? ($square ? 'micro' : 'micro')
     : ($square ? 'mini' : 'micro');
 
+// When using the outline icon variant, we need to size it down to match the default icon sizes...
+$iconClasses = Flux::classes()
+    ->add($iconVariant === 'outline' ? ($square && $size !== 'xs' ? 'size-5' : 'size-4') : '')
+    ;
+
 $isTypeSubmitAndNotDisabledOnRender = $type === 'submit' && ! $attributes->has('disabled');
 
 $loading ??= $loading ?? ($isTypeSubmitAndNotDisabledOnRender || $attributes->whereStartsWith('wire:click')->isNotEmpty());
@@ -115,12 +120,12 @@ $classes = Flux::classes()
     <flux:button-or-link :$type :attributes="$attributes->class($classes)" data-flux-button>
         <?php if ($loading): ?>
             <div class="absolute inset-0 flex items-center justify-center opacity-0" data-flux-loading-indicator>
-                <flux:icon icon="loading" :variant="$iconVariant" />
+                <flux:icon icon="loading" :variant="$iconVariant" :class="$iconClasses" />
             </div>
         <?php endif; ?>
 
         <?php if (is_string($iconLeading) && $iconLeading !== ''): ?>
-            <flux:icon :icon="$iconLeading" :variant="$iconVariant" />
+            <flux:icon :icon="$iconLeading" :variant="$iconVariant" :class="$iconClasses" />
         <?php elseif ($iconLeading): ?>
             {{ $iconLeading }}
         <?php endif; ?>
@@ -137,7 +142,9 @@ $classes = Flux::classes()
         <?php endif; ?>
 
         <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
-            <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$square ? '' : '-ml-1'" />
+            {{-- Adding the extra margin class inline on the icon component below was causing a double up, so it needs to be added here first... --}}
+            <?php $iconClasses->add($square ? '' : '-ml-1'); ?>
+            <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$iconClasses" />
         <?php elseif ($iconTrailing): ?>
             {{ $iconTrailing }}
         <?php endif; ?>


### PR DESCRIPTION
# The scenario

If you use buttons with `icon-variant="outline"` the icons are bigger than the default solid sizes.

<img width="280" alt="image" src="https://github.com/user-attachments/assets/2f8bd11d-041a-41ab-bc58-9872a1838ce4" />

```blade
<flux:button
    variant="outline"
    icon="bolt"
    icon-trailing="academic-cap"
    icon-variant="outline">
    Outline
</flux:button>
<flux:button
    variant="outline"
    icon="bolt"
    icon-trailing="academic-cap">
    Solid
</flux:button>
```

And the same issue happens with square buttons.

<img width="192" alt="image" src="https://github.com/user-attachments/assets/b9d9467d-a3ef-47ac-9fb9-6c73c51d75f0" />

# The problem

The issue is that outline icons have a 24x24 view box and there isn't a smaller outline variant. Where as for buttons the default icon variant is micro which has a view box of 16x16.

# The solution

This PR resizes the outline icon variant to be the same size as the default button icon sizes, using `size-4` by default.

<img width="255" alt="image" src="https://github.com/user-attachments/assets/c73c8dd6-8b5e-4d7c-83d0-e8ca2e799612" />

If the `square` button attribute is used, then the size is set to `size-5`.
<img width="187" alt="image" src="https://github.com/user-attachments/assets/1268b41f-41c1-4fa0-9f77-6e416c22d6de" />

It's not an ideal solution as the size of the icons is now not encapsulated in the icon components.

An alternative solution to this would be to add sizes as an option on the icons themselves, but that would require a lot more work, as we now need to determine what happens with the solid/mini/micro solid variants.

Ideally in the future we would just have a outline and solid variants and a separate size attribute.

Fixes livewire/flux#887