### PR TITLE
Fix avatar initials edge cases

### DIFF
--- a/stubs/resources/views/flux/avatar/index.blade.php
+++ b/stubs/resources/views/flux/avatar/index.blade.php
@@ -18,7 +18,7 @@
 
 @php
 if ($name && ! $initials) {
-    $parts = explode(' ', preg_replace('/[^a-zA-Z\s]/', '', $name));
+    $parts = explode(' ', preg_replace('/[^a-zA-Z0-9\s]/', '', trim($name)));
 
     if ($attributes->pluck('initials:single')) {
         $initials = strtoupper($parts[0][0]);


### PR DESCRIPTION
# The scenario

Currently if you try to use the avatar component with a name that starts with a number or is incorrectly formatted (like it has leading spaces or something), then the avatar component throws the below error.

<img width="1446" alt="image" src="https://github.com/user-attachments/assets/f73716be-c74c-4e6f-a344-253a5383df31" />

```blade
<div> 
    <flux:avatar name="3M"/>
    <flux:avatar name=" bob smith"/>
</div>
```

# The problem

The issue is that the regex doesn't account for names that can start with digits,  like a company name such as 3M, and it also doesn't factor in leading white space, if data is incorrectly formatted.

```php
$parts = explode(' ', preg_replace('/[^a-zA-Z\s]/', '', $name));
```

# The solution

To fix this, I've updated the regex to allow digits and also added a `trim()` to the `$name`.

```php
$parts = explode(' ', preg_replace('/[^a-zA-Z0-9\s]/', '', trim($name)));
```

<img width="55" alt="image" src="https://github.com/user-attachments/assets/827f5e39-51ad-4c63-8dfc-5aff9f7be779" />

Fixes livewire/flux#1387