### PR TITLE
Make label badge slottable

### DIFF
--- a/stubs/resources/views/flux/label.blade.php
+++ b/stubs/resources/views/flux/label.blade.php
@@ -13,8 +13,12 @@
 <ui-label {{ $attributes->class($classes) }} data-flux-label>
     {{ $slot }}
 
-    <?php if ($badge): ?>
+    <?php if (is_string($badge)): ?>
         <span class="ml-1.5 text-zinc-800/70 text-xs bg-zinc-800/5 px-1.5 py-1 rounded-[4px] dark:bg-white/10 dark:text-zinc-300" aria-hidden="true">
+            {{ $badge }}
+        </span>
+    <?php elseif ($badge): ?>
+        <span class="ml-1.5" aria-hidden="true">
             {{ $badge }}
         </span>
     <?php endif; ?>


### PR DESCRIPTION
# The scenario

Currently if you use normal badges near label badges, they look different. The label badges also can't make use of the different badge colours.

<img width="197" alt="image" src="https://github.com/user-attachments/assets/0dfc6043-da30-4f66-8102-8686bce45771" />

```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    //
}; ?>

<div>
    <flux:badge size="sm">Badge</flux:badge>
    <flux:field>
        <flux:label badge="Required">Email</flux:label>

        <flux:input type="email" required />
    </flux:field>
</div>
```

# The problem

The issue is that the label badge isn't using the badge component as it was designed to be something slightly different.

# The solution

The solution is to make the label badge slotable, that way if a user needs an actual badge there whether for design reasons or colour reasons, they can do so.

<img width="247" alt="image" src="https://github.com/user-attachments/assets/12f2047b-283d-4629-ad84-bdf8171697ac" />

```blade
<flux:label>
    <x-slot:badge>
        <flux:badge size="sm">Required</flux:badge>
    </x-slot:badge>
    Email
</flux:label>
```

Fixes livewire/flux#1093