### PR TITLE
Fix deprecation warning when button has missing wire:click

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -30,7 +30,7 @@ $iconClasses = Flux::classes()
 
 $isTypeSubmitAndNotDisabledOnRender = $type === 'submit' && ! $attributes->has('disabled');
 
-$isJsMethod = str_starts_with($attributes->whereStartsWith('wire:click')->first(), '$js.');
+$isJsMethod = str_starts_with($attributes->whereStartsWith('wire:click')->first() ?? '', '$js.');
 
 $loading ??= $loading ?? ($isTypeSubmitAndNotDisabledOnRender || $attributes->whereStartsWith('wire:click')->isNotEmpty() && ! $isJsMethod);
 


### PR DESCRIPTION
I just changed the conditional that sets the $isJsMethod value to use an empty string in cases where there isn't a wire:click attribute passed to the button component.

It may not be the best solution; I haven't really looked at the rest of the codebase. A user in the Livewire Discord posted that he'd received these notices, and I'm assuming it's from Flux.

Discord Details:

[Original Message ](https://discord.com/channels/698229985755791471/698229986233942028/1344385903233335390)

<img width="1037" alt="image" src="https://github.com/user-attachments/assets/4774e9ad-29d6-40ae-aeca-bbd80ce54176" />
