### PR TITLE
Updates FluxManager to be compatible with Laravel 10

### DIFF
--- a/src/FluxManager.php
+++ b/src/FluxManager.php
@@ -124,7 +124,7 @@ class FluxManager
     {
         $newAttributes = new \Illuminate\View\ComponentAttributeBag($default);
 
-        foreach ($attributes->all() as $key => $value) {
+        foreach ($attributes->getAttributes() as $key => $value) {
             if (str_starts_with($key, $prefix)) {
                 $newAttributes[substr($key, strlen($prefix))] = $value;
             }


### PR DESCRIPTION
Updated FluxManager line 127 to use `->getAttributes()` on the `ComponentAttributeBag` rather than `->all()` to be compatible with Laravel 10.


Fixes livewire/flux#1385
Similar to livewire/flux#621