### PR TITLE
Fix anonymous component views for Laravel 12

### DIFF
--- a/src/FluxManager.php
+++ b/src/FluxManager.php
@@ -140,6 +140,11 @@ class FluxManager
 
     public function componentExists($name)
     {
+        // Laravel 12+ uses xxh128 hashing for views https://github.com/laravel/framework/pull/52301...
+        if (app()->version() >= 12) {
+            return app('view')->exists(hash('xxh128', 'flux') . '::' . $name);
+        }
+
         return app('view')->exists(md5('flux') . '::' . $name);
     }
 }

--- a/src/FluxTagCompiler.php
+++ b/src/FluxTagCompiler.php
@@ -14,8 +14,9 @@ class FluxTagCompiler extends ComponentTagCompiler
 
             $class = \Illuminate\View\AnonymousComponent::class;
 
+            // Laravel 12+ uses xxh128 hashing for views https://github.com/laravel/framework/pull/52301...
             return "<?php if (!Flux::componentExists(\$name = {$component})) throw new \Exception(\"Flux component [{\$name}] does not exist.\"); ?>##BEGIN-COMPONENT-CLASS##@component('{$class}', 'flux::' . {$component}, [
-    'view' => md5('flux') . '::' . {$component},
+    'view' => (app()->version() >= 12 ? hash('xxh128', 'flux') : md5('flux')) . '::' . {$component},
     'data' => \$__env->getCurrentComponentData(),
 ])
 <?php \$component->withAttributes(\$attributes->getAttributes()); ?>";


### PR DESCRIPTION
# The scenario

Current components that use the Flux delegate component to dynamically load components, like icons, aren't loading on Laravel 12.

<img width="765" alt="image" src="https://github.com/user-attachments/assets/d238f56a-8b1e-41c3-9bd0-97443459df50" />

# The problem

The issue is that in Laravel 12 the Blade compiler's anonymous component path has been updated to use a faster hashing algorithm instead of md5 https://github.com/laravel/framework/pull/52301.

# The solution

The solution is we need to update Flux's component checks and delegate component generation to detect whether Laravel 12 or newer is being used and use the new hashing algorithm if so.