### PR TITLE
Add the selected prop to select options

### DIFF
--- a/stubs/resources/views/flux/select/option/variants/default.blade.php
+++ b/stubs/resources/views/flux/select/option/variants/default.blade.php
@@ -1,9 +1,11 @@
 @props([
     'value' => null,
+    'selected' => null,
 ])
 
 <option
     {{ $attributes }}
     @if (isset($value)) value="{{ $value }}" @endif
     @if (isset($value)) wire:key="{{ $value }}" @endif
+    @if ($selected) selected @endif
 >{{ $slot }}</option>


### PR DESCRIPTION
This adds a selected prop to the select options components so that the user can force an option as selected properly. 

Saw a few people reporting this issue and couldn't find anyone with a fix.

- https://github.com/livewire/flux/discussions/1089
- https://github.com/livewire/flux/issues/983

## Example
```blade
<flux:select variant="listbox" placeholder="Select Something..." wire:change="setSomething($event.target.value)">
    @foreach($somethings as $something)
        <flux:select.option :selected="$selectedSomething === $something->id" :value="$something->id">
            {{ $something->name }}
        </flux:select.option>
    @endforeach
</flux:select>
```