### PR TITLE
Fix component icons to also support slots

### DIFF
--- a/stubs/resources/views/flux/menu/checkbox/index.blade.php
+++ b/stubs/resources/views/flux/menu/checkbox/index.blade.php
@@ -1,14 +1,26 @@
 @props([
+    'iconVariant' => 'mini',
+    'iconTrailing' => null,
     'variant' => 'default',
     'indent' => false,
     'suffix' => null,
     'label' => null,
-    'icon' => null,
     'kbd' => null,
 ])
 
 @php
 if ($kbd) $suffix = $kbd;
+
+$iconClasses = Flux::classes()
+    // When using the outline icon variant, we need to size it down to match the default icon sizes...
+    ->add($iconVariant === 'outline' ? 'size-5' : null)
+    ;
+
+$iconTrailingClasses = Flux::classes()
+    ->add('ml-auto')
+    // When using the outline icon variant, we need to size it down to match the default icon sizes...
+    ->add($iconVariant === 'outline' ? 'size-5' : null)
+    ;
 
 $classes = Flux::classes()
     ->add('group/menu-checkbox flex items-center px-2 py-1.5 w-full focus:outline-none')
@@ -25,7 +37,7 @@ $classes = Flux::classes()
 <ui-menu-checkbox {{ $attributes->class($classes) }} data-flux-menu-item-has-icon data-flux-menu-checkbox>
     <div class="w-7">
         <div class="hidden group-data-[checked]/menu-checkbox:block">
-            <flux:icon variant="mini" icon="check" data-flux-menu-item-icon />
+            <flux:icon :variant="$iconVariant" icon="check" :class="$iconClasses" data-flux-menu-item-icon />
         </div>
     </div>
 
@@ -35,5 +47,11 @@ $classes = Flux::classes()
         <div class="ml-auto opacity-50 text-xs">
             {{ $suffix }}
         </div>
+    <?php endif; ?>
+
+    <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
+        <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$iconTrailingClasses" data-flux-menu-item-icon />
+    <?php elseif ($iconTrailing): ?>
+        {{ $iconTrailing }}
     <?php endif; ?>
 </ui-menu-checkbox>

--- a/stubs/resources/views/flux/menu/item.blade.php
+++ b/stubs/resources/views/flux/menu/item.blade.php
@@ -1,4 +1,5 @@
 @props([
+    'iconTrailing' => null,
     'iconVariant' => 'mini',
     'variant' => 'default',
     'suffix' => null,
@@ -12,6 +13,12 @@ if ($kbd) $suffix = $kbd;
 
 $iconClasses = Flux::classes()
     ->add('mr-2')
+    // When using the outline icon variant, we need to size it down to match the default icon sizes...
+    ->add($iconVariant === 'outline' ? 'size-5' : null)
+    ;
+
+$trailingIconClasses = Flux::classes()
+    ->add('ml-auto text-zinc-400 [[data-flux-menu-item-icon]:hover_&]:text-current')
     // When using the outline icon variant, we need to size it down to match the default icon sizes...
     ->add($iconVariant === 'outline' ? 'size-5' : null)
     ;
@@ -39,8 +46,10 @@ $suffixClasses = Flux::classes()
 @endphp
 
 <flux:button-or-link :attributes="$attributes->class($classes)" data-flux-menu-item :data-flux-menu-item-has-icon="!! $icon">
-    <?php if ($icon): ?>
+    <?php if (is_string($icon) && $icon !== ''): ?>
         <flux:icon :$icon :variant="$iconVariant" :class="$iconClasses" data-flux-menu-item-icon />
+    <?php elseif ($icon): ?>
+        {{ $icon }}
     <?php else: ?>
         <div class="w-7 hidden [[data-flux-menu]:has(>[data-flux-menu-item-has-icon])_&]:block"></div>
     <?php endif; ?>
@@ -55,6 +64,12 @@ $suffixClasses = Flux::classes()
         <?php else: ?>
             {{ $suffix }}
         <?php endif; ?>
+    <?php endif; ?>
+
+    <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
+        <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$trailingIconClasses" data-flux-menu-item-icon />
+    <?php elseif ($iconTrailing): ?>
+        {{ $iconTrailing }}
     <?php endif; ?>
 
     {{ $submenu ?? '' }}

--- a/stubs/resources/views/flux/menu/radio/index.blade.php
+++ b/stubs/resources/views/flux/menu/radio/index.blade.php
@@ -1,14 +1,26 @@
 @props([
+    'iconVariant' => 'mini',
+    'iconTrailing' => null,
     'variant' => 'default',
     'indent' => false,
     'suffix' => null,
     'label' => null,
-    'icon' => null,
     'kbd' => null,
 ])
 
 @php
 if ($kbd) $suffix = $kbd;
+
+$iconClasses = Flux::classes()
+    // When using the outline icon variant, we need to size it down to match the default icon sizes...
+    ->add($iconVariant === 'outline' ? 'size-5' : null)
+    ;
+
+$iconTrailingClasses = Flux::classes()
+    ->add('ml-auto')
+    // When using the outline icon variant, we need to size it down to match the default icon sizes...
+    ->add($iconVariant === 'outline' ? 'size-5' : null)
+    ;
 
 $classes = Flux::classes()
     ->add('group/menu-radio flex items-center px-2 py-1.5 w-full focus:outline-none')
@@ -25,7 +37,7 @@ $classes = Flux::classes()
 <ui-menu-radio {{ $attributes->class($classes) }} data-flux-menu-item-has-icon data-flux-menu-radio>
     <div class="w-7">
         <div class="hidden group-data-[checked]/menu-radio:block">
-            <flux:icon variant="mini" icon="check" data-flux-menu-item-icon />
+            <flux:icon :variant="$iconVariant" icon="check" :class="$iconClasses" data-flux-menu-item-icon />
         </div>
     </div>
 
@@ -35,5 +47,11 @@ $classes = Flux::classes()
         <div class="ml-auto opacity-50 text-xs">
             {{ $suffix }}
         </div>
+    <?php endif; ?>
+
+    <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
+        <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$iconTrailingClasses" data-flux-menu-item-icon />
+    <?php elseif ($iconTrailing): ?>
+        {{ $iconTrailing }}
     <?php endif; ?>
 </ui-menu-radio>

--- a/stubs/resources/views/flux/menu/submenu.blade.php
+++ b/stubs/resources/views/flux/menu/submenu.blade.php
@@ -1,14 +1,29 @@
 @props([
+    'iconVariant' => 'mini',
+    'iconTrailing' => null,
     'heading' => '',
     'icon' => null,
 ])
 
+@php
+$iconClasses = Flux::classes()
+    ->add('ml-auto text-zinc-400 [[data-flux-menu-item]:hover_&]:text-current')
+    // When using the outline icon variant, we need to size it down to match the default icon sizes...
+    ->add($iconVariant === 'outline' ? 'size-5' : '');
+@endphp
+
 <ui-submenu data-flux-menu-submenu>
-    <flux:menu.item :$icon>
+    <flux:menu.item :$icon :$iconVariant>
         {{ $heading }}
 
         <x-slot:suffix>
-            <flux:icon class="ml-auto text-zinc-400 [[data-flux-menu-item]:hover_&]:text-current" icon="chevron-right" variant="mini" />
+            <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
+                <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$iconClasses" />
+            <?php elseif ($iconTrailing): ?>
+                {{ $iconTrailing }}
+            <?php else: ?>
+                <flux:icon icon="chevron-right" :variant="$iconVariant" :class="$iconClasses" />
+            <?php endif; ?>
         </x-slot:suffix>
     </flux:menu.item>
 

--- a/stubs/resources/views/flux/navmenu/item.blade.php
+++ b/stubs/resources/views/flux/navmenu/item.blade.php
@@ -1,4 +1,6 @@
 @props([
+    'iconVariant' => 'mini',
+    'iconTrailing' => null,
     'variant' => 'default',
     'disabled' => false,
     'indent' => false,
@@ -10,6 +12,18 @@
 
 @php
 if ($kbd) $suffix = $kbd;
+
+$iconClasses = Flux::classes()
+    ->add('mr-2')
+    // When using the outline icon variant, we need to size it down to match the default icon sizes...
+    ->add($iconVariant === 'outline' ? 'size-5' : null)
+    ;
+
+$trailingIconClasses = Flux::classes()
+    ->add('ml-auto')
+    // When using the outline icon variant, we need to size it down to match the default icon sizes...
+    ->add($iconVariant === 'outline' ? 'size-5' : null)
+    ;
 
 $classes = Flux::classes()
     ->add('group flex items-center px-2 py-2 lg:py-1.5 w-full')
@@ -34,8 +48,10 @@ $classes = Flux::classes()
         <div class="w-7"></div>
     <?php endif; ?>
 
-    <?php if ($icon): ?>
-        <flux:icon :$icon variant="mini" class="mr-2" data-navmenu-icon />
+    <?php if (is_string($icon) && $icon !== ''): ?>
+        <flux:icon :$icon :variant="$iconVariant" :class="$iconClasses" data-navmenu-icon />
+    <?php elseif ($icon): ?>
+        {{ $icon }}
     <?php endif; ?>
 
     {{ $slot }}
@@ -48,5 +64,11 @@ $classes = Flux::classes()
         <?php else: ?>
             {{ $suffix }}
         <?php endif; ?>
+    <?php endif; ?>
+
+    <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
+        <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$trailingIconClasses" />
+    <?php elseif ($iconTrailing): ?>
+        {{ $iconTrailing }}
     <?php endif; ?>
 </flux:button-or-link>


### PR DESCRIPTION
# The scenario

In Flux some components support passing in icon names.

```blade
<flux:button icon="arrow-down-tray">Export</flux:button>
```

Or using icon as a slot.

```blade
<flux:button>
    <x-slot:icon>
        <flux:icon.arrow-down-tray />
    </x-slot>
    Export
</flux:button>
```

# The problem
But there are some components that don't support this and only support passing the name of an icon in.

# The solution

This PR and a companion Flux Pro PR livewire/flux-pro#173 fixes this by updating all components that support icons to have icon slots as well.

Some components that are similar, like some of the menu components, may have supported trailing icons and others not, so support has also been added so this is consistent with components that as used similarly.