### PR TITLE
Fix asset route caching

### DIFF
--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -70,12 +70,12 @@ class AssetManager
 
     public function registerAssetRoutes()
     {
-        Route::get('/flux/flux.css', [self::class, 'getFluxCss']);
-        Route::get('/flux/flux.js', [self::class, 'getFluxJs']);
-        Route::get('/flux/flux.min.js', [self::class, 'getFluxMinJs']);
-        Route::get('/flux/editor.css', [self::class, 'getEditorCss']);
-        Route::get('/flux/editor.js', [self::class, 'getEditorJs']);
-        Route::get('/flux/editor.min.js', [self::class, 'getEditorMinJs']);
+        Route::get('/flux/flux.css', [static::class, 'getFluxCss']);
+        Route::get('/flux/flux.js', [static::class, 'getFluxJs']);
+        Route::get('/flux/flux.min.js', [static::class, 'getFluxMinJs']);
+        Route::get('/flux/editor.css', [static::class, 'getEditorCss']);
+        Route::get('/flux/editor.js', [static::class, 'getEditorJs']);
+        Route::get('/flux/editor.min.js', [static::class, 'getEditorMinJs']);
     }
 
     public static function scripts($options = [])

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -32,43 +32,50 @@ class AssetManager
         });
     }
 
+    public function getFluxCss() {
+        return Flux::pro()
+            ? $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/flux.css', 'text/css')
+            : $this->pretendResponseIsFile(__DIR__.'/../../flux/dist/flux-lite.css', 'text/css');
+    }
+
+    public function getFluxJs() {
+        return Flux::pro()
+            ? $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/flux.js', 'text/javascript')
+            : $this->pretendResponseIsFile(__DIR__.'/../../flux/dist/flux-lite.min.js', 'text/javascript');
+    }
+
+    public function getFluxMinJs() {
+        return Flux::pro()
+            ? $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/flux.min.js', 'text/javascript')
+            : $this->pretendResponseIsFile(__DIR__.'/../../flux/dist/flux-lite.min.js', 'text/javascript');
+    }
+
+    public function getEditorCss() {
+        if (! Flux::pro()) throw new \Exception('Flux Pro is required to use the Flux editor.');
+
+        return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.css', 'text/css');
+    }
+
+    public function getEditorJs() {
+        if (! Flux::pro()) throw new \Exception('Flux Pro is required to use the Flux editor.');
+
+        return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.js', 'text/javascript');
+    }
+
+    public function getEditorMinJs() {
+        if (! Flux::pro()) throw new \Exception('Flux Pro is required to use the Flux editor.');
+
+        return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.min.js', 'text/javascript');
+    }
+
     public function registerAssetRoutes()
     {
-        Route::get('/flux/flux.css', function () {
-            return Flux::pro()
-                ? $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/flux.css', 'text/css')
-                : $this->pretendResponseIsFile(__DIR__.'/../../flux/dist/flux-lite.css', 'text/css');
-        });
-
-        Route::get('/flux/flux.js', function () {
-            return Flux::pro()
-                ? $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/flux.js', 'text/javascript')
-                : $this->pretendResponseIsFile(__DIR__.'/../../flux/dist/flux-lite.min.js', 'text/javascript');
-        });
-
-        Route::get('/flux/flux.min.js', function () {
-            return Flux::pro()
-                ? $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/flux.min.js', 'text/javascript')
-                : $this->pretendResponseIsFile(__DIR__.'/../../flux/dist/flux-lite.min.js', 'text/javascript');
-        });
-
-        Route::get('/flux/editor.css', function () {
-            if (! Flux::pro()) throw new \Exception('Flux Pro is required to use the Flux editor.');
-
-            return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.css', 'text/css');
-        });
-
-        Route::get('/flux/editor.js', function () {
-            if (! Flux::pro()) throw new \Exception('Flux Pro is required to use the Flux editor.');
-
-            return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.js', 'text/javascript');
-        });
-
-        Route::get('/flux/editor.min.js', function () {
-            if (! Flux::pro()) throw new \Exception('Flux Pro is required to use the Flux editor.');
-
-            return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.min.js', 'text/javascript');
-        });
+        Route::get('/flux/flux.css', [self::class, 'getFluxCss']);
+        Route::get('/flux/flux.js', [self::class, 'getFluxJs']);
+        Route::get('/flux/flux.min.js', [self::class, 'getFluxMinJs']);
+        Route::get('/flux/editor.css', [self::class, 'getEditorCss']);
+        Route::get('/flux/editor.js', [self::class, 'getEditorJs']);
+        Route::get('/flux/editor.min.js', [self::class, 'getEditorMinJs']);
     }
 
     public static function scripts($options = [])

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -32,50 +32,50 @@ class AssetManager
         });
     }
 
