### PR TITLE
Fix select option

### DIFF
--- a/stubs/resources/views/flux/select/option/index.blade.php
+++ b/stubs/resources/views/flux/select/option/index.blade.php
@@ -11,6 +11,4 @@ $variant = $variant !== 'default' && Flux::componentExists('select.variants.' . 
     : 'default';
 @endphp
 
-<flux:with-field :$attributes>
-    <flux:delegate-component :component="'select.option.variants.' . $variant">{{ $slot }}</flux:delegate-component>
-</flux:with-field>
+<flux:delegate-component :component="'select.option.variants.' . $variant">{{ $slot }}</flux:delegate-component>


### PR DESCRIPTION
# The scenario

Currently if you have a `<flux:select.option>` and you put a `label` attribute on it, it renders the option with a label which is incorrect.

![Recording 2025-05-30 at 10 52 26](https://github.com/user-attachments/assets/f8dbca31-c35d-441c-a8ce-300509bb6fa9)

```blade
<?php

use Livewire\Attributes\On;
use Livewire\Volt\Component;

new class extends Component {
    //
}; ?>

<div>
    <flux:select variant="combobox">
        <flux:select.option label="John Smith">
            John Smith <span class="ml-1 text-gray-500">Smith Constructions</span>
        </flux:select.option>
        <flux:select.option label="Bob Jane">
            Bob Jane <span class="ml-1 text-gray-500">Bob's Tyres</span>
        </flux:select.option>
        <flux:select.option label="John Doe">
            John Doe <span class="ml-1 text-gray-500">Doe's Plumbing</span>
        </flux:select.option>
    </flux:select>
</div>

```
# The problem

The issue is that `select/option/index.blade.php` is a component which delegates to other option components depending on the variant. Inside of it is a `<flux:with-field :$attributes>` which is picking up the label and rendering an actual label above the option. 

```blade
<flux:with-field :$attributes>
    <flux:delegate-component :component="'select.option.variants.' . $variant">{{ $slot }}</flux:delegate-component>
</flux:with-field>
```

But the problem is that Flux's select supports adding a `label` attribute to them so that way it is the value that get's displayed in the input when an option is selected instead of the option's inner HTML. As such there is a conflict between the two.

When I dug into this to find out when it was introduced, I found that it was added by me by mistake in Flux v2, which I created the `option.index` delegator component as part of the split between free select and pro listbox and combobox.

This happened because I had copied the `select.index` delegator component which has the `with-field` wrapper. But `select.option.index` shouldn't have this.

I double checked what `option` looked like in V1 to make sure and it didn't have it.

```blade
<?php if ($custom): ?>
    <ui-option
        @if ($value !== null) value="{{ $value }}" @endif
        @if ($value) wire:key="{{ $value }}" @endif
        @if ($filterable === false) filter="manual" @endif
        @if ($livewireAction || $alpineAction) action @endif
        {{ $attributes->class($classes) }}
        data-flux-option
    >
        <div class="w-6 shrink-0 [ui-selected_&]:hidden">
            <flux:select.indicator :variant="$indicator" />
        </div>

        {{ $slot }}

        <?php if ($loading): ?>
            <flux:icon.loading class="hidden [[data-flux-loading]>&]:block ml-auto text-zinc-400 [[data-flux-menu-item]:hover_&]:text-current" variant="micro" />
        <?php endif; ?>
    </ui-option>
<?php else: ?>
    <option
        {{ $attributes }}
        @if (isset($value)) value="{{ $value }}" @endif
        @if (isset($value)) wire:key="{{ $value }}" @endif
    >{{ $slot }}</option>
<?php endif; ?>
```

# The solution

The solution is to remove the `<flux:with-field>` wrapper from the `select/option/index.blade.php` and now everything works as expected.

![Recording 2025-05-30 at 10 51 15](https://github.com/user-attachments/assets/c042aacc-7a80-4133-9087-c90d549adf59)