### PR TITLE
Add `data-flux-clear-button` to the clear button

### DIFF
--- a/stubs/resources/views/flux/input/clearable.blade.php
+++ b/stubs/resources/views/flux/input/clearable.blade.php
@@ -14,6 +14,7 @@ $attributes = $attributes->merge([
     x-on:click="$el.closest('[data-flux-input]').querySelector('input').value = ''; $el.closest('[data-flux-input]').querySelector('input').dispatchEvent(new Event('input', { bubbles: false })); $el.closest('[data-flux-input]').querySelector('input').focus()"
     tabindex="-1"
     aria-label="Clear input"
+    data-flux-clear-button
 >
     <flux:icon.x-mark variant="micro" />
 </flux:button>


### PR DESCRIPTION
This PR adds a `data-flux-clear-button` attribute to the input clear button so it can be identified by the date picker and filtered out so it doesn't become a trigger button. See livewire/flux-pro#196 for details.