### PR TITLE
Fix profile initials

### DIFF
--- a/stubs/resources/views/flux/profile.blade.php
+++ b/stubs/resources/views/flux/profile.blade.php
@@ -14,13 +14,6 @@
 @php
 $iconTrailing = $iconTrailing ?? ($chevron ? 'chevron-down' : null);
 
-// If no initials are provided, we'll try to generate them from the name by taking the first letter of the first and last name...
-$initials ??= collect(explode(' ', $name ?? ''))
-    ->map(fn($part) => Str::substr($part, 0, 1))
-    ->filter()
-    ->only([0, count(explode(' ', $name ?? '')) - 1])
-    ->implode('');
-
 // When using the outline icon variant, we need to size it down to match the default icon sizes...
 $iconClasses = Flux::classes('text-zinc-400 dark:text-white/80 group-hover:text-zinc-800 dark:group-hover:text-white')
     ->add($iconVariant === 'outline' ? 'size-4' : '');


### PR DESCRIPTION
# The scenario

Currently if you pass a name like "Caleb" to the avatar component, it will generate initials "Ca", but if you do the same for the profile component it generates initials "C".

<img width="120" alt="image" src="https://github.com/user-attachments/assets/a225a138-7db8-4019-b60d-ee79c59d9547" />

```blade
<div>
    <flux:profile name="Caleb" />
    <flux:avatar name="Caleb" />
</div>
```

# The problem

The issue is that there is an inconsistency between how the initials are generated because the profile component has it's own initials generation logic which is different to the avatar logic.

# The solution

The profile component only passes the initials on to the avatar component and doesn't use them anywhere else, so there is no need for it to calculated them. So I've removed the initials logic from the profile component and it now falls through to the avatar component to calculate them.

Now both match and are consistent.

<img width="124" alt="image" src="https://github.com/user-attachments/assets/a160f7d9-ca7f-48df-92f8-974ac6bf03d9" />

Fixes livewire/flux#1737