### PR TITLE
Add `.self` to `wire:model` on wrapper components

### DIFF
--- a/stubs/resources/views/flux/dropdown.blade.php
+++ b/stubs/resources/views/flux/dropdown.blade.php
@@ -3,6 +3,17 @@
     'align' => 'start',
 ])
 
+@php
+// Support adding the .self modifier to the wire:model directive...
+if (($wireModel = $attributes->wire('model')) && $wireModel->directive && ! $wireModel->hasModifier('self')) {
+    unset($attributes[$wireModel->directive]);
+
+    $wireModel->directive .= '.self';
+
+    $attributes = $attributes->merge([$wireModel->directive => $wireModel->value]);
+}
+@endphp
+
 <ui-dropdown position="{{ $position }} {{ $align }}" {{ $attributes }} data-flux-dropdown>
     {{ $slot }}
 </ui-dropdown>

--- a/stubs/resources/views/flux/tooltip/index.blade.php
+++ b/stubs/resources/views/flux/tooltip/index.blade.php
@@ -7,6 +7,17 @@
     'toggleable' => null,
 ])
 
+@php
+// Support adding the .self modifier to the wire:model directive...
+if (($wireModel = $attributes->wire('model')) && $wireModel->directive && ! $wireModel->hasModifier('self')) {
+    unset($attributes[$wireModel->directive]);
+
+    $wireModel->directive .= '.self';
+
+    $attributes = $attributes->merge([$wireModel->directive => $wireModel->value]);
+}
+@endphp
+
 <?php if ($toggleable): ?>
     <ui-dropdown position="{{ $position }} {{ $align }}" {{ $attributes }} data-flux-tooltip>
         {{ $slot }}


### PR DESCRIPTION
# The scenario

This is a follow up from PR livewire/flux-pro#142 "Add `.self` to `wire:model` on a modal automatically".

In this PR we also automatically add `.self` to other components that are wrapping components like a modal is.

See PR description copied to the original issue here for details https://github.com/livewire/flux/issues/850#issuecomment-2576895754

This PR adds `.self` check to the following components:
- dropdown
- tooltip

There is also a companion PR livewire/flux-pro#154 on the Flux Pro repo which adds `.self` check to the following components:
- accordion
- context