### PR TITLE
Fix default select disabled and dark styles

### DIFF
--- a/stubs/resources/views/flux/select/variants/default.blade.php
+++ b/stubs/resources/views/flux/select/variants/default.blade.php
@@ -17,8 +17,8 @@ $classes = Flux::classes()
         'xs' => 'h-6 text-xs leading-[1.125rem] rounded-md',
     })
     ->add('shadow-xs border')
-    ->add('bg-white dark:bg-white/10 dark:disabled:bg-white/[9%]')
-    ->add('text-zinc-700 dark:text-zinc-300')
+    ->add('bg-white dark:bg-white/10 dark:disabled:bg-white/[7%]')
+    ->add('text-zinc-700 dark:text-zinc-300 disabled:text-zinc-500 dark:disabled:text-zinc-400')
     // Make the placeholder match the text color of standard input placeholders...
     ->add('has-[option.placeholder:checked]:text-zinc-400 dark:has-[option.placeholder:checked]:text-zinc-400')
     // Options on Windows don't inherit dark mode styles, so we need to force them...


### PR DESCRIPTION
# The scenario

Currently if you have a default select and it's disabled it doesn't look disabled.

**Light mode disabled**
<img width="615" alt="image" src="https://github.com/user-attachments/assets/51f782b8-ed2f-4a3e-a860-6db3906335c2" />

**Dark mode disabled**
<img width="615" alt="image" src="https://github.com/user-attachments/assets/0cbf8bb3-aeed-482d-9b61-597013062909" />


```blade
<div>
    <flux:input label="Input" value="Test" disabled />
    <flux:select label="Default Select" disabled>
       <flux:select.option selected>Test</flux:select.option>
    </flux:select>
    <flux:select label="Listbox" variant="listbox" disabled>
        <flux:select.option selected>Test</flux:select.option>
    </flux:select>
</div>
```

# The problem

The issue is that there are no disabled text styles for the default select. I also noticed that when default select is disabled in dark mode, it's background colour is slightly different to the input and listbox select.

# The solution

The solution is to add disabled text colours for light and dark mode to match inputs/ listboxes and fix the dark disabled background to match  them too.

**Light mode**
<img width="615" alt="image" src="https://github.com/user-attachments/assets/67dfcd7a-0afe-4714-b57a-b14767887781" />

**Light mode disabled**
<img width="615" alt="image" src="https://github.com/user-attachments/assets/355397ef-2f8f-4965-92f9-c537e8d584d2" />

**Dark mode**
<img width="615" alt="image" src="https://github.com/user-attachments/assets/b03f6bbd-692a-4e80-915a-756398470876" />

**Dark mode disabled**
<img width="615" alt="image" src="https://github.com/user-attachments/assets/c2629ce7-e56f-4bf6-add5-e22f6f9a75f2" />

Fixes livewire/flux#1610