### PR TITLE
Add missing `isNotAllTime()` method to DateRange

### DIFF
--- a/src/DateRange.php
+++ b/src/DateRange.php
@@ -44,6 +44,11 @@ class DateRange extends CarbonPeriod
         return $this->preset !== null;
     }
 
+    public function isNotAllTime(): bool
+    {
+        return $this->preset !== DateRangePreset::AllTime;
+    }
+
     protected static function fromPreset(DateRangePreset $preset)
     {
         if ($preset === DateRangePreset::AllTime) {


### PR DESCRIPTION
# The problem

We have documented that a `isNotAllTime()` method exists on the `DateRange` object, but it doesn't actually exist.

https://fluxui.dev/components/date-picker#all-time

> If you are using this date range to filter data, you may want to remove "where" constraints from the query when allTime is selected:
>
> ```php
> <?php
> 
> $orders = Order::when($this->range->isNotAllTime(), function ($query) => {
>     $query->whereBetween('created_at', $this->range);
> })->get();
> ```

# The solution

This PR adds it.

```php
public function isNotAllTime(): bool
{
    return $this->preset !== DateRangePreset::AllTime;
}
```

Fixes livewire/flux#1164