### PR TITLE
Fix select option variant not found

### DIFF
--- a/stubs/resources/views/flux/select/option/index.blade.php
+++ b/stubs/resources/views/flux/select/option/index.blade.php
@@ -5,8 +5,10 @@
 ])
 
 @php
-// If the variant is coming from the parent component and is not default, we need to use the custom variant...
-$variant = $variant === 'default' ? 'default' : 'custom';
+// This prevents variants picked up by `@aware()` from other wrapping components like flux::modal from being used here...
+$variant = $variant !== 'default' && Flux::componentExists('select.variants.' . $variant)
+    ? 'custom'
+    : 'default';
 @endphp
 
 <flux:with-field :$attributes>


### PR DESCRIPTION
# The scenario

If you use a default select inside a component that has a variant defined, like a modal, then the select options aren't showing up.

<img width="778" alt="image" src="https://github.com/user-attachments/assets/41f3d34c-f915-4df4-8f57-82b617abcfaf" />

```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    //
}; ?>

<div>
    <flux:modal.trigger name="edit-profile">
        <flux:button>Edit profile</flux:button>
    </flux:modal.trigger>

    <flux:modal variant="flyout" name="edit-profile" class="md:w-96">
        <flux:select placeholder="Choose industry...">
            <flux:select.option>Photography</flux:select.option>
            <flux:select.option>Design services</flux:select.option>
            <flux:select.option>Web development</flux:select.option>
            <flux:select.option>Accounting</flux:select.option>
            <flux:select.option>Legal services</flux:select.option>
            <flux:select.option>Consulting</flux:select.option>
            <flux:select.option>Other</flux:select.option>
        </flux:select>
    </flux:modal>
</div>
```

# The problem

The issue is that we recently split the select components, so some are free and some are pro, which required the option component to be split into multiple variants, but I didn't add the check back in to make sure that the variant for the option is coming from a select component and not any other components.

```blade
@php
// If the variant is coming from the parent component and is not default, we need to use the custom variant...
$variant = $variant === 'default' ? 'default' : 'custom';
@endphp
```

# The solution

The solution is to update the variant check to include a check to make sure the select variant exists first. Now everything works happily.

```blade
@php
// This prevents variants picked up by `@aware()` from other wrapping components like flux::modal from being used here...
$variant = $variant !== 'default' && Flux::componentExists('select.variants.' . $variant)
    ? 'custom'
    : 'default';
@endphp
```

<img width="778" alt="image" src="https://github.com/user-attachments/assets/c3ea0e77-6b76-43e3-8158-fd3faf293cbc" />

Fixes livewire/flux#1209