### PR TITLE
Fix label so it's selectable

### DIFF
--- a/stubs/resources/views/flux/label.blade.php
+++ b/stubs/resources/views/flux/label.blade.php
@@ -5,7 +5,7 @@
 
 @php
     $classes = Flux::classes()
-        ->add('text-sm font-medium select-none')
+        ->add('text-sm font-medium')
         ->add('text-zinc-800 dark:text-white')
         ;
 @endphp


### PR DESCRIPTION
# The scenario

Currently you cannot select the text of an input label, which is different to how the native browser label works.

You can see in the screencapture below, that a browser label has a default cursor but the text is selectable, where as the Flux label has a default cursor but the text is not selectable (for some reason the cursor didn't move in the screencapture, but rest assured that it did). This is inconsistent.

![Recording 2025-03-10 at 12 02 33](https://github.com/user-attachments/assets/b318b1c4-00fd-4e41-aa43-f5a172ef1b91)

```blade
<div>
    <flux:input label="Flux Label" />

    <label for="testing">Browser Label</label>
    <input type="text" id="testing" class="block border" />
</div>
```

# The problem

The issue is that the label component has `select-none` class on it and the label javascript is injecting `user-select: none`.

```js
inject(({ css }) => css`
    ui-label { display: inline-block; cursor: default; user-select: none; }
    ui-description { display: block; }
`)
```

# The solution

This PR removes the `select-none` class and a companion Flux Pro PR livewire/flux-pro#220 fixes the javascript by removing the injected `user-select` style.

Now the label can be highlighted.

![Recording 2025-03-10 at 12 01 29](https://github.com/user-attachments/assets/8822062c-1c2b-4efc-8a4f-c619b9e4f51f)

Fixes livewire/flux#1270