### PR TITLE
Fix avatar component

### DIFF
--- a/stubs/resources/views/flux/avatar/index.blade.php
+++ b/stubs/resources/views/flux/avatar/index.blade.php
@@ -21,14 +21,15 @@ if ($name && ! $initials) {
     $parts = explode(' ', preg_replace('/[^a-zA-Z0-9\s]/', '', trim($name)));
 
     if ($attributes->pluck('initials:single')) {
-        $initials = strtoupper($parts[0][0]);
+        $initials = strtoupper(substr($parts[0], 0, 1));
     } else {
         // Remove empty strings from the array...
         $parts = collect($parts)->filter()->values()->all();
+
         if (count($parts) > 1) {
-            $initials = strtoupper($parts[0][0] . $parts[1][0]);
+            $initials = strtoupper(substr($parts[0], 0, 1) . substr($parts[1], 0, 1));
         } else if (count($parts) === 1) {
-            $initials = strtoupper($parts[0][0]) . strtolower($parts[0][1]);
+            $initials = strtoupper(substr($parts[0], 0, 1)) . strtolower(substr($parts[0], 1, 1));
         }
     }
 }

--- a/stubs/resources/views/flux/avatar/index.blade.php
+++ b/stubs/resources/views/flux/avatar/index.blade.php
@@ -18,18 +18,18 @@
 
 @php
 if ($name && ! $initials) {
-    $parts = explode(' ', preg_replace('/[^a-zA-Z0-9\s]/', '', trim($name)));
+    $parts = explode(' ', trim($name));
 
     if ($attributes->pluck('initials:single')) {
-        $initials = strtoupper(substr($parts[0], 0, 1));
+        $initials = strtoupper(mb_substr($parts[0], 0, 1));
     } else {
         // Remove empty strings from the array...
         $parts = collect($parts)->filter()->values()->all();
 
         if (count($parts) > 1) {
-            $initials = strtoupper(substr($parts[0], 0, 1) . substr($parts[1], 0, 1));
+            $initials = strtoupper(mb_substr($parts[0], 0, 1) . mb_substr($parts[1], 0, 1));
         } else if (count($parts) === 1) {
-            $initials = strtoupper(substr($parts[0], 0, 1)) . strtolower(substr($parts[0], 1, 1));
+            $initials = strtoupper(mb_substr($parts[0], 0, 1)) . strtolower(mb_substr($parts[0], 1, 1));
         }
     }
 }

--- a/stubs/resources/views/flux/avatar/index.blade.php
+++ b/stubs/resources/views/flux/avatar/index.blade.php
@@ -27,7 +27,7 @@ if ($name && ! $initials) {
         $parts = collect($parts)->filter()->values()->all();
         if (count($parts) > 1) {
             $initials = strtoupper($parts[0][0] . $parts[1][0]);
-        } else {
+        } else if (count($parts) === 1) {
             $initials = strtoupper($parts[0][0]) . strtolower($parts[0][1]);
         }
     }

--- a/stubs/resources/views/flux/avatar/index.blade.php
+++ b/stubs/resources/views/flux/avatar/index.blade.php
@@ -40,6 +40,12 @@ if ($name && $tooltip === true) {
 
 $hasTextContent = $icon ?? $initials ?? $slot->isNotEmpty();
 
+// If there's no text content, we'll fallback to using the user icon otherwise there will be an empty white square...
+if (! $hasTextContent) {
+    $icon = 'user';
+    $hasTextContent = true;
+}
+
 // Be careful not to change the order of these colors.
 // They're used in the hash function below and changing them would change actual user avatar colors that they might have grown to identify with.
 $colors = ['red', 'orange', 'amber', 'yellow', 'lime', 'green', 'emerald', 'teal', 'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose'];


### PR DESCRIPTION
# The scenario

Currently if the avatar component is passed a name that isn't in a specific format, it can cause a few different errors to be thrown depending on the contents:

<img width="1455" alt="image" src="https://github.com/user-attachments/assets/4131aeda-5f80-4b57-a3b2-847dfbb2e460" />

<img width="1463" alt="image" src="https://github.com/user-attachments/assets/5568431f-61e4-455e-95c0-e4828ea19d66" />

Things like a name with unicode characters, a name with only a single letter, and name with a last name that is a single letter, etc.

```blade
<div>
    <flux:avatar name="" initials:single/>
    <flux:avatar name="Caleb Porzio" initials:single/>
    <flux:avatar name="Админ" initials:single/>
    <flux:avatar name="" />
    <flux:avatar name="Caleb" />
    <flux:avatar name="Админ" />
    <flux:avatar name="C" />
    <flux:avatar name="Caleb P" />
    <flux:avatar name="Caleb Porzio" />
    <flux:avatar initials="CP" />
    <flux:avatar icon="key" />
</div>
```

# The problem

The issue is that there are a bunch of arrays being accessed without any checks to ensure the array keys exist. Also currently we are filtering out any names with unicode characters.

# The solution

The PR improves the avatar component by changing a few different things. Each thing is built upon the previous one and has been committed individually, so they can be reverted easily if not wanted.

The first thing fixed is fixing the `Undefined array key 0` error. To do this, I added a check to make sure that parts has one item before accessing it

```php
if (count($parts) > 1) {
    $initials = strtoupper($parts[0][0] . $parts[1][0]);
} else if (count($parts) === 1) {
    $initials = strtoupper($parts[0][0]) . strtolower($parts[0][1]);
}
```

The second thing fixed is the `Uninitialised string offset 1`. If a first name or last name only has one character, this error was being thrown. The fix is to use substr instead of array access, as it will return an empty string if the indexes are not found.

```php
$initials = strtoupper(substr($parts[0], 0, 1)) . strtolower(substr($parts[0], 1, 1));
```

The third thing fixed is support for unicode characters. To do this, I removed the `preg_replace` and changed all the `substr()` to `mb_substr()` to ensure multibyte unicode characters are supported.

Finally, if there is a scenario where no initials are generated, ie the name is empty, then currently the avatar is being displayed as an empty white box. Which is inconsistent with how all other possibilities are generated.

<img width="65" alt="image" src="https://github.com/user-attachments/assets/a4635248-5ce6-410d-aa39-acaee7638cc0" />

So I've updated the component to fall back to using the `user` icon if no name/icon/slot has been provided.

<img width="59" alt="image" src="https://github.com/user-attachments/assets/ace12e09-9802-4003-b0cc-ced7af21dd2e" />

Now all the name variations in the top code block all render happily.

<img width="789" alt="image" src="https://github.com/user-attachments/assets/10882207-c072-47e6-aa76-1e0213b2009a" />

Fixes livewire/flux#1441