### PR TITLE
Fixed button padding

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -62,7 +62,7 @@ $classes = Flux::classes()
     ->add('relative items-center font-medium justify-center gap-2 whitespace-nowrap')
     ->add('disabled:opacity-75 dark:disabled:opacity-75 disabled:cursor-default disabled:pointer-events-none')
     ->add(match ($size) { // Size...
-        'base' => 'h-10 text-sm rounded-lg' . ' ' . ($square ? 'w-10' : 'px-4 [&:has(>:not(span):first-child)]:ps-3 [&:has(>:not(span):last-child)]:pe-3'),
+        'base' => 'h-10 text-sm rounded-lg' . ' ' . ($square ? 'w-10' : 'px-4 [&:has(>:not(span):not([data-flux-loading-indicator]):first-child)]:ps-3 [&:has(>:not(span):not([data-flux-loading-indicator]):last-child)]:pe-3'),
         'sm' => 'h-8 text-sm rounded-md' . ' ' . ($square ? 'w-8' : 'px-3'),
         'xs' => 'h-6 text-xs rounded-md' . ' ' . ($square ? 'w-6' : 'px-2'),
     })


### PR DESCRIPTION
This PR fixed a visual issue with the button padding if the button is type submit.

## Visual issue before:

```html
<flux:button variant="primary">Save</flux:button>
```
![image](https://github.com/user-attachments/assets/f6ffb7f0-f587-4ea4-b10a-abd2ee74e39c)

```html
<flux:button variant="primary" type="submit">Save</flux:button>
```
![image](https://github.com/user-attachments/assets/d5090a5e-e4b1-4073-9c5b-47464f35b46c)

As you can see the left padding is smaller if the button is type submit, so the text is not centered.

Fixes #1728