### PR TITLE
Fix input clearable button to also dispatch change event

### DIFF
--- a/stubs/resources/views/flux/input/clearable.blade.php
+++ b/stubs/resources/views/flux/input/clearable.blade.php
@@ -11,7 +11,7 @@ $attributes = $attributes->merge([
     :$attributes
     :size="$size === 'sm' ? 'xs' : 'sm'"
     x-data
-    x-on:click="$el.closest('[data-flux-input]').querySelector('input').value = ''; $el.closest('[data-flux-input]').querySelector('input').dispatchEvent(new Event('input', { bubbles: false })); $el.closest('[data-flux-input]').querySelector('input').focus()"
+    x-on:click="let input = $el.closest('[data-flux-input]').querySelector('input'); input.value = ''; input.dispatchEvent(new Event('input', { bubbles: false })); input.dispatchEvent(new Event('change', { bubbles: false })); input.focus()"
     tabindex="-1"
     aria-label="Clear input"
 >


### PR DESCRIPTION
# The scenario

If you have a date pciker with an input that has the `clearable` attribute, currently pressing the clear button will clear the input value but won't update the value stored by Livewire.

<img width="612" alt="image" src="https://github.com/user-attachments/assets/b5ca66dc-3564-4a38-9d3a-97f4bb7c99c0" />

```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    public $date;
};
?>

<div>
    <flux:text>Date: {{ $date }}</flux:text>
    <flux:date-picker
        wire:model.live="date"
    >
        <x-slot name="trigger">
            <flux:date-picker.input clearable />
        </x-slot>
    </flux:date-picker>
</div>
```

# The problem

The problem is that the clear button only dispatches an input event but the date picker is listening for a change event on the input.

# The solution

The solution is to update the clearable button to also dispatch a change event, which I have done in this PR. I also refactored the clear button to make it more efficient and readable.

<img width="612" alt="image" src="https://github.com/user-attachments/assets/49299e87-b90c-433b-a7a5-6202a1ea3d11" />

Fixes livewire/flux#1157