### PR TITLE
Update error component to support nested attributes

### DIFF
--- a/stubs/resources/views/flux/error.blade.php
+++ b/stubs/resources/views/flux/error.blade.php
@@ -7,7 +7,7 @@
 @php
 $message ??= $name ? $errors->first($name) : null;
 
-if ((is_null($message) || $message === '') && $nested === true) {
+if ((is_null($message) || $message === '') && filter_var($nested, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== false) {
     $message = $errors->first($name . '.*');
 }
 

--- a/stubs/resources/views/flux/error.blade.php
+++ b/stubs/resources/views/flux/error.blade.php
@@ -1,10 +1,15 @@
 @props([
     'name' => null,
     'message' => null,
+    'nested' => true,
 ])
 
 @php
 $message ??= $name ? $errors->first($name) : null;
+
+if ((is_null($message) || $message === '') && $nested === true) {
+    $message = $errors->first($name . '.*');
+}
 
 $classes = Flux::classes('mt-3 text-sm font-medium text-red-500 dark:text-red-400')
     ->add($message ? '' : 'hidden');


### PR DESCRIPTION
While this PR doesn't actually depend on PR #1295, I have branched this PR off that one to make testing easier, so I would recommend merging that PR first before reviewing this one. 

# The scenario

Currently if we have a component, like the date picker, that updates a property which has nested attributes, then the validation errors for those nested attributes aren't shown.

For example, if we have a date range picker and we have rules for start and end to ensure that start is before end, then if a range is submitted the wrong way around and validation fails, no error messages are show for `range.start` or `range.end`.

<img width="310" alt="image" src="https://github.com/user-attachments/assets/9ca6ee57-33e2-4032-9346-578f72161151" />

```blade
<?php

use App\Rules\DateRangeRule;
use Flux\DateRange;
use Flux\DateRangePreset;
use Livewire\Attributes\Computed;
use Livewire\Attributes\Validate;
use Livewire\Volt\Component;

new class extends Component {
    public ?DateRange $range = null;

public function rules()
{
    return [
        'range' => ['required'],
        'range.start' => ['required', 'date', 'before:range.end'],
        'range.end' => ['required', 'date', 'after:range.start'],
        'range.preset' => ['nullable', 'in:' . collect(DateRangePreset::cases())->pluck('value')->implode(',')],
    ];
}

    public function submit()
    {
        $this->validate();

        Flux::toast('Date range is valid!', variant: 'success');
    }
};
?>

<div>
    <form wire:submit="submit">
        <flux:date-picker mode="range" label="Range" wire:model.live="range" with-presets />
        <flux:button variant="primary" type="submit">Submit</flux:button>
    </form>
</div>
```

# The problem

The issue is that the errors component is only showing exact errors for `range` and not any of range's attributes, like `range.start`.

# The solution

This PR adds support to the `<flux:error>` component for showing errors for the property and any nested attributes. So the below code, will display errors for the range property itself.

```blade
<flux:error name="range" />
```
<img width="258" alt="Screenshot 2025-03-12 at 1 12 37 pm" src="https://github.com/user-attachments/assets/29a6fd8a-be15-4817-bf2a-1b27934766ab" />

And if there are no errors on the base property, it will display any errors on nested attributes for the property.

<img width="398" alt="Screenshot 2025-03-12 at 1 13 00 pm" src="https://github.com/user-attachments/assets/34c3ea92-0a27-4ddb-a811-52127ea53ed4" />

It will only display the first nested attribute error it comes across. So if there are errors on both `range.start` and `range.end`, then it will only show the `range.start` error message.

In case someone doesn't want the errors component to display nested attribute errors, they can set `:nested="false"`.

```blade
<flux:error name="range" :nested="false" />
```

This will then only show errors for `range` and not `range.start`, etc.

Fixes livewire/flux#1222

And if you noticed that the red border is missing from the date picker when the error is a nested attribute error, that is because the date picker itself isn't using the nested logic, so I've also submitted a PR to fix that https://github.com/livewire/flux-pro/pull/228