### PR TITLE
Fix: Prevent null passing to str_starts_with()

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -30,7 +30,7 @@ $iconClasses = Flux::classes()
 
 $isTypeSubmitAndNotDisabledOnRender = $type === 'submit' && ! $attributes->has('disabled');
 
-$isJsMethod = str_starts_with($attributes->whereStartsWith('wire:click')->first() ?? '', '$js.');
+$isJsMethod = str_starts_with((string) ($attributes->whereStartsWith('wire:click')->first() ?? ''), '$js.');
 
 $loading ??= $loading ?? ($isTypeSubmitAndNotDisabledOnRender || $attributes->whereStartsWith('wire:click')->isNotEmpty() && ! $isJsMethod);
 


### PR DESCRIPTION
Ensure the attribute value is always cast to a string before passing it to str_starts_with() to avoid deprecation warnings in PHP 8.1+.

Fixes https://github.com/livewire/flux/issues/1207