### PR TITLE
Add `.self` to `wire:model` on `checkbox.group` component

### DIFF
--- a/stubs/resources/views/flux/checkbox/group/variants/default.blade.php
+++ b/stubs/resources/views/flux/checkbox/group/variants/default.blade.php
@@ -4,6 +4,15 @@ $classes = Flux::classes()
     ->add('[&>[data-flux-field]:has(>[data-flux-description])]:mb-4')
     ->add('[&>[data-flux-field]:last-child]:mb-0!')
     ;
+
+// Support adding the .self modifier to the wire:model directive...
+if (($wireModel = $attributes->wire('model')) && $wireModel->directive && ! $wireModel->hasModifier('self')) {
+    unset($attributes[$wireModel->directive]);
+
+    $wireModel->directive .= '.self';
+
+    $attributes = $attributes->merge([$wireModel->directive => $wireModel->value]);
+}
 @endphp
 
 <flux:with-field :$attributes>


### PR DESCRIPTION
# The scenario

Currently if you have any inputs inside a checkbox group with `wire:model` on it (such as a table wrapped with checkbox.group for check all functionality), then typing in one of the inputs changes the checkbox group `wire:model` value.

<img width="951" alt="image" src="https://github.com/user-attachments/assets/f2a9c9a0-7055-45c1-bcd0-c0822ad26776" />

<details>
<summary>Volt component</summary>

```blade
<?php

use Flux\DateRange;
use Livewire\Attributes\Computed;
use Livewire\Volt\Component;

new class extends Component {
    use \Livewire\WithPagination;

    public $selectedUsers = [];

    public $sortBy = 'date';
    public $sortDirection = 'desc';

    public function sort($column) {
        if ($this->sortBy === $column) {
            $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
        } else {
            $this->sortBy = $column;
            $this->sortDirection = 'asc';
        }
    }

    #[\Livewire\Attributes\Computed]
    public function users()
    {
        return \App\Models\User::query()
            ->tap(fn ($query) => $this->sortBy ? $query->orderBy($this->sortBy, $this->sortDirection) : $query)
            ->paginate(5);
    }
};
?>

<div>
    <flux:text>Selected Users: {{ var_export($this->selectedUsers, true) }}</flux:text>
    <flux:checkbox.group wire:model.live="selectedUsers">
        <flux:table :paginate="$this->users">
            <flux:table.columns>
                <flux:table.column>
                    <flux:checkbox.all />
                </flux:table.column>
                <flux:table.column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">Name</flux:table.column>
                <flux:table.column sortable :sorted="$sortBy === 'email'" :direction="$sortDirection" wire:click="sort('email')">Email</flux:table.column>
                <flux:table.column>Random</flux:table.column>
                <flux:table.column sortable :sorted="$sortBy === 'created_at'" :direction="$sortDirection" wire:click="sort('created_at')">Signed up</flux:table.column>
            </flux:table.columns>

            <flux:table.rows>
                @foreach ($this->users as $user)
                    <flux:table.row :key="$user->id">
                        <flux:table.cell>
                            <flux:checkbox :value="$user->id" />
                        </flux:table.cell>

                        <flux:table.cell class="flex items-center gap-3">{{ $user->name }}</flux:table.cell>

                        <flux:table.cell class="whitespace-nowrap">{{ $user->email }}</flux:table.cell>

                        <flux:table.cell>
                            <flux:input />
                        </flux:table.cell>

                        <flux:table.cell variant="strong">{{ $user->created_at->diffForHumans() }}</flux:table.cell>

                        <flux:table.cell>
                            <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom"></flux:button>
                        </flux:table.cell>
                    </flux:table.row>
                @endforeach
            </flux:table.rows>
        </flux:table>
    </flux:checkbox.group>
</div>
```
</details>

# The problem

The issue is that the input events from the input are bubbling up to the `wire:model` on the wrapping `checkbox.group`.

# The solution

The solution is to add the `.self` modifier to `wire:model` in the `checkbox.group` if it hasn't been applied, like we did for modals, dropdown, accordion, etc. See PR #1017 for details

<img width="945" alt="image" src="https://github.com/user-attachments/assets/34e7129c-2fa5-46a5-bb8d-6ed0c313d033" />

Fixes livewire/flux#1094