### PR TITLE
Brand Component Improvements

### DIFF
--- a/stubs/resources/views/flux/brand.blade.php
+++ b/stubs/resources/views/flux/brand.blade.php
@@ -5,35 +5,29 @@
 ])
 
 @php
-$classes = Flux::classes()
-    ->add('h-10 flex items-center mr-4')
-    ;
+    $classes = Flux::classes()->add('h-10 flex items-center mr-4');
 
-$textClasses = Flux::classes()
-    ->add('text-sm font-medium truncate [:where(&)]:text-zinc-800 dark:[:where(&)]:text-zinc-100')
-    ;
+    $textClasses = Flux::classes()->add(
+        'text-sm font-medium truncate [:where(&)]:text-zinc-800 dark:[:where(&)]:text-zinc-100',
+    );
 @endphp
 
-<?php if ($name): ?>
-    <a href="{{ $href }}" {{ $attributes->class([ $classes, 'gap-2' ])->except('alt') }} data-flux-brand>
-        <div class="size-6 rounded-sm overflow-hidden shrink-0">
-            <?php if (is_string($logo)): ?>
-                <img src="{{ $logo }}" {{ $attributes->only('alt') }} />
-            <?php else: ?>
-                {{ $logo ?? $slot }}
-            <?php endif; ?>
-        </div>
-
-        <div class="{{ $textClasses }}">{{ $name }}</div>
-    </a>
-<?php else: ?>
-    <a href="{{ $href }}" {{ $attributes->class($classes)->except('alt') }} data-flux-brand>
-        <div class="size-8 rounded-sm overflow-hidden shrink-0">
-            <?php if (is_string($logo)): ?>
-                <img src="{{ $logo }}" {{ $attributes->only('alt') }} />
-            <?php else: ?>
-                {{ $logo ?? $slot }}
-            <?php endif; ?>
-        </div>
-    </a>
-<?php endif; ?>
+<a {{ $attributes->class([$classes, 'gap-2' => $name !== null])->except('alt') }} data-flux-brand
+    href="{{ $href }}">
+    <div @class([
+        'rounded-sm overflow-hidden shrink-0',
+        'hidden' => $logo === null,
+        'inline-flex align-middle' => $logo !== null,
+        'size-8' => $name === null,
+        'size-6' => $name !== null,
+    ])>
+        <?php if (is_string($logo)): ?>
+        <img {{ $attributes->only('alt') }} class="object-contain" src="{{ $logo }}" />
+        <?php else: ?>
+        {{ $logo ?? $slot }}
+        <?php endif; ?>
+    </div>
+    <?php if ($name): ?>
+    <div class="{{ $textClasses }}">{{ $name }}</div>
+    <?php endif; ?>
+</a>


### PR DESCRIPTION
# Styling Improvements with some refactoring.

I've just started using Flux, and I needed to modify the Brand component in my app.

I noticed that my logo was rendering too small on my side-nav. It was also at the top of its parent container, while the text was vertically centered, breaking the alignment.

## Fixed Image Alignment 

Example:

<img width="439" alt="image" src="https://github.com/user-attachments/assets/443fa743-5e9c-4cb1-8735-ee6b3f2dfab6" />

Fixed by adding inline-flex and align-middle to the img element's parent container.
object-contain was also added to the img element to prevent the brand image from being vertically stretched.

<img width="354" alt="image" src="https://github.com/user-attachments/assets/d978f363-cc1d-4b7e-a726-d28d093796ee" />

## Text is misaligned when no logo is present

If a logo is rendered with a name but no logo, the logo's fixed size parent is still rendered, causing the name to be misaligned. I've made the container red to make it visible:

<img width="425" alt="image" src="https://github.com/user-attachments/assets/222ee9f2-86c7-4b7d-92a9-0edf602d395a" />

This element now has the hidden class if no logo is provided to prevent it from mis-aligning the brand name.

## Refactoring

The conditional code handling how the component is rendered when the name is/isn't null seemed redundant. The only changes between the two outputs were the logo image size and the name being printed. Thought it would make sense to merge them both together and remove the repeated code.
