### PR TITLE
Add loading support to inputs

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -13,6 +13,7 @@
     'copyable' => null,
     'viewable' => null,
     'invalid' => null,
+    'loading' => null,
     'type' => 'text',
     'mask' => null,
     'size' => null,
@@ -22,6 +23,28 @@
 ])
 
 @php
+
+// There are a few loading scenarios that this covers:
+// If `:loading="false"` then never show loading.
+// If `:loading="true"` then always show loading.
+// If `:loading="foo"` then show loading when `foo` request is happening.
+// If `wire:model` then never show loading.
+// If `wire:model.live` then show loading when the `wire:model` value request is happening.
+$wireModel = $attributes->wire('model');
+$wireTarget = null;
+
+if ($loading !== false) {
+    if ($loading === true) {
+        $loading = true;
+    } elseif ($wireModel?->directive) {
+        $loading = $wireModel->hasModifier('live');
+        $wireTarget = $loading ? $wireModel->value() : null;
+    } else {
+        $wireTarget = $loading;
+        $loading = true;
+    }
+}
+
 $invalid ??= ($name && $errors->has($name));
 
 $iconLeading ??= $icon;
@@ -94,6 +117,12 @@ $classes = Flux::classes()
                 data-flux-control
                 data-flux-group-target
             >
+
+            <?php if ($loading): ?>
+                <div wire:loading.flex @if($wireTarget) wire:target="{{ $wireTarget }}" @endif class="absolute top-0 bottom-0 flex items-center pe-3 end-0">
+                    <flux:icon name="loading" :variant="$iconVariant" :class="$iconClasses" />
+                </div>
+            <?php endif; ?>
 
             <?php if ($kbd): ?>
                 <div class="pointer-events-none absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400 pe-4 end-0">

--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -41,7 +41,7 @@ if ($loading !== false) {
         $wireTarget = $loading ? $wireModel->value() : null;
     } else {
         $wireTarget = $loading;
-        $loading = true;
+        $loading = (bool) $loading;
     }
 }
 
@@ -50,13 +50,31 @@ $invalid ??= ($name && $errors->has($name));
 $iconLeading ??= $icon;
 
 $hasLeadingIcon = (bool) ($iconLeading);
-$hasTrailingIcon = (bool) ($iconTrailing) || (bool) $kbd || (bool) $clearable || (bool) $copyable || (bool) $viewable || (bool) $expandable;
-$hasBothIcons = $hasLeadingIcon && $hasTrailingIcon;
-$hasNoIcons = (! $hasLeadingIcon) && (! $hasTrailingIcon);
+$countOfTrailingIcons = collect([
+    (bool) $iconTrailing,
+    (bool) $kbd,
+    (bool) $clearable,
+    (bool) $copyable,
+    (bool) $viewable,
+    (bool) $expandable,
+])->filter()->count();
 
 $iconClasses = Flux::classes()
     // When using the outline icon variant, we need to size it down to match the default icon sizes...
     ->add($iconVariant === 'outline' ? 'size-5' : '')
+    ;
+
+$inputLoadingClasses = Flux::classes()
+    // When loading, we need to add some extra padding to the input to account for the loading icon...
+    ->add(match ($countOfTrailingIcons) {
+        0 => 'pe-10',
+        1 => 'pe-16',
+        2 => 'pe-23',
+        3 => 'pe-30',
+        4 => 'pe-37',
+        5 => 'pe-44',
+        6 => 'pe-51',
+    })
     ;
 
 $classes = Flux::classes()
@@ -67,11 +85,19 @@ $classes = Flux::classes()
         'sm' => 'text-sm py-1.5 h-8 leading-[1.125rem]',
         'xs' => 'text-xs py-1.5 h-6 leading-[1.125rem]',
     })
