### PR TITLE
Fix file input name being escaped

### DIFF
--- a/stubs/resources/views/flux/input/file.blade.php
+++ b/stubs/resources/views/flux/input/file.blade.php
@@ -51,7 +51,7 @@ $classes = Flux::classes()
         type="file"
         class="sr-only"
         tabindex="-1"
-        {{ $attributes }} {{ $multiple ? 'multiple' : '' }} {{ $name ? 'name="'.$name.'"' : '' }}
+        {{ $attributes }} {{ $multiple ? 'multiple' : '' }} @if($name)name="{{ $name }}"@endif
     >
 
     <flux:button as="div" class="cursor-pointer" :$size aria-hidden="true">


### PR DESCRIPTION
# The scenario

Currently if you add a `name` attribute to a file input it's being incorrectly escaped.

<img width="158" alt="image" src="https://github.com/user-attachments/assets/92c61141-e742-4d2b-aab7-370be8644795" />

```blade
<flux:input type="file" name="my-file" />
```

# The problem

The issue is that in the code, the `{{ }}` is escaping everything including the quotes.

```blade
{{ $name ? 'name="'.$name.'"' : '' }}
```

# The solution

The solution is to switch to using a blade conditional instead

```blade
@if($name)name="{{ $name }}"@endif
```

<img width="123" alt="image" src="https://github.com/user-attachments/assets/3f8e1924-71ed-481f-999b-a2e8e58f48b6" />


Fixes livewire/flux#1063