### PR TITLE
Add switch `left-align` attribute

### DIFF
--- a/stubs/resources/views/flux/switch.blade.php
+++ b/stubs/resources/views/flux/switch.blade.php
@@ -1,6 +1,6 @@
 @props([
     'name' => $attributes->whereStartsWith('wire:model')->first(),
-    'leftAlign' => false,
+    'align' => 'right',
 ])
 
 @php
@@ -27,7 +27,7 @@ $indicatorClasses = Flux::classes()
     ]);
 @endphp
 
-@if ($leftAlign)
+@if ($align === 'left')
     <flux:with-inline-field :$attributes>
         <ui-switch {{ $attributes->class($classes) }} data-flux-control data-flux-switch>
             <span class="{{ \Illuminate\Support\Arr::toCssClasses($indicatorClasses) }}"></span>

--- a/stubs/resources/views/flux/switch.blade.php
+++ b/stubs/resources/views/flux/switch.blade.php
@@ -1,5 +1,6 @@
 @props([
     'name' => $attributes->whereStartsWith('wire:model')->first(),
+    'leftAlign' => false,
 ])
 
 @php
@@ -26,8 +27,16 @@ $indicatorClasses = Flux::classes()
     ]);
 @endphp
 
-<flux:with-reversed-inline-field :$attributes>
-    <ui-switch {{ $attributes->class($classes) }} data-flux-control data-flux-switch>
-        <span class="{{ \Illuminate\Support\Arr::toCssClasses($indicatorClasses) }}"></span>
-    </ui-switch>
-</flux:with-reversed-inline-field>
+@if ($leftAlign)
+    <flux:with-inline-field :$attributes>
+        <ui-switch {{ $attributes->class($classes) }} data-flux-control data-flux-switch>
+            <span class="{{ \Illuminate\Support\Arr::toCssClasses($indicatorClasses) }}"></span>
+        </ui-switch>
+    </flux:with-inline-field>
+@else
+    <flux:with-reversed-inline-field :$attributes>
+        <ui-switch {{ $attributes->class($classes) }} data-flux-control data-flux-switch>
+            <span class="{{ \Illuminate\Support\Arr::toCssClasses($indicatorClasses) }}"></span>
+        </ui-switch>
+    </flux:with-reversed-inline-field>
+@endif


### PR DESCRIPTION
# The scenario

Currently if you want to left-align a switch, you can't use the `label` short hand and instead you need to use the `flux:field` component and syntax.

<img width="240" alt="image" src="https://github.com/user-attachments/assets/f2e830cb-28f9-4f56-bc38-0d2a473f48c3" />

```blade
<flux:fieldset>
    <flux:legend>Email notifications</flux:legend>

    <div class="space-y-3">
        <flux:field variant="inline" class="w-full flex justify-between">
            <flux:switch wire:model.live="email" />
            <flux:label>Communication emails</flux:label>
            <flux:error name="email" />
        </flux:field>

        <flux:field variant="inline" class="w-full flex justify-between">
            <flux:switch wire:model.live="marketing" />
            <flux:label>Marketing emails</flux:label>
            <flux:error name="marketing" />
        </flux:field>

        <flux:field variant="inline" class="w-full flex justify-between">
            <flux:switch wire:model.live="social" />
            <flux:label>Social emails</flux:label>
            <flux:error name="social" />
        </flux:field>

        <flux:field variant="inline" class="w-full flex justify-between">
            <flux:switch wire:model.live="security" />
            <flux:label>Security emails</flux:label>
            <flux:error name="security" />
        </flux:field>
    </div>
</flux:fieldset>
```

# The proposal

It would be much nicer if we could just add a `left-align` attribute to the switch component which handles it all for us

```blade
<flux:fieldset>
    <flux:legend>Email notifications</flux:legend>

    <div class="space-y-3">
        <flux:switch left-align label="Communication emails" wire:model.live="email" />

        <flux:switch left-align label="Marketing emails" wire:model.live="marketing" />

        <flux:switch left-align label="Social emails" wire:model.live="social" />

        <flux:switch left-align label="Security emails" wire:model.live="security" />
    </div>
</flux:fieldset>
```

# The solution

This PR implements the `left-align` attribute. The implementation is simple as we already have a `flux:with-inline-field` component, so this PR just makes use of that.