-    ->add(match (true) { // Spacing...
-        $hasNoIcons => 'ps-3 pe-3',
-        $hasBothIcons =>'ps-10 pe-10',
-        $hasLeadingIcon => 'ps-10 pe-3',
-        $hasTrailingIcon => 'ps-3 pe-10',
+    ->add(match ($hasLeadingIcon) {
+        true => 'ps-10',
+        false => 'ps-3',
+    })
+    ->add(match ($countOfTrailingIcons) {
+        // Make sure there's enough padding on the right side of the input to account for all the icons...
+        0 => 'pe-3',
+        1 => 'pe-10',
+        2 => 'pe-16',
+        3 => 'pe-23',
+        4 => 'pe-30',
+        5 => 'pe-37',
+        6 => 'pe-44',
     })
     ->add(match ($variant) { // Background...
         'outline' => 'bg-white dark:bg-white/10 dark:disabled:bg-white/[7%]',
@@ -116,53 +142,46 @@ $classes = Flux::classes()
                 @if (is_numeric($size)) size="{{ $size }}" @endif
                 data-flux-control
                 data-flux-group-target
+                @if ($loading) wire:loading.class="{{ $inputLoadingClasses }}" @endif
+                @if ($loading && $wireTarget) wire:target="{{ $wireTarget }}" @endif
             >
 
-            <?php if ($loading): ?>
-                <div wire:loading.flex @if($wireTarget) wire:target="{{ $wireTarget }}" @endif class="absolute top-0 bottom-0 flex items-center pe-3 end-0">
-                    <flux:icon name="loading" :variant="$iconVariant" :class="$iconClasses" />
-                </div>
-            <?php endif; ?>
+            <div class="absolute top-0 bottom-0 flex items-center gap-x-1.5 pe-3 end-0 text-xs text-zinc-400">
+                {{-- Icon should be text-zinc-400/75 --}}
+                <?php if ($loading): ?>
+                    <flux:icon name="loading" :variant="$iconVariant" :class="$iconClasses" wire:loading :wire:target="$wireTarget" />
+                <?php endif; ?>
 
-            <?php if ($kbd): ?>
-                <div class="pointer-events-none absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400 pe-4 end-0">
-                    {{ $kbd }}
-                </div>
-            <?php endif; ?>
+                <?php if ($clearable): ?>
+                    <flux:input.clearable inset="left right" :$size />
+                <?php endif; ?>
 
-            <?php if (is_string($iconTrailing)): ?>
-                <div class="pointer-events-none absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 pe-3 end-0">
-                    <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$iconClasses" />
-                </div>
-            <?php elseif ($iconTrailing): ?>
-                <div {{ $iconTrailing->attributes->class('absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 pe-2 end-0') }}>
+                <?php if ($kbd): ?>
+                    <span class="pointer-events-none">{{ $kbd }}</span>
+                <?php endif; ?>
+
+                <?php if ($expandable): ?>
+                    <flux:input.expandable inset="left right" :$size />
+                <?php endif; ?>
+
+                <?php if ($copyable): ?>
+                    <flux:input.copyable inset="left right" :$size />
+                <?php endif; ?>
+
+                <?php if ($viewable): ?>
+                    <flux:input.viewable inset="left right" :$size />
+                <?php endif; ?>
+
+                <?php if (is_string($iconTrailing)): ?>
+                    <?php
+                        $trailingIconClasses = clone $iconClasses;
+                        $trailingIconClasses->add('pointer-events-none');
+                    ?>
+                    <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$trailingIconClasses" />
+                <?php elseif ($iconTrailing): ?>
                     {{ $iconTrailing }}
-                </div>
-            <?php endif; ?>
-
-            <?php if ($expandable): ?>
-                <div class="absolute top-0 bottom-0 flex items-center justify-center pe-2 end-0">
-                    <flux:input.expandable :$size />
-                </div>
-            <?php endif; ?>
-
-            <?php if ($clearable): ?>
-                <div class="absolute top-0 bottom-0 flex items-center justify-center pe-2 end-0">
-                    <flux:input.clearable :$size />
-                </div>
-            <?php endif; ?>
-
-            <?php if ($copyable): ?>
-                <div class="absolute top-0 bottom-0 flex items-center justify-center pe-2 end-0">
-                    <flux:input.copyable :$size />
-                </div>
-            <?php endif; ?>
-
-            <?php if ($viewable): ?>
-                <div class="absolute top-0 bottom-0 flex items-center justify-center pe-2 end-0">
-                    <flux:input.viewable :$size />
-                </div>
-            <?php endif; ?>
+                <?php endif; ?>
+            </div>
         </div>
     </flux:with-field>
 <?php else: ?>

--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -175,7 +175,7 @@ $classes = Flux::classes()
                 <?php if (is_string($iconTrailing)): ?>
                     <?php
                         $trailingIconClasses = clone $iconClasses;
-                        $trailingIconClasses->add('pointer-events-none');
+                        $trailingIconClasses->add('pointer-events-none text-zinc-400/75');
                     ?>
                     <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$trailingIconClasses" />
                 <?php elseif ($iconTrailing): ?>


### PR DESCRIPTION
# The scenario

Currently if an input is used for search or something like that, there is no easy way to get the trailing icon to display a spinner when a Livewire request is happening.

```blade
<flux:input wire:model.live="search" icon-trailing="loading" placeholder="Search transactions" />
```

Instead you have to use slots.

```blade
<flux:input wire:model.live="search" placeholder="Search transactions">
    <x-slot:trailing-icon>
        <flux:icon.loading wire:loading wire:target="search" />
    </x-slot>
</flux:input>
```

# The proposal

This PR adds support for the following API mapped out by @calebporzio here https://github.com/livewire/flux/issues/1286#issuecomment-2719092938.

```blade
<flux:input wire:model="search" />{{-- no loading indicator ever --}}
<flux:input wire:model.live="search" />{{-- loading indicator when request is out --}}
<flux:input wire:model.live="search" :loading="false" />{{-- no loading indicator ever --}}
<flux:input loading />{{-- always show loading indicator --}}
<flux:input loading="foo" />{{-- show loading indicator when a request is out for the foo property (wire:loading + wire:target type deal) --}}
```

# Trailing icon/ control issue

**UPDATE:**

I've added support for multiple trailing icons, so now the loading icon just appears to the left of all the other icons. I am calculating the required amount of padding based on how many of the trailing icons/controls are present. I'm also using `wire:loading.class` to increase the padding while loading is happening.

**Without loading**
<img width="970" alt="image" src="https://github.com/user-attachments/assets/ae745ed6-3e93-4a41-9b2e-c856d614b5cc" />

**With loading**
<img width="979" alt="image" src="https://github.com/user-attachments/assets/d7a3adfd-d170-40a2-9306-7887481158d3" />

The below is no longer relevant.

---

The only issue with the implementation is what should happen if there are currently any trailing icons or extra controls like copyable, clearable, etc.?

<img width="755" alt="image" src="https://github.com/user-attachments/assets/b32ca198-a7b0-4bf0-9b4b-90ce766ffddc" />

<img width="755" alt="image" src="https://github.com/user-attachments/assets/7e9e483d-0dda-44d8-886d-472a02782aa3" />

Volt component for testing
```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    public $search;
    public $foo;

    public function updated()
    {
        sleep(2);
    }

    public function submit()
    {
        sleep(2);
    }
}; ?>

<div>
    <form wire:submit="submit">
        <flux:input as="button">Should there be a loading indicator for this button?</flux:input>
        <flux:input label="No loading indicator ever" wire:model="search" />
        <flux:input label="Loading indicator when request is out" wire:model.live="search" />
        <flux:input label="No loading indicator ever" wire:model.live="search" :loading="false" />
        <flux:input label="Always show loading indicator" loading />
        <flux:input label="Show loading indicator when a request is out for the foo property (wire:loading + wire:target type deal)" loading="foo" />
        <flux:input wire:model="foo" />


        <flux:input label="Keyboard Shortcut" loading kbd="⌘K" />
        <flux:input label="Icon Trailing" loading icon-trailing="credit-card" />
        <flux:input label="Expandable" loading expandable />
        <flux:input label="Clearable" loading clearable />
        <flux:input label="Copyable" loading copyable />
        <flux:input label="Viewable" loading viewable />

        <flux:button type="submit">Submit</flux:button>

        <flux:icon name="loading" wire:loading wire:target="search" class="mt-4" />
    </form>
</div>

```

Fixes livewire/flux#1286