### PR TITLE
Fix DateRangeSynth hydrate of all time preset

### DIFF
--- a/src/DateRangeSynth.php
+++ b/src/DateRangeSynth.php
@@ -53,6 +53,10 @@ class DateRangeSynth extends Synth
         $preset = $value['preset'] ?? null;
 
         if ($preset) {
+            if ($preset === DateRangePreset::AllTime->value) {
+                return DateRange::allTime($value['start']);
+            }
+
             return DateRange::fromPreset(DateRangePreset::from($preset));
         }
 


### PR DESCRIPTION
# The scenario

If a Livewire property is set to a DateRange with a preset of AllTime, then on the next request it fails to hydrate and throws the following error:

<img width="1345" alt="image" src="https://github.com/user-attachments/assets/88834d89-7195-4c48-b0f6-fdbb2b8e7ad5" />

```blade
<?php

use Livewire\Volt\Component;
use Flux\DateRange;

new class extends Component {
    public DateRange $range;

    public function mount(): void
    {
        $this->range = DateRange::allTime('2018-01-01');
    }
}; ?>

<div class="flex">
    <flux:date-picker wire:model.live="range" mode="range" min="2018-01-01" with-presets/>
</div>
```

# The problem

The issue is that we're not handling the AllTime preset in the hydrate method of `DateRangeSynth`.

```php
if ($preset) {
    return DateRange::fromPreset(DateRangePreset::from($preset));
}
```

# The solution

This PR adds a check for AllTime and handles it the same way that the `hydrateType` method does.

```php
if ($preset) {
    if ($preset === DateRangePreset::AllTime->value) {
        return DateRange::allTime($value['start']);
    }

    return DateRange::fromPreset(DateRangePreset::from($preset));
}
```

Fixes livewire/flux#1160