### PR TITLE
Fix select sizes to match other inputs

### DIFF
--- a/stubs/resources/views/flux/select/variants/default.blade.php
+++ b/stubs/resources/views/flux/select/variants/default.blade.php
@@ -12,7 +12,7 @@ $classes = Flux::classes()
     ->add('appearance-none') // Strip the browser's default <select> styles...
     ->add('w-full pl-3 pr-10 block')
     ->add(match ($size) {
-        default => 'h-10 py-2 text-sm leading-none rounded-lg',
+        default => 'h-10 py-2 text-base sm:text-sm leading-none rounded-lg',
         'sm' => 'h-8 py-1.5 text-sm leading-none rounded-md',
         'xs' => 'h-6 text-xs leading-none rounded-md',
     })


### PR DESCRIPTION
# The scenario

Currently if you have inputs, date pickers and selects together in the same form, they are displaying different text sizes

**Mobile before**
![image](https://github.com/user-attachments/assets/99fdd1c5-7e84-432e-9b61-2332ba19fd2e)

**Desktop before**
![image](https://github.com/user-attachments/assets/463a7e93-074e-46f9-8515-f017094fcbd3)

```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    //
}; ?>

<div class="flex flex-col gap-2">
    <flux:input label="Input" value="5 Feb 2025" />
    <flux:date-picker label="Date picker" value="2025-02-05"/>
    <flux:date-picker value="2025-02-05">
        <x-slot name="trigger">
            <flux:date-picker.input />
        </x-slot>
    </flux:date-picker>
    <flux:select label="Select">
        <flux:select.option selected>5 Feb 2025</flux:select.option>
    </flux:select>
    <flux:select variant="listbox" label="Listbox">
        <flux:select.option selected>5 Feb 2025</flux:select.option>
    </flux:select>
    <flux:select variant="combobox" label="Combobox">
        <x-slot name="input">
            <flux:select.input value="5 Feb 2025" />
        </x-slot>
        <flux:select.option selected>5 Feb 2025</flux:select.option>
    </flux:select>
</div>
```

# The problem

The issue is that selects and date pickers didn't have the correct text sizes applied like inputs do.

The sizes we have on inputs for the `default` size are:

```php
default => 'text-base sm:text-sm ...'
```

These were applied in a previous PR where we decided to make mobile 16px (text-base) by default and 14px (text-sm) for desktops.

# The solution

This PR fixes selects and the date picker to have the correct sizes for the default size.

There is also a corresponding Flux Pro PR livewire/flux-pro#199

**Mobile after fix**
![image](https://github.com/user-attachments/assets/8cebfbc8-c780-47f3-803f-1f7d1e617f21)

**Desktop after fix**
![image](https://github.com/user-attachments/assets/cea01333-7464-4b1a-bbf7-0b07598ac120)

Fixes livewire/flux#1191
