### PR TITLE
Fix attributes after with multi-word props

### DIFF
--- a/src/FluxManager.php
+++ b/src/FluxManager.php
@@ -127,6 +127,9 @@ class FluxManager
         foreach ($attributes->getAttributes() as $key => $value) {
             if (str_starts_with($key, $prefix)) {
                 $newAttributes[substr($key, strlen($prefix))] = $value;
+                // If a prop is passed in as `kebab-case`, we need to convert it to `camelCase` so that when Blade separates
+                // the prop values from the attributes, it matches the prop value correctly, if it's a multi-word prop...
+                $newAttributes[Str::camel(substr($key, strlen($prefix)))] = $value;
             }
         }
 


### PR DESCRIPTION
# The scenario

Currently if we have a component within another component, we can forward attributes to the inner component using a prefix. For example if we call the `table` component, we can pass props to the `paginator` component like this:

```blade
<flux:table paginator:preserve-scroll>
```

But if the preserve scroll prop is defined as `camelCase` inside the paginator component, and the prop is passed in using `kebab-case` then the value isn't being forwarded properly.

```blade
@props([
    'preserveScroll' => false,
])
```

If we use `camelCase` when calling the table component though, it works happily.

```blade
<flux:table paginator:preserveScroll>
```

# The problem

When attributes are forwarded like that, under the hood, Laravel tries to detect if there are any props defined in the attribute bag, and if they are, it sets the values and removes them from the attribute bag.

But, the way it does it, is it looks to see if the prop name (with the casing as defined in `@props`), for example `preserveScroll` is in the attribute bag.

The issue is that what is in the attribute bag is actually `preserve-scroll`, so when Laravel looks up `preserverScroll` it can't find it.

This problem has been raised here https://github.com/laravel/framework/issues/48956

And attempted to be fixed here https://github.com/laravel/framework/pull/48983
And here https://github.com/laravel/framework/pull/49146

But it hasn't been accepted.

# The solution

The solution is to implement a fix internally. When we extract the attributes that should be passed on to the nested component, we can just ensure there is a `camelCase` version of that attribute/ prop name so Blade matches it correctly and filters it out of the attributes.

I also did a check to make sure that the attributes are correctly filtered out of the attribute bag, due to now having both naming schemes in the attribute bag, and it does.

But I just realised that filtering only happens for matching prop names, so there will still be a double up of normal attributes with both cases.