### PR TITLE
Fix flyout modal and toasts display bug

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -128,6 +128,14 @@ ui-toast {
                 transform: translateX(0.5rem);
             }
 
+            [dir="rtl"] &[data-position*="top"][data-position*="left"] {
+                transform: translateX(0.5rem);
+            }
+
+            [dir="rtl"] &[data-position*="top"][data-position*="right"] {
+                transform: translateX(-0.5rem);
+            }
+
             &[data-position*="bottom"] {
                 transform: translateY(0.5rem);
             }

--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -15,10 +15,9 @@ $classes = Flux::classes()
         default => 'p-6 [:where(&)]:max-w-xl shadow-lg rounded-xl',
         'flyout' => match($position) {
             'bottom' => 'fixed m-0 p-8 min-w-[100vw] overflow-y-auto mt-auto [--fx-flyout-translate:translateY(50px)] border-t',
-            'left' => 'fixed m-0 p-8 max-h-dvh min-h-dvh md:[:where(&)]:min-w-[25rem] overflow-y-auto me-auto [--fx-flyout-translate:translateX(-50px)] border-e',
-            default => 'fixed m-0 p-8 max-h-dvh min-h-dvh md:[:where(&)]:min-w-[25rem] overflow-y-auto ms-auto [--fx-flyout-translate:translateX(50px)] border-s',
+            'left' => 'fixed m-0 p-8 max-h-dvh min-h-dvh md:[:where(&)]:min-w-[25rem] overflow-y-auto mr-auto [--fx-flyout-translate:translateX(-50px)] border-e rtl:mr-0 rtl:ml-auto rtl:[--fx-flyout-translate:translateX(50px)]',
+            default => 'fixed m-0 p-8 max-h-dvh min-h-dvh md:[:where(&)]:min-w-[25rem] overflow-y-auto ml-auto [--fx-flyout-translate:translateX(50px)] border-s rtl:ml-0 rtl:mr-auto rtl:[--fx-flyout-translate:translateX(-50px)]',
         },
-        'flyout' => 'fixed m-0 p-8 max-h-dvh min-h-dvh md:[:where(&)]:min-w-[25rem] overflow-y-auto ms-auto',
         'bare' => '',
     })
     ->add(match ($variant) {


### PR DESCRIPTION
This has a corresponding Flux Pro PR livewire/flux-pro#234

# The scenario

Currently if you open a flyout modal on Safari, the flyout initially appears on the left, and then jumps to the right instead of animating in. The same issue is also happening with toasts.

![Recording 2025-03-26 at 18 22 02](https://github.com/user-attachments/assets/e5ae5294-afbe-4981-abc4-ff644df2d192)

```blade
<div> 
    <flux:modal.trigger name="edit-profile">
        <flux:button>Edit profile</flux:button>
    </flux:modal.trigger>

    <flux:modal name="edit-profile" variant="flyout">
        <div class="space-y-6">
            <div>
                <flux:heading size="lg">Update profile</flux:heading>
                <flux:text class="mt-2">Make changes to your personal details.</flux:text>
            </div>

            <flux:input label="Name" placeholder="Your name" />

            <flux:input label="Date of birth" type="date" />

            <div class="flex">
                <flux:spacer />

                <flux:button type="submit" variant="primary">Save changes</flux:button>
            </div>
        </div>
    </flux:modal>
</div>
```

# The problem

The issue is that to support RTL, we changed `ml-auto` to `ms-auto` and the issues have started appearing since then.

I'm not 100% on what is causing it, but I suspect it's because `ml-auto` becomes `margin-left: auto;` where as `ms-auto` becomes `margin-inline-start: auto;`, as such I suspect it's something to do with the inline part of it.

# The solution

The solution is to change back to using `ml-auto` and use `mr-auto` if RTL is detected. I also found that the fly in animation for flyouts and toasts were wrong on RTL, so fixed that too. Finally there was a duplicate `flyout` in the match so I have removed that.

```
ml-auto [--fx-flyout-translate:translateX(50px)] rtl:ml-0 rtl:mr-auto rtl:[--fx-flyout-translate:translateX(-50px)]
```

![Recording 2025-03-26 at 18 32 15](https://github.com/user-attachments/assets/fb403ee5-461f-4545-920f-e7f396d8f1ab)

Fixes livewire/flux#1375