### PR TITLE
Fix misalignment when using badge in flux:label

### DIFF
--- a/stubs/resources/views/flux/label.blade.php
+++ b/stubs/resources/views/flux/label.blade.php
@@ -15,7 +15,7 @@
     {{ $slot }}
 
     <?php if (is_string($badge)): ?>
-        <span class="ms-1.5 text-zinc-800/70 text-xs bg-zinc-800/5 px-1.5 py-1 rounded-[4px] dark:bg-white/10 dark:text-zinc-300 -mb-1 -mt-1" aria-hidden="true">
+        <span class="ms-1.5 text-zinc-800/70 text-xs bg-zinc-800/5 px-1.5 py-1 -my-1 rounded-[4px] dark:bg-white/10 dark:text-zinc-300" aria-hidden="true">
             {{ $badge }}
         </span>
     <?php elseif ($badge): ?>
@@ -25,7 +25,7 @@
     <?php endif; ?>
 
     <?php if ($aside): ?>
-        <span class="ms-1.5 text-zinc-800/70 text-xs bg-zinc-800/5 px-1.5 py-1 rounded-[4px] dark:bg-white/10 dark:text-zinc-300 -mb-1 -mt-1" aria-hidden="true">
+        <span class="ms-1.5 text-zinc-800/70 text-xs bg-zinc-800/5 px-1.5 py-1 -my-1 rounded-[4px] dark:bg-white/10 dark:text-zinc-300" aria-hidden="true">
             {{ $aside }}
         </span>
     <?php endif; ?>

--- a/stubs/resources/views/flux/label.blade.php
+++ b/stubs/resources/views/flux/label.blade.php
@@ -15,7 +15,7 @@
     {{ $slot }}
 
     <?php if (is_string($badge)): ?>
-        <span class="ms-1.5 text-zinc-800/70 text-xs bg-zinc-800/5 px-1.5 py-1 rounded-[4px] dark:bg-white/10 dark:text-zinc-300" aria-hidden="true">
+        <span class="ms-1.5 text-zinc-800/70 text-xs bg-zinc-800/5 px-1.5 py-1 rounded-[4px] dark:bg-white/10 dark:text-zinc-300 -mb-1 -mt-1" aria-hidden="true">
             {{ $badge }}
         </span>
     <?php elseif ($badge): ?>
@@ -25,7 +25,7 @@
     <?php endif; ?>
 
     <?php if ($aside): ?>
-        <span class="ms-1.5 text-zinc-800/70 text-xs bg-zinc-800/5 px-1.5 py-1 rounded-[4px] dark:bg-white/10 dark:text-zinc-300" aria-hidden="true">
+        <span class="ms-1.5 text-zinc-800/70 text-xs bg-zinc-800/5 px-1.5 py-1 rounded-[4px] dark:bg-white/10 dark:text-zinc-300 -mb-1 -mt-1" aria-hidden="true">
             {{ $aside }}
         </span>
     <?php endif; ?>


### PR DESCRIPTION
# The problem
There is a misalignment when using `<flux:label>` with a badge
![CleanShot 2025-06-03 at 19 01 59@2x](https://github.com/user-attachments/assets/943bcf2b-a848-4f02-9428-ea485e0cdf87)



# The solution

Simply adding inset top bottom, `-mb-1 -mt-1` fixes the problem


# Code to reproduce
```blade
<div class="space-y-6 md:space-y-0 md:grid grid-cols-2 gap-4">
    <flux:input label="Email" type="email"/>
    <flux:input badge="Optional" label="Phone" type="phone"/>
</div>
```