### PR TITLE
Add missing components to publish command

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -24,7 +24,9 @@ class PublishCommand extends Command
     protected array $fluxComponents = [
         'free' => [
             'Accent' => ['accent'],
+            'Avatar' => ['avatar'],
             'Badge' => ['badge'],
+            'Brand' => ['brand'],
             'Breadcrumbs' => ['breadcrumbs'],
             'Button' => ['button'],
             'Checkbox' => ['checkbox'],
@@ -58,7 +60,7 @@ class PublishCommand extends Command
             'Radio' => ['radio'],
             'Select' => ['select'],
             'Tabs' => ['tabs','tab'],
-            'Table' => ['table', 'pagination', 'avatar'],
+            'Table' => ['table', 'pagination'],
             'Toast' => ['toast'],
         ],
     ];


### PR DESCRIPTION
# The scenario

Currently brand and avatar cannot be published.

# The problem

The issue is that brand isn't listed in the publish command and avatar was still under table in the Pro section, but it's now standalone and should be free.

# The solution

Added brand and avatar, each as their own options to publish under the free components. And removed avatar from under table in the pro components.

<img width="583" alt="image" src="https://github.com/user-attachments/assets/c0fd70ec-a3e7-4f4e-9add-35c1c706d618" />

Fixes livewire/flux#1311