### PR TITLE
Add `info` Callout variant 

### DIFF
--- a/stubs/resources/views/flux/callout/index.blade.php
+++ b/stubs/resources/views/flux/callout/index.blade.php
@@ -21,6 +21,7 @@
         'danger' => 'red',
         'warning' => 'yellow',
         'secondary' => 'zinc',
+        'info' => 'blue',
         default => $color,
     };
 


### PR DESCRIPTION
# The scenario

Hey 👋 

My application uses callouts for various things. I discovered that there's no callout variant for if you want to show information. 

# The problem

Flux already does a great job for variants such as if you want to show an error, a warning or a success message, but there's no set variant for if you want to show just general information.

# The solution

This PR adds an additional variant called `info` which is mapped to `blue`. 

![Screenshot 2025-04-29 at 23 17 47](https://github.com/user-attachments/assets/973556b8-0ba7-4091-9387-fbc27f0f26cc)

Fixes livewire/flux#

