### PR TITLE
Switch Toggle: Replace w-8 with min-w-8 to fix parent's flex issues

### DIFF
--- a/stubs/resources/views/flux/switch.blade.php
+++ b/stubs/resources/views/flux/switch.blade.php
@@ -5,7 +5,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('group h-5 w-8 relative inline-flex items-center outline-offset-2')
+    ->add('group h-5 min-w-8 relative inline-flex items-center outline-offset-2')
     ->add('rounded-full')
     ->add('transition')
     ->add('bg-zinc-800/15 [&[disabled]]:opacity-50 dark:bg-transparent dark:border dark:border-white/20 dark:[&[disabled]]:border-white/10')

--- a/stubs/resources/views/flux/switch.blade.php
+++ b/stubs/resources/views/flux/switch.blade.php
@@ -5,7 +5,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('group h-5 min-w-8 relative inline-flex items-center outline-offset-2')
+    ->add('group h-5 w-8 min-w-8 relative inline-flex items-center outline-offset-2')
     ->add('rounded-full')
     ->add('transition')
     ->add('bg-zinc-800/15 [&[disabled]]:opacity-50 dark:bg-transparent dark:border dark:border-white/20 dark:[&[disabled]]:border-white/10')


### PR DESCRIPTION
I have a switch toggle placed within a flex and justify-between element, which get's truncated and looks like this:

<img width="350" alt="Bildschirmfoto 2025-02-28 um 09 40 08" src="https://github.com/user-attachments/assets/bd22cbbd-d8bc-4bb5-a11b-e1a99fb7a8bc" />

The only fix I found so far is to replace the fixed width with a min width, so instead of w-8 we take min-w-8, and voila, it works:

<img width="346" alt="Bildschirmfoto 2025-02-28 um 09 40 16" src="https://github.com/user-attachments/assets/a72ee690-49e3-46d2-bbfb-2c5850d4681e" />

For clarification, my blade template is this:
```blade
<div class="flex items-start gap-4 justify-between">
    <flux:heading>{{ __('Get email notifications about new subscribers') }}</flux:heading>
    <flux:switch wire:model.live="state.notify_about_new_subscriber" class="cursor-pointer"/>
</div>
```