### PR TITLE
Fix checkbox and radio wrapping element variant does not exist error

### DIFF
--- a/stubs/resources/views/flux/checkbox/index.blade.php
+++ b/stubs/resources/views/flux/checkbox/index.blade.php
@@ -4,4 +4,11 @@
     'variant' => 'default',
 ])
 
+@php
+// This prevents variants picked up by `@aware()` from other wrapping components like flux::modal from being used here...
+$variant = $variant !== 'default' && Flux::componentExists('checkbox.variants.' . $variant)
+    ? $variant
+    : 'default';
+@endphp
+
 <flux:delegate-component :component="'checkbox.variants.' . $variant">{{ $slot }}</flux:delegate-component>

--- a/stubs/resources/views/flux/radio/index.blade.php
+++ b/stubs/resources/views/flux/radio/index.blade.php
@@ -4,4 +4,11 @@
     'variant' => 'default',
 ])
 
+@php
+// This prevents variants picked up by `@aware()` from other wrapping components like flux::modal from being used here...
+$variant = $variant !== 'default' && Flux::componentExists('radio.variants.' . $variant)
+    ? $variant
+    : 'default';
+@endphp
+
 <flux:delegate-component :component="'radio.variants.' . $variant">{{ $slot }}</flux:delegate-component>


### PR DESCRIPTION
# The scenario

If you have a checkbox or radio button wrapped in another element that sets a variant like a modal with a flyout variant, the checkbox/ radio were incorrectly trying to use that variant type.

![image](https://github.com/user-attachments/assets/72bfc514-a607-46c0-83f2-a53bf66dc92f)

```blade
<flux:modal variant="flyout">
        <flux:checkbox label="Email" />
</flux:modal>
```

# The problem

The issue is that the `@aware('variant')` inside checkboxes/ radios is pulling the variant from the modal component, causing an invalid variant.

# The solution

The solution is to add a check to make sure the variant exists for the checkbox/radio and if it doesn't then just fall back to using the default instead of throwing an error.

Fixes #1106, fixes #1108, fixes #1116, fixes #1121