### PR TITLE
Fix badge left inset

### DIFF
--- a/stubs/resources/views/flux/badge/index.blade.php
+++ b/stubs/resources/views/flux/badge/index.blade.php
@@ -9,7 +9,7 @@
 ])
 
 @php
-$insetClasses = Flux::applyInset($inset, top: '-mt-1', right: '-mr-2', bottom: '-mb-1', left: '-ml-1');
+$insetClasses = Flux::applyInset($inset, top: '-mt-1', right: '-mr-2', bottom: '-mb-1', left: '-ml-2');
 
 // When using the outline icon variant, we need to size it down to match the default icon sizes...
 $iconClasses = Flux::classes()->add($iconVariant === 'outline' ? 'size-4' : '');


### PR DESCRIPTION
# The scenario

Currently if you have a badge with `inset` or `inset="left"` it's not inset fully. As you can see in the image below, the badge text is slightly to the right of the heading text.

<img width="284" alt="image" src="https://github.com/user-attachments/assets/29e61361-5714-4505-939a-78cc60f3f524" />

<div>
    <flux:badge inset="left">Badge</flux:badge>
    <flux:heading>Heading</flux:heading>
</div>

# The problem

The issue is that the badge has a `px-2` on it, and the inset for right is set to `-mr-2` but left is set to `-ml-1`.

# The solution

This PR updates the left inset to be `-ml-2` to match the padding.

<img width="280" alt="image" src="https://github.com/user-attachments/assets/178824f4-16b5-4e7a-8508-d8e0ea4d99bf" />

Fixes livewire/flux#1294