### PR TITLE
Fix button-or-div to allow button type to be changed

### DIFF
--- a/stubs/resources/views/flux/button-or-div.blade.php
+++ b/stubs/resources/views/flux/button-or-div.blade.php
@@ -3,7 +3,7 @@
 ])
 
 <?php if ($as === 'button'): ?>
-    <button type="button" {{ $attributes }}>
+    <button {{ $attributes->merge(['type' => 'button']) }}>
         {{ $slot }}
     </button>
 <?php else: ?>


### PR DESCRIPTION
# The scenario

Currently if you want to use a badge as a submit button, the button's type is set to `button` even if you pass in `type="submit"`.

```blade
<flux:badge color="cyan" as="button" type="submit">Submit button</flux:badge>
```

# The problem

The badge component is wrapped in the `button-or-div` component and the attributes are being correctly forwarded to it.

But it turns out that the type on the button in the `button-or-div` component is hard coded, so can't be overridden with attributes.

```blade
<button type="button" {{ $attributes }}>
```

# The solution

Change `button-or-div` button so that the type can be merged in through attributes.

```blade
<button {{ $attributes->merge(['type' => 'button']) }}>
```