### PR TITLE
Fix avatar in a flexbox

### DIFF
--- a/stubs/resources/views/flux/avatar/index.blade.php
+++ b/stubs/resources/views/flux/avatar/index.blade.php
@@ -71,7 +71,7 @@ $classes = Flux::classes()
         'sm' => '[--avatar-radius:var(--radius-md)]',
         'xs' => '[--avatar-radius:var(--radius-sm)]',
     })
-    ->add('relative isolate flex items-center justify-center')
+    ->add('relative flex-none isolate flex items-center justify-center')
     ->add('[:where(&)]:font-medium')
     ->add('rounded-[var(--avatar-radius)]')
     ->add($hasTextContent ? '[:where(&)]:bg-zinc-200 [:where(&)]:dark:bg-zinc-600 [:where(&)]:text-zinc-800 [:where(&)]:dark:text-white' : '')


### PR DESCRIPTION
# The scenario

Currently if you use avatar inside a flexbox and one of the other elements tries to take up extra space, the avatar background circle gets all squished up.

<img width="795" alt="image" src="https://github.com/user-attachments/assets/c97e0df8-ae13-4c52-afff-50f3a4e7d1bc" />

```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    //
};
?>

<div class="flex w-full items-center gap-4">
    <flux:avatar circle src="https://unavatar.io/x/calebporzio" />

    <div class="w-full">
        <p class="font-bold">Caleb Porzio</p>
        <p>commented</p>
    </div>
</div>
```

# The problem

The issue is that the avatar element is being squished by the flexbox, but the img is still being shown as a perfect circle, which is causing the background circle to be pushed out of shape.

# The solution

The solution is to add `flex-none` to the avatar component, which stops it from being squished by the flexbox.

<img width="826" alt="image" src="https://github.com/user-attachments/assets/b98f128e-5109-4d5d-88f2-9984f15281fe" />

Fixes livewire/flux#1532