### PR TITLE
Enable scoped attributes for field components

### DIFF
--- a/stubs/resources/views/flux/with-field.blade.php
+++ b/stubs/resources/views/flux/with-field.blade.php
@@ -36,7 +36,6 @@ extract(Flux::forwardedAttributes($attributes, [
             <flux:description :attributes="Flux::attributesAfter('description:', $attributes, [])">{{ $descriptionTrailing }}</flux:description>
         <?php endif; ?>
     </flux:field>
-    <div {{ $attributes }}></div>
 <?php else: ?>
     {{ $slot }}
 <?php endif; ?>

--- a/stubs/resources/views/flux/with-field.blade.php
+++ b/stubs/resources/views/flux/with-field.blade.php
@@ -19,23 +19,24 @@ extract(Flux::forwardedAttributes($attributes, [
 ])
 
 <?php if ($label || $description): ?>
-    <flux:field>
+    <flux:field :attributes="Flux::attributesAfter('field:', $attributes, [])">
         <?php if ($label): ?>
-            <flux:label :$badge>{{ $label }}</flux:label>
+            <flux:label :attributes="Flux::attributesAfter('label:', $attributes, ['badge' => $badge])">{{ $label }}</flux:label>
         <?php endif; ?>
 
         <?php if ($description): ?>
-            <flux:description>{{ $description }}</flux:description>
+            <flux:description :attributes="Flux::attributesAfter('description:', $attributes, [])">{{ $description }}</flux:description>
         <?php endif; ?>
 
         {{ $slot }}
 
-        <flux:error :$name />
+        <flux:error :attributes="Flux::attributesAfter('error:', $attributes, ['name' => $name])" />
 
         <?php if ($descriptionTrailing): ?>
-            <flux:description>{{ $descriptionTrailing }}</flux:description>
+            <flux:description :attributes="Flux::attributesAfter('description:', $attributes, [])">{{ $descriptionTrailing }}</flux:description>
         <?php endif; ?>
     </flux:field>
+    <div {{ $attributes }}></div>
 <?php else: ?>
     {{ $slot }}
 <?php endif; ?>


### PR DESCRIPTION
# The scenario

Currently if you have a input that has a label using the short hand syntax, if you try to add margin top to that component `class="mt-6"`, it actually puts the margin between the label and the input instead of above the input which is what is intended.

```blade
<div>
    <flux:heading size="xl">Profile</flux:heading>

    <flux:input class="mt-6" label="Name" />
</div>
```

<img width="612" alt="image" src="https://github.com/user-attachments/assets/6085b1ea-c1bc-45d4-a7ff-f4944fbcd3d3" />

# The problem

The issue is that any classes that are passed into the input component are being applied to the input components itself and not the wrapping field/label component.

The input component at the moment is structured like this (simplified for demonstration purposes)

```blade
<flux:with-field :$attributes :$name>
    <div {{ $attributes->only('class') }}>
    <input
            type="{{ $type }}"
            {{ $attributes->except('class')->class($classes) }}
        >
</flux:with-field>
```

# The solution

The solution proposed in this PR is to add support to the `with-field` component for the new component attribute prefixes, for example `field:class` or `label:class`.

The changes in this PR allow the following field components to be targeted:
- field - `field:class`
- label - `label:class`
- description - `description:class`
- error - `error:class`

This means that for the example at the top, we can change `class="mt-6` to `field:class="mt-6"` to ensure the margin top gets applied to the wrapping `field` component.

```blade
<div>
    <flux:heading size="xl">Profile</flux:heading>

    <flux:input field:class="mt-6" label="Name" />
</div>
```

<img width="612" alt="image" src="https://github.com/user-attachments/assets/8113ceb3-8edd-4f34-8a19-ea365fe569e1" />

Fixes livewire/flux#1416