### PR TITLE
Fix input leading icons appearing above headers

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -123,11 +123,11 @@ $classes = Flux::classes()
     <flux:with-field :$attributes :$name>
         <div {{ $attributes->only('class')->class('w-full relative block group/input') }} data-flux-input>
             <?php if (is_string($iconLeading)): ?>
-                <div class="z-10 pointer-events-none absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 ps-3 start-0">
+                <div class="pointer-events-none absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 ps-3 start-0">
                     <flux:icon :icon="$iconLeading" :variant="$iconVariant" :class="$iconClasses" />
                 </div>
             <?php elseif ($iconLeading): ?>
-                <div {{ $iconLeading->attributes->class('z-10 absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 ps-3 start-0') }}>
+                <div {{ $iconLeading->attributes->class('absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 ps-3 start-0') }}>
                     {{ $iconLeading }}
                 </div>
             <?php endif; ?>
@@ -187,11 +187,11 @@ $classes = Flux::classes()
 <?php else: ?>
     <button {{ $attributes->merge(['type' => 'button'])->class([$classes, 'w-full relative flex']) }}>
         <?php if (is_string($iconLeading)): ?>
-            <div class="z-10 absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 ps-3 start-0">
+            <div class="absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 ps-3 start-0">
                 <flux:icon :icon="$iconLeading" :variant="$iconVariant" :class="$iconClasses" />
             </div>
         <?php elseif ($iconLeading): ?>
-            <div {{ $iconLeading->attributes->class('z-10 absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 ps-3 start-0') }}>
+            <div {{ $iconLeading->attributes->class('absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 ps-3 start-0') }}>
                 {{ $iconLeading }}
             </div>
         <?php endif; ?>


### PR DESCRIPTION
# The scenario

Currently if you have an input with a leading icon and the page is scrolled, the leading icon is appearing above the header element. But this doesn't happen for trailing icons.

<img width="419" alt="image" src="https://github.com/user-attachments/assets/a2b59e91-d394-472e-9582-0aaa2b81a06a" />

```blade
<flux:input icon="key" value="FLUX-1234-5678-ABCD-EFGH" readonly copyable />
```

# The problem

The issue is that input leading icons have a `z-10` on them, causing them to appear above the `<flux:header>` component.

# The solution

I'm not exactly sure why the z-index was on there, but this PR removes it. In my testing I couldn't find why that might have been required.

<img width="415" alt="image" src="https://github.com/user-attachments/assets/53144d45-e8d7-452d-9bdf-5fbbbb73bbae" />