### PR TITLE
Fix RTL navlist group closed chevron

### DIFF
--- a/stubs/resources/views/flux/navlist/group.blade.php
+++ b/stubs/resources/views/flux/navlist/group.blade.php
@@ -9,7 +9,7 @@
         <button type="button" class="w-full h-10 lg:h-8 flex items-center group/disclosure-button mb-[2px] rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
             <div class="ps-3 pe-4">
                 <flux:icon.chevron-down class="size-3! hidden group-data-open/disclosure-button:block" />
-                <flux:icon.chevron-right class="size-3! block group-data-open/disclosure-button:hidden" />
+                <flux:icon.chevron-right class="size-3! block group-data-open/disclosure-button:hidden rtl:rotate-180" />
             </div>
 
             <span class="text-sm font-medium leading-none">{{ $heading }}</span>


### PR DESCRIPTION
# The scenario

Currently if you are using the navlist group on an RTL site, the closed chevron is still pointing right instead of left.

<img width="266" alt="image" src="https://github.com/user-attachments/assets/99a371ef-3f96-4f51-8fa6-93af57101c27" />

# The problem

The issue is we have no handling for RTL in the navlist group component, so it needs to be added.

# The solution

The solution is to ensure we rotate the chevron to the left instead of the right when RTL is enabled.

I've done this by adding `rtl:rotate-180` to the icon.

<img width="265" alt="image" src="https://github.com/user-attachments/assets/42d5a001-955c-4dd7-87e6-10c91f2d357f" />

Fixes livewire/flux#1691