-    public function getFluxCss() {
+    public function registerAssetRoutes()
+    {
+        Route::get('/flux/flux.css', [static::class, 'fluxCss']);
+        Route::get('/flux/flux.js', [static::class, 'fluxJs']);
+        Route::get('/flux/flux.min.js', [static::class, 'fluxMinJs']);
+        Route::get('/flux/editor.css', [static::class, 'editorCss']);
+        Route::get('/flux/editor.js', [static::class, 'editorJs']);
+        Route::get('/flux/editor.min.js', [static::class, 'editorMinJs']);
+    }
+
+    public function fluxCss() {
         return Flux::pro()
             ? $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/flux.css', 'text/css')
             : $this->pretendResponseIsFile(__DIR__.'/../../flux/dist/flux-lite.css', 'text/css');
     }
 
-    public function getFluxJs() {
+    public function fluxJs() {
         return Flux::pro()
             ? $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/flux.js', 'text/javascript')
             : $this->pretendResponseIsFile(__DIR__.'/../../flux/dist/flux-lite.min.js', 'text/javascript');
     }
 
-    public function getFluxMinJs() {
+    public function fluxMinJs() {
         return Flux::pro()
             ? $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/flux.min.js', 'text/javascript')
             : $this->pretendResponseIsFile(__DIR__.'/../../flux/dist/flux-lite.min.js', 'text/javascript');
     }
 
-    public function getEditorCss() {
+    public function editorCss() {
         if (! Flux::pro()) throw new \Exception('Flux Pro is required to use the Flux editor.');
 
         return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.css', 'text/css');
     }
 
-    public function getEditorJs() {
+    public function editorJs() {
         if (! Flux::pro()) throw new \Exception('Flux Pro is required to use the Flux editor.');
 
         return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.js', 'text/javascript');
     }
 
-    public function getEditorMinJs() {
+    public function editorMinJs() {
         if (! Flux::pro()) throw new \Exception('Flux Pro is required to use the Flux editor.');
 
         return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.min.js', 'text/javascript');
-    }
-
-    public function registerAssetRoutes()
-    {
-        Route::get('/flux/flux.css', [static::class, 'getFluxCss']);
-        Route::get('/flux/flux.js', [static::class, 'getFluxJs']);
-        Route::get('/flux/flux.min.js', [static::class, 'getFluxMinJs']);
-        Route::get('/flux/editor.css', [static::class, 'getEditorCss']);
-        Route::get('/flux/editor.js', [static::class, 'getEditorJs']);
-        Route::get('/flux/editor.min.js', [static::class, 'getEditorMinJs']);
     }
 
     public static function scripts($options = [])


### PR DESCRIPTION
This addresses #998 .

**Before**: `php artisan route:cache` serializes through reflection the route callbacks, hardwiring the execution context's absolute path to flux's asset files (ex: /Users/vorban/repositories/...) because of `__DIR__` resolution.

**After**: `php artisan route:cache` serializes references to the route actions, preventing any resolution of `__DIR__` before runtime.

I've tested it locally. The routes are listed by `artisan route:list`, and `artisan route:cache` correctly serialized references to the functions.

After a `route:cache`, going to any page that uses the blade directives like `@fluxStyles` works and the files are correctly fetched.

I'd prefer this to be thoroughly reviewed, as I failed to find the contribution guidelines and test suites to run.