### PR TITLE
Fix select default variant background not dark in dark mode on Windows

### DIFF
--- a/stubs/resources/views/flux/select/variants/default.blade.php
+++ b/stubs/resources/views/flux/select/variants/default.blade.php
@@ -21,6 +21,8 @@ $classes = Flux::classes()
     ->add('text-zinc-700 dark:text-zinc-300')
     // Make the placeholder match the text color of standard input placeholders...
     ->add('has-[option.placeholder:checked]:text-zinc-400 dark:has-[option.placeholder:checked]:text-zinc-400')
+    // Options on Windows don't inherit dark mode styles, so we need to force them...
+    ->add('dark:[&>option]:bg-zinc-700 dark:[&>option]:text-white')
     ->add('disabled:shadow-none')
     ->add($invalid
         ? 'border border-red-500'


### PR DESCRIPTION
# The scenario

If you use the select default variant in dark mode on windows, the background of the select is not dark and the contrast makes it hard to read.

![Flux Select Default Dark Windows Broken](https://github.com/user-attachments/assets/3ccfb916-4f7c-44da-a4b7-e213204484b1)

```blade
<flux:select wire:model="industry" placeholder="Choose industry...">
    <flux:select.option>Photography</flux:select.option>
    <flux:select.option>Design services</flux:select.option>
    <flux:select.option>Web development</flux:select.option>
    <flux:select.option>Accounting</flux:select.option>
    <flux:select.option>Legal services</flux:select.option>
    <flux:select.option>Consulting</flux:select.option>
    <flux:select.option>Other</flux:select.option>
</flux:select>
```

# The problem

The issue is that the native select dropdown doesn't seem to allow background styles to be applied directly to it. Filament has run into this issue before too https://github.com/filamentphp/filament/issues/7127

# The solution

The solution is to apply background styles to the options components instead of just the select element, as described here https://github.com/filamentphp/filament/issues/7127#issuecomment-1661386902

So this PR adds background and text styles to the select default options.

![Flux Select Default Dark Windows Fixed](https://github.com/user-attachments/assets/04967622-39cd-434a-9a4c-d0c679d963e1)

This is a similar issue to the one found in livewire/flux#1098