### PR TITLE
Add nonce to dark mode script tag

### DIFF
--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -107,7 +107,7 @@ class AssetManager
 
         return <<<HTML
 <link rel="stylesheet" href="/flux/flux.css?id=$versionHash"$nonce>
-<script>
+<script$nonce>
     let appearance = window.localStorage.getItem('flux.appearance') || 'system'
 
     if (appearance === 'system') {


### PR DESCRIPTION
# The scenario

If you have a strict CSP setup, an error is being thrown because of Flux's dark mode detection script that gets injected with the styles.

```
Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self' 'nonce-pUT16AksAMo5zjRjbkiC8r9adYK9uLENJMpcYSZD' https://www.googletagmanager.com 'unsafe-eval'". Either the 'unsafe-inline' keyword, a hash ('sha256-10Dh1l13zor4I3gkPqw4Y1m3FpiMnB1VtjcVaCLTYFg='), or a nonce ('nonce-...') is required to enable inline execution.
```

# The problem

The issue is that Flux's styles and scripts both support a nonce but the new inline dark mode script does not.

# The solution

The solution is to add the nonce that can be passed into `@fluxStyles(['nonce' => 'abc'])` to the inline script.

Fixes #1034