### PR TITLE
Fix: Sidebar visibility in RTL mode when stashable

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/stubs/resources/views/flux/sidebar/index.blade.php
+++ b/stubs/resources/views/flux/sidebar/index.blade.php
@@ -19,7 +19,7 @@ if ($stashable) {
     $attributes = $attributes->merge([
         'x-bind:data-stashed' => '! screenLg',
         'x-resize.document' => 'screenLg = window.innerWidth >= 1024',
-        'x-init' => '$el.classList.add(\'-translate-x-full\', \'rtl:translate-x-full\'); $el.removeAttribute(\'data-mobile-cloak\'); $el.classList.add(\'transition-transform\')',
+        'x-init' => "const isRtl = document.documentElement.dir === 'rtl';if (isRtl) {\$el.classList.add('translate-x-full');} else {\$el.classList.add('-translate-x-full');}\$el.removeAttribute('data-mobile-cloak');\$el.classList.add('transition-transform');",
     ])->class([
         'max-lg:data-mobile-cloak:hidden',
         '[[data-show-stashed-sidebar]_&]:translate-x-0! lg:translate-x-0!',


### PR DESCRIPTION
# The scenario

The `flux:sidebar` component, when configured with the `stashable` prop, fails to display correctly when the HTML page direction is set to `dir="rtl"`. Instead of sliding into view, the sidebar remains completely invisible on bigger screens. The component works as expected in LTR mode.

**Expected behavior:**
The sidebar should slide into view from the right side of the screen.

**Actual behavior:**
The sidebar does not appear; it remains completely invisible.

```
<html dir="rtl">
<body>
        <flux:sidebar sticky stashable class="border-e border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
                 //
        </flux:sidebar>
    </body>
</html>
```

# The problem
The current implementation within the index.blade.php for the stashable sidebar relies on adding both -translate-x-full and rtl:translate-x-full classes in the x-init directive:
```
if ($stashable) {
    $attributes = $attributes->merge([
        // ... other attributes ...
        'x-init' => '$el.classList.add(\'-translate-x-full\', \'rtl:translate-x-full\'); $el.removeAttribute(\'data-mobile-cloak\'); $el.classList.add(\'transition-transform\')',
    ])->class([
        // ... other classes ...
        '[[data-show-stashed-sidebar]_&]:translate-x-0! lg:translate-x-0!',
        // ...
    ]);
}
```
In RTL mode, Tailwind CSS specificity rules ensure that rtl:translate-x-full (which applies transform: translateX(100%)) overrides -translate-x-full (which applies transform: translateX(-100%)). This correctly sets the initial off-screen position to the right.

However, when the sidebar is toggled to be shown, the [[data-show-stashed-sidebar]_&]:translate-x-0! class (applying transform: translateX(0) !important) seems unable to correctly override or reset this initial transformation in RTL, leading to the sidebar remaining off-screen or otherwise invisible. The exact cause of this override failure with the current class setup in RTL is unclear but points to an interaction issue.

# The solution
The proposed solution is to make the initial off-screen transformation class more explicit within the x-init directive by detecting the document's direction using JavaScript and applying the correct Tailwind utility class directly. This removes the reliance on adding both LTR and RTL-specific transform classes simultaneously and letting CSS specificity sort it out, which might be the source of the conflict.

Code changes in index.blade.php:

The x-init attribute for the stashable sidebar is modified as follows:
```
if ($stashable) {
    $attributes = $attributes->merge([
        'x-bind:data-stashed' => '! screenLg',
        'x-resize.document' => 'screenLg = window.innerWidth >= 1024',
        'x-init' => "
            const isRtl = document.documentElement.dir === 'rtl';
            if (isRtl) {
                \$el.classList.add('translate-x-full'); // Hides sidebar to the right in RTL
            } else {
                \$el.classList.add('-translate-x-full'); // Hides sidebar to the left in LTR
            }
            \$el.removeAttribute('data-mobile-cloak');
            \$el.classList.add('transition-transform');
        ",
    ])->class([
        'max-lg:data-mobile-cloak:hidden',
        '[[data-show-stashed-sidebar]_&]:translate-x-0! lg:translate-x-0!',
        'z-20! data-stashed:start-0! data-stashed:fixed! data-stashed:top-0! data-stashed:min-h-dvh! data-stashed:max-h-dvh!'
    ]);
}
```
This modification avoids the conflict caused by using two classes simultaneously, and ensures that the correct transformation is applied based on the page orientation, which solves the problem of the gibberish not appearing in RTL mode.