### PR TITLE
Fix modal autofocus issue

### DIFF
--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -1,6 +1,5 @@
 @props([
     'dismissible' => null,
-    'autofocus' => null,
     'position' => null,
     'closable' => null,
     'trigger' => null,
@@ -54,7 +53,7 @@ if ($dismissible === false) {
     $attributes = $attributes->merge(['disable-click-outside' => '']);
 }
 
-[ $styleAttributes, $attributes ] = Flux::splitAttributes($attributes, ['class', 'style', 'wire:close', 'x-on:close', 'wire:cancel', 'x-on:cancel']);
+[ $styleAttributes, $attributes ] = Flux::splitAttributes($attributes, ['autofocus', 'class', 'style', 'wire:close', 'x-on:close', 'wire:cancel', 'x-on:cancel']);
 @endphp
 
 <ui-modal {{ $attributes }} data-flux-modal>
@@ -63,7 +62,6 @@ if ($dismissible === false) {
     <?php endif; ?>
 
     <dialog
-        @if (isset($autofocus)){!! $autofocus === 'false' || $autofocus === false ? 'autofocus="false"' : 'autofocus' !!}@endif
         wire:ignore.self {{-- This needs to be here because the dialog element adds a "close" attribute that isn't durable... --}}
         {{ $styleAttributes->class($classes) }}
         @if ($name) data-modal="{{ $name }}" @endif

--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -1,5 +1,6 @@
 @props([
     'dismissible' => null,
+    'autofocus' => null,
     'position' => null,
     'closable' => null,
     'trigger' => null,
@@ -62,6 +63,7 @@ if ($dismissible === false) {
     <?php endif; ?>
 
     <dialog
+        @if (isset($autofocus)){!! $autofocus === 'false' || $autofocus === false ? 'autofocus="false"' : 'autofocus' !!}@endif
         wire:ignore.self {{-- This needs to be here because the dialog element adds a "close" attribute that isn't durable... --}}
         {{ $styleAttributes->class($classes) }}
         @if ($name) data-modal="{{ $name }}" @endif


### PR DESCRIPTION
This PR has a supplementary Flux Pro PR livewire/flux-pro#242.

The main fix is in the Flux Pro PR, so I recommend checking that out first.

# The scenario

Currently, if you have a modal which has an input, that input is being focused when the modal is opened.

This is causing issues for screen readers as the screen reader is also being focused at the input and any heading/ text gets skipped.

![image](https://github.com/user-attachments/assets/f2bfe19f-a3ec-47b9-bf65-82a1ec442fbd)

This also causes issues for mobile users as by focusing the input, the keyboard is shown which takes up half of the screen hiding some of the contents of the modal.

<img width="332" alt="image" src="https://github.com/user-attachments/assets/6a7d7a60-22f3-4ccf-94e8-6dd400d52d89" />

<img width="332" alt="image" src="https://github.com/user-attachments/assets/c54b9280-0cfc-4101-808c-f7e602fff1f5" />

```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    public $show = false;
}; ?>

<div>
    <flux:modal.trigger name="edit-profile">
        <flux:button>Edit profile</flux:button>
    </flux:modal.trigger>

    <flux:modal wire:model="show" name="edit-profile" class="md:w-96" autofocus="false">
        <div class="space-y-6">
            <div>
                <flux:heading size="lg">Update profile</flux:heading>
                <flux:text class="mt-2">Make changes to your personal details.</flux:text>
            </div>

            <flux:input label="Name" placeholder="Your name" />
            <flux:input label="Name2" placeholder="Your name2" />

            <flux:input label="Date of birth" type="date" />

            <div class="flex">
                <flux:spacer />

                <flux:button type="submit" variant="primary">Save changes</flux:button>
            </div>
        </div>
    </flux:modal>
</div>
```

# The problem

The issue is that the native `<dialog>` element will autofocus the first element inside of it when it is opened.

A user can choose to put the `autofocus` attribute on a different input and the browsers will honour that and focus the input that has the attribute.

But at this stage there is no way built into browsers to disable this feature.

# The solution

The solution proposed in this PR is to add support for `autofocus="false"` on the modal component.

To achieve this is a bit of a hack. What we are doing is if `autofocus="false"` is set on the `<flux:modal>` component, then we set `tabindex="-1"` on the dialog element, focus it and then unfocus/ blur it. This ensures that none of the inputs/ buttons are focused when it's opened but also ensures that the tab index is in the correct place, so that if a user hits `tab` then the first focusable element will then be focused.

One catch is that for Safari, focusing the dialog before blurring it, causes page layout shifts as it happens before the transitions have finished. Thankfully, if there is an `autofocus` attribute on a dialog element (regardless of if it has a value of `false` or not), Safari actually focuses the dialog element. So we can skip calling `focus()` on it manually and only call `blur()` on it.

Now the user experience is much nicer for screenreaders and mobile devices.

For a screenreader now, the window is focused.
![image](https://github.com/user-attachments/assets/b3a082c2-e8bb-4fa8-b30a-c992a61fa748)

And if they press ctrl+opt+shift+downarrow it will move focus to the first element inside the modal.

![image](https://github.com/user-attachments/assets/e01f6516-1a8b-4a50-8a63-5416566f3b62)

For mobile, the keyboard is no longer shown.

<img width="332" alt="image" src="https://github.com/user-attachments/assets/c18a6b85-a279-40f2-a5b5-ae61f6bf51bf" />
<img width="332" alt="image" src="https://github.com/user-attachments/assets/53f61b52-c9d0-4efd-8b97-e91f1a4aeac2" />

Fixes livewire/flux#854