### PR TITLE
Add menu `keep-open`

### DIFF
--- a/stubs/resources/views/flux/menu/submenu.blade.php
+++ b/stubs/resources/views/flux/menu/submenu.blade.php
@@ -6,6 +6,7 @@
     'iconTrailing' => null,
     'heading' => '',
     'icon' => null,
+    'keepOpen' => false,
 ])
 
 @php
@@ -31,7 +32,7 @@ $iconClasses = Flux::classes()
         </x-slot:suffix>
     </flux:menu.item>
 
-    <flux:menu>
+    <flux:menu :keep-open="$keepOpen">
         {{ $slot }}
     </flux:menu>
 </ui-submenu>


### PR DESCRIPTION
# The scenario

Currently if you have a dropdown menu which contains checkboxes or radios and you select one of them, the dropdown closes which makes it hard to see that the checkbox was checked but also you then need to open the dropdown again if you want to select another checkbox item.

![Recording 2025-05-19 at 17 55 49](https://github.com/user-attachments/assets/7da0f5d5-9e31-4187-b8ef-10e47edd4efe)

```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    //
}; ?>

<div>
    <flux:dropdown>
        <flux:button icon:trailing="chevron-down">Options</flux:button>

        <flux:menu>
            <flux:menu.item icon="plus">New post</flux:menu.item>

            <flux:menu.separator />

            <flux:menu.submenu heading="Sort by">
                <flux:menu.radio.group>
                    <flux:menu.radio checked>Name</flux:menu.radio>
                    <flux:menu.radio>Date</flux:menu.radio>
                    <flux:menu.radio>Popularity</flux:menu.radio>
                </flux:menu.radio.group>
            </flux:menu.submenu>

            <flux:menu.submenu heading="Filter">
                <flux:menu.checkbox checked>Draft</flux:menu.checkbox>
                <flux:menu.checkbox checked>Published</flux:menu.checkbox>
                <flux:menu.checkbox>Archived</flux:menu.checkbox>
            </flux:menu.submenu>

            <flux:menu.separator />

            <flux:menu.item variant="danger" icon="trash">Delete</flux:menu.item>
        </flux:menu>
    </flux:dropdown>
</div>
```

# The problem

The issue is that when any click happens on a checkbox, radio, or menu item, they all dispatch a `lofi-close-popovers` which the menu is listening for an will close.

# The solution

I had a look at other frameworks to see if they handle this and for a lot of them, users can just register a click listener on the items and call `event.preventDefault()`.

As we don't want users to have to worry about that, the solution is instead to add an attribute that signals to Flux not to close the dropdown when an checkbox/ item is clicked.

I had a chat with Mr Gippity and these were the ideas for naming the attribute.

![image](https://github.com/user-attachments/assets/6ce7c488-9b81-4047-b781-0e2c47fdbf86)

I already had `keep-open` in my head so I went with that option.

Now a user can put `keep-open` directly on their `flux:menu.checkbox`, `flux:menu.radio.group`, `flux:menu.radio` and even on `flux:menu.item` to stop a selection/ click on any of them from closing the dropdown.

```blade
<flux:menu.checkbox keep-open>Checkbox</flux:menu.checkbox>
```

They can also put `keep-open` on any `<flux:menu>` or `<flux:menu.submenu>` if they just want to keep the dropdown open no matter what is selected. In that scenario clicking away or escape will still close the dropdowns. To get `flux:menu.submenu` working, I had to add attribute forwarding for `keep-open` as it needed to be forward onto the `flux:menu` within the submenu component.

![Recording 2025-05-19 at 18 08 24](https://github.com/user-attachments/assets/1fbf9348-b122-426c-ad28-c36a9ed56114)

Fixes livewire/flux#130