### PR TITLE
Fix callout action button icon colours

### DIFF
--- a/stubs/resources/views/flux/callout/heading.blade.php
+++ b/stubs/resources/views/flux/callout/heading.blade.php
@@ -11,7 +11,7 @@
         ;
 
     $iconClasses = Flux::classes()
-        ->add('inline-block size-5 text-zinc-500 dark:text-zinc-400')
+        ->add('inline-block size-5 text-[var(--callout-icon)] dark:text-[var(--callout-icon)]')
         ->add($attributes->pluck('class:icon'))
         ;
 @endphp

--- a/stubs/resources/views/flux/callout/index.blade.php
+++ b/stubs/resources/views/flux/callout/index.blade.php
@@ -30,7 +30,6 @@
             'border-(--callout-border) bg-(--callout-background)',
             '[&_[data-slot=heading]]:text-(--callout-heading)',
             '[&_[data-slot=text]]:text-(--callout-text)',
-            '[&_[data-slot=icon]]:text-(--callout-icon)',
         ])
         ->add(match($color) {
             'blue' => [
@@ -174,7 +173,7 @@
         ;
 
     $iconClasses = Flux::classes()
-        ->add('inline-block size-5 text-zinc-400 dark:text-zinc-400')
+        ->add('inline-block size-5 text-[var(--callout-icon)] dark:text-[var(--callout-icon)]')
         ->add($attributes->pluck('class:icon'))
         ;
 @endphp


### PR DESCRIPTION
# The scenario

Currently if you have a coloured callout that has an action button with an icon, the action button icon colour is being changed to the colour of the other icons in the callout.

<img width="708" alt="image" src="https://github.com/user-attachments/assets/5bcf7c58-29b9-4249-a9f6-737e5652b037" />

```blade
<div> 
    <flux:callout icon="information-circle" color="amber" inline>
        <flux:callout.text>There is an issue with your provider account. </flux:callout.text>

        <x-slot name="actions">
            <flux:button icon="wrench">Repair</flux:button>
        </x-slot>
    </flux:callout>

    <flux:callout color="amber">
        <flux:callout.heading icon="newspaper">Policy update</flux:callout.heading>

        <flux:callout.text>We've updated our Terms of Service and Privacy Policy. Please review them to stay informed.</flux:callout.text>

        <x-slot name="actions">
            <flux:button icon="wrench">Repair</flux:button>
        </x-slot>
    </flux:callout>
</div>
```

# The problem

The issue is that there is a CSS selector that is targeting all icons inside a callout and setting the colour of the icon to the colour of the callout.

```css
[&_[data-slot=icon]]:text-(--callout-icon)
```

This means that even icons within a button are being targeted.



# The solution

One solution would be to ensure that the button sets the colour of the icons within it, like the callout is doing. But I felt like that could potentially be a rabbit hole.

Instead I opted to remove that CSS selector an instead change the icon colours of the callout icon and the callout heading icon to make use of the `callout-icon` colour.

```php
->add('inline-block size-5 text-[var(--callout-icon)] dark:text-[var(--callout-icon)]')
```

<img width="708" alt="image" src="https://github.com/user-attachments/assets/49c6fb18-f8b1-4325-9592-66001456e6e0" />

Fixes livewire/flux#1390