### PR TITLE
Fix `DateRangeSynth` so the `DateRange` can be validated

### DIFF
--- a/src/DateRangeSynth.php
+++ b/src/DateRangeSynth.php
@@ -17,6 +17,19 @@ class DateRangeSynth extends Synth
         return $type === DateRange::class;
     }
 
+    static function unwrap($target) {
+        $data = [
+            'start' => $target->start()?->format('Y-m-d'),
+            'end' => $target->end()?->format('Y-m-d'),
+        ];
+
+        $preset = $target->preset();
+
+        $preset && $data['preset'] = $preset->value;
+
+        return $data;
+    }
+
     static function hydrateFromType($type, $value) {
         if ($value === '' || $value === null) return null;
 

--- a/src/DateRangeSynth.php
+++ b/src/DateRangeSynth.php
@@ -17,7 +17,7 @@ class DateRangeSynth extends Synth
         return $type === DateRange::class;
     }
 
-    static function unwrap($target) {
+    static function unwrapForValidation($target) {
         $data = [
             'start' => $target->start()?->format('Y-m-d'),
             'end' => $target->end()?->format('Y-m-d'),

--- a/stubs/resources/views/flux/error.blade.php
+++ b/stubs/resources/views/flux/error.blade.php
@@ -1,10 +1,15 @@
 @props([
     'name' => null,
     'message' => null,
+    'nested' => true,
 ])
 
 @php
 $message ??= $name ? $errors->first($name) : null;
+
+if ((is_null($message) || $message === '') && filter_var($nested, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== false) {
+    $message = $errors->first($name . '.*');
+}
 
 $classes = Flux::classes('mt-3 text-sm font-medium text-red-500 dark:text-red-400')
     ->add($message ? '' : 'hidden');


### PR DESCRIPTION
Note: This PR depends on this Livewire PR [Add validation support to synths](https://github.com/livewire/livewire/pull/9231#top) being merged and tagged first.

# The scenario

Currently if we have a date range picker that is bound to a property of type `DateRange`, there is no way to validate that the start, end, and preset properties on the `DateRange` object are valid.

For a full write up of this issue, please read this comment https://github.com/livewire/flux/issues/1222#issuecomment-2712542844

# The problem

The issue is that Livewire has no way of knowing how to format a `DateRange` object in a way where Laravel's validation can process the properties on the `DateRange` object.

I go into detail in the issue comment https://github.com/livewire/flux/issues/1222#issuecomment-2712542844 and the Livewire PR https://github.com/livewire/livewire/pull/9231 on why this is.

# The solution

The solution is to instruct Livewire on how to format the data ready for validation.

If the Livewire PR https://github.com/livewire/livewire/pull/9231 gets merged, then we will be able to update the `DateRangeSynth` to add a `unwrap()` method which instructs Livewire on how to prepare a `DateRange` object for validation.

This PR adds the `unwrap()` method to the `DateRangeSynth` in preparation.

See livewire/flux#1222

I've not marked this PR as fixing issue livewire/flux#1222 as there is still a question of how to display error messages for the nested properties inside the `DateRange` object. But that can be addressed in a separate PR.