### PR TITLE
Fix default select line height

### DIFF
--- a/stubs/resources/views/flux/select/variants/default.blade.php
+++ b/stubs/resources/views/flux/select/variants/default.blade.php
@@ -12,9 +12,9 @@ $classes = Flux::classes()
     ->add('appearance-none') // Strip the browser's default <select> styles...
     ->add('w-full ps-3 pe-10 block')
     ->add(match ($size) {
-        default => 'h-10 py-2 text-base sm:text-sm leading-none rounded-lg',
-        'sm' => 'h-8 py-1.5 text-sm leading-none rounded-md',
-        'xs' => 'h-6 text-xs leading-none rounded-md',
+        default => 'h-10 py-2 text-base sm:text-sm leading-[1.375rem] rounded-lg',
+        'sm' => 'h-8 py-1.5 text-sm leading-[1.125rem] rounded-md',
+        'xs' => 'h-6 text-xs leading-[1.125rem] rounded-md',
     })
     ->add('shadow-xs border')
     ->add('bg-white dark:bg-white/10 dark:disabled:bg-white/[9%]')


### PR DESCRIPTION
# The scenario

Currently if you have a default select and have selected a option that has a letter that hangs down, like `g` or `y`, then the bottom of the letter is being cut off.

<img width="972" alt="image" src="https://github.com/user-attachments/assets/2075a03d-4454-4b42-a95e-a59054086c43" />

```blade
<flux:select wire:model="industry" placeholder="Choose industry...">
    <flux:select.option>Photography</flux:select.option>
    <flux:select.option>Design services</flux:select.option>
    <flux:select.option>Web development</flux:select.option>
    <flux:select.option>Accounting</flux:select.option>
    <flux:select.option>Legal services</flux:select.option>
    <flux:select.option>Consulting</flux:select.option>
    <flux:select.option>Other</flux:select.option>
</flux:select>
```

# The problem

The issue is that the line height is set to `leading-none` for the default select, which is causing the descenders to be cut off.

```php
->add(match ($size) {
    default => 'h-10 py-2 text-base sm:text-sm leading-none rounded-lg',
    'sm' => 'h-8 py-1.5 text-sm leading-none rounded-md',
    'xs' => 'h-6 text-xs leading-none rounded-md',
})
```

The input component on the other hand is working fine. So if we have a look at what the input component has, we can see it has a small amount of leading set, which is different depending on the size of the text.

```php
->add(match ($size) {
    default => 'text-base sm:text-sm py-2 h-10 leading-[1.375rem]',
    'sm' => 'text-sm py-1.5 h-8 leading-[1.125rem]',
    'xs' => 'text-xs py-1.5 h-6 leading-[1.125rem]',
})
```

# The solution

The solution is to apply the same leading sizes, that input has, to the default select component.

Now everything looks as expected. I also made sure that it is correct for both mobile and desktop sizes, as they have different font sizes if the default size is being used.

<img width="972" alt="image" src="https://github.com/user-attachments/assets/c77a2090-d77c-4591-9480-d062eea2900b" />

Fixes livewire/flux#1540