### PR TITLE
[1.x] Fix anonymous component views for Laravel 12

### DIFF
--- a/src/FluxManager.php
+++ b/src/FluxManager.php
@@ -140,6 +140,11 @@ class FluxManager
 
     public function componentExists($name)
     {
+        // Laravel 12+ uses xxh128 hashing for views https://github.com/laravel/framework/pull/52301...
+        if (app()->version() >= 12) {
+            return app('view')->exists(hash('xxh128', 'flux') . '::' . $name);
+        }
+
         return app('view')->exists(md5('flux') . '::' . $name);
     }
 }

--- a/src/FluxTagCompiler.php
+++ b/src/FluxTagCompiler.php
@@ -14,8 +14,9 @@ class FluxTagCompiler extends ComponentTagCompiler
 
             $class = \Illuminate\View\AnonymousComponent::class;
 
+            // Laravel 12+ uses xxh128 hashing for views https://github.com/laravel/framework/pull/52301...
             return "##BEGIN-COMPONENT-CLASS##@component('{$class}', 'flux::' . {$component}, [
-    'view' => md5('flux') . '::' . {$component},
+    'view' => (app()->version() >= 12 ? hash('xxh128', 'flux') : md5('flux')) . '::' . {$component},
     'data' => \$__env->getCurrentComponentData(),
 ])
 <?php \$component->withAttributes(\$attributes->getAttributes()); ?>";


### PR DESCRIPTION
This is a backport of PR #1141 to Flux v1 to fix anonymous component views in Laravel 12.

Fixes livewire/flux#1192