### PR TITLE
Fix `-able` buttons on xs inputs

### DIFF
--- a/stubs/resources/views/flux/input/clearable.blade.php
+++ b/stubs/resources/views/flux/input/clearable.blade.php
@@ -9,7 +9,7 @@ $attributes = $attributes->merge([
 
 <flux:button
     :$attributes
-    :size="$size === 'sm' ? 'xs' : 'sm'"
+    :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
     x-data
     x-on:click="let input = $el.closest('[data-flux-input]').querySelector('input'); input.value = ''; input.dispatchEvent(new Event('input', { bubbles: false })); input.dispatchEvent(new Event('change', { bubbles: false })); input.focus()"
     tabindex="-1"

--- a/stubs/resources/views/flux/input/copyable.blade.php
+++ b/stubs/resources/views/flux/input/copyable.blade.php
@@ -9,7 +9,7 @@ $attributes = $attributes->merge([
 
 <flux:button
     :$attributes
-    :size="$size === 'sm' ? 'xs' : 'sm'"
+    :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
     x-data="{ copied: false }"
     x-on:click="copied = ! copied; navigator.clipboard && navigator.clipboard.writeText($el.closest('[data-flux-input]').querySelector('input').value); setTimeout(() => copied = false, 2000)"
     x-bind:data-copyable-copied="copied"

--- a/stubs/resources/views/flux/input/expandable.blade.php
+++ b/stubs/resources/views/flux/input/expandable.blade.php
@@ -9,7 +9,7 @@ $attributes = $attributes->merge([
 
 <flux:button
     :$attributes
-    :size="$size === 'sm' ? 'xs' : 'sm'"
+    :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
     x-on:click="$el.closest('[data-flux-input]').querySelector('input').value = ''"
 >
     <flux:icon.chevron-down variant="micro" />

--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -22,9 +22,6 @@ $invalid ??= ($name && $errors->has($name));
 
 $iconLeading ??= $icon;
 
-// Clearable is not supported on xs size...
-if ($size === 'xs') $clearable = null;
-
 $hasLeadingIcon = (bool) ($iconLeading);
 $hasTrailingIcon = (bool) ($iconTrailing) || (bool) $kbd || (bool) $clearable || (bool) $copyable || (bool) $viewable || (bool) $expandable;
 $hasBothIcons = $hasLeadingIcon && $hasTrailingIcon;
@@ -112,7 +109,7 @@ $classes = Flux::classes()
 
             <?php if ($expandable): ?>
                 <div class="absolute top-0 bottom-0 flex items-center justify-center pr-2 right-0">
-                    <flux:input.expandable />
+                    <flux:input.expandable :$size />
                 </div>
             <?php endif; ?>
 

--- a/stubs/resources/views/flux/input/viewable.blade.php
+++ b/stubs/resources/views/flux/input/viewable.blade.php
@@ -9,7 +9,7 @@ $attributes = $attributes->merge([
 
 <flux:button
     :$attributes
-    :size="$size === 'sm' ? 'xs' : 'sm'"
+    :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
     x-data="{ open: false }"
     x-on:click="open = ! open; $el.closest('[data-flux-input]').querySelector('input').setAttribute('type', open ? 'text' : 'password')"
     x-bind:data-viewable-open="open"


### PR DESCRIPTION
# The scenario

Currently if you try to use `copyable`, `viewable`, or `expandable` on inputs that are size `xs` then the overstate overlaps and the icon sizes aren't great. But if you try to use `clearable` on an `xs` input, then it doesn't show at all.

<img width="612" alt="image" src="https://github.com/user-attachments/assets/9d49ef76-7866-4f5a-8e3f-800da6574125" />

```blade
<div class="space-y-4">
    <flux:input size="xs" clearable />
    <flux:input size="xs" copyable />
    <flux:input size="xs" viewable />
    <flux:input size="xs" expandable />
</div>
```

# The problem

The issue with the first 3 options is that when looking in the copyable/expandable/viewable components, they have support for size `sm` but not size `xs` which is causing the larger buttons and icons to be shown.

```blade
<flux:button
    :size="$size === 'sm' ? 'xs' : 'sm'"
    ...
>
```

Where as the clearable component won't even render at all, because the `input/index.blade.php` component has the following line which is disabling clearable altogether for `xs` inputs.

```php
// Clearable is not supported on xs size...
if ($size === 'xs') $clearable = null;
```

# The solution

To fix this there are two possible options. One is we can also disable copyable/expandable/viewable buttons in the input component and add a note in the docs that these won't work on an `xs` input.

Or the other option is to add support for the `xs` size in the copyable/expandable/viewable components and also in the clearable component, and remove the line that disables clearable.

The second option is what has been implemented in this PR and everything fits nicely inside the input.

```blade
<flux:button
    :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
    ...
>
```

<img width="612" alt="image" src="https://github.com/user-attachments/assets/d821d276-dd67-4166-b56b-87ae13ca008c" />

<img width="247" alt="image" src="https://github.com/user-attachments/assets/d4f166d0-43a1-4a89-93d4-b5fb48a55f3d" />

Fixes livewire/flux#1266