### PR TITLE
fix sidebar for RTL

### DIFF
--- a/stubs/resources/views/flux/sidebar/index.blade.php
+++ b/stubs/resources/views/flux/sidebar/index.blade.php
@@ -22,7 +22,7 @@ if ($stashable) {
         'x-init' => '$el.classList.add(\'-translate-x-full\', \'rtl:translate-x-full\'); $el.removeAttribute(\'data-mobile-cloak\'); $el.classList.add(\'transition-transform\')',
     ])->class([
         'max-lg:data-mobile-cloak:hidden',
-        '[[data-show-stashed-sidebar]_&]:translate-x-0! lg:translate-x-0!',
+        '[[data-show-stashed-sidebar]_&]:translate-x-0! lg:ltr:translate-x-0! lg:rtl:translate-x-0!',
         'z-20! data-stashed:start-0! data-stashed:fixed! data-stashed:top-0! data-stashed:min-h-dvh! data-stashed:max-h-dvh!'
     ]);
 }


### PR DESCRIPTION
# The scenario

Not sure why, but it seems that translations get ignored if rtl or ltr not specified for translation.

# The problem

in RTL, the sidemenu is opened to the right when the page loaded (disappear).

# The solution

I added both `ltr:` and `rtl:` to `translate-x-0!`

Fixes livewire/flux#