### PR TITLE
Fix modal trigger on Firefox

### DIFF
--- a/stubs/resources/views/flux/modal/trigger.blade.php
+++ b/stubs/resources/views/flux/modal/trigger.blade.php
@@ -8,7 +8,7 @@
     x-data
     x-on:click="$el.querySelector('button[disabled]') || $dispatch('modal-show', { name: '{{ $name }}' })"
     @if ($shortcut)
-        x-on:keydown.{{ $shortcut }}.document="$dispatch('modal-show', { name: '{{ $name }}' })"
+        x-on:keydown.{{ $shortcut }}.document="$event.preventDefault(); $dispatch('modal-show', { name: '{{ $name }}' })"
     @endif
     data-flux-modal-trigger
 >


### PR DESCRIPTION
# The scenario

Currently if you use the command palette in a modal on Firefox and try to open the command palette using the `cmd+k` modal trigger shortcut, those command palette opens but so does Firefox's address bar.

![Recording 2025-03-06 at 12 36 02](https://github.com/user-attachments/assets/1c05d0b1-e396-44fb-8078-3c985b064442)

```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    //
}; ?>

<div>
    <flux:modal.trigger name="search" shortcut="cmd.k">
        <flux:input as="button" placeholder="Search..." icon="magnifying-glass" kbd="⌘K" />
    </flux:modal.trigger>

    <flux:modal name="search" variant="bare" class="w-full max-w-[30rem] my-[12vh] max-h-screen overflow-y-hidden">
        <flux:command class="border-none shadow-lg inline-flex flex-col max-h-[76vh]">
            <flux:command.input placeholder="Search..." closable />

            <flux:command.items>
                <flux:command.item icon="user-plus" kbd="⌘A">Assign to…</flux:command.item>
                <flux:command.item icon="document-plus">Create new file</flux:command.item>
                <flux:command.item icon="folder-plus" kbd="⌘⇧N">Create new project</flux:command.item>
                <flux:command.item icon="book-open">Documentation</flux:command.item>
                <flux:command.item icon="newspaper">Changelog</flux:command.item>
                <flux:command.item icon="cog-6-tooth" kbd="⌘,">Settings</flux:command.item>
            </flux:command.items>
        </flux:command>
    </flux:modal>
</div>
```

# The problem

The issue is that the `cmd+k` shortcut is being used by Firefox but if a user has set the modal to open on `cmd+k` then both shouldn't open.

# The solution

The solution is to prevent the default action from happening when a modal trigger shortcut is fired.

![Recording 2025-03-06 at 12 35 11](https://github.com/user-attachments/assets/367d007a-67b4-4a0d-88f6-ca5722d3b8f4)

This does block Firefox's native browser behaviour, but if a user want's to keep that behaviour, they can use a different shortcut than `cmd+k`. I tested on other modals, such as Algolia's seach, and they also block the default browser behaviour if `cmd+k` is used.

Fixes livewire/flux#1050