### PR TITLE
Fix error component by adding name check

### DIFF
--- a/stubs/resources/views/flux/error.blade.php
+++ b/stubs/resources/views/flux/error.blade.php
@@ -7,7 +7,7 @@
 @php
 $message ??= $name ? $errors->first($name) : null;
 
-if ((is_null($message) || $message === '') && filter_var($nested, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== false) {
+if ($name && (is_null($message) || $message === '') && filter_var($nested, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== false) {
     $message = $errors->first($name . '.*');
 }
 


### PR DESCRIPTION
# The scenario

With the recent changes to error component to support nesting #1308, occasionally there can be an issue if `$errors->first()` is called in a test, as it throws an `Undefined variable $errors` error. This recently caused a breaking change for someone.

<img width="508" alt="image" src="https://github.com/user-attachments/assets/c709ab1a-d0f9-4f5a-a4b9-19c804e2f4ca" />


# The problem

The issue is actually an underlying Laravel issue where for some reason if a view is manually rendered in a test, it has no idea that the `$errors` variable should exist and throws an error. https://laracasts.com/discuss/channels/testing/undefined-variable-errors-when-testing-a-view

By itself, this shouldn't cause issues for us, but with the recent change to the errors component, this error is now being throws in a users app.

The reason why it wasn't being thrown before, is because we only had the below code.

```php
$message ??= $name ? $errors->first($name) : null;
```

You can see here that if no `$name` prop is provided, it will never call the `$errors->first()`.

But we recently just added the below, which is causing `$errors->first()` to always be called, hence is throwing the error.

```php
if ((is_null($message) || $message === '') && filter_var($nested, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== false) {
    $message = $errors->first($name . '.*');
}
```

# The solution

The easy win solution is to just update the conditional to also check for a name. So that's what has been done in this PR.

```php
if ($name && (is_null($message) || $message === '') && filter_var($nested, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== false) {
    $message = $errors->first($name . '.*');
}
```

Fixes livewire/flux#1330