### PR TITLE
Fix text component to use `<p>` tag

### DIFF
--- a/stubs/resources/views/flux/text.blade.php
+++ b/stubs/resources/views/flux/text.blade.php
@@ -39,4 +39,4 @@ $classes = Flux::classes()
     ;
 @endphp
 {{-- NOTE: It's important that this file has NO newline at the end of the file. --}}
-<?php if ($inline) : ?><span {{ $attributes->class($classes) }} data-flux-text @if ($color) color="{{ $color }}" @endif>{{ $slot }}</span><?php else: ?><div {{ $attributes->class($classes) }} data-flux-text @if ($color) data-color="{{ $color }}" @endif>{{ $slot }}</div><?php endif; ?>
+<?php if ($inline) : ?><span {{ $attributes->class($classes) }} data-flux-text @if ($color) color="{{ $color }}" @endif>{{ $slot }}</span><?php else: ?><p {{ $attributes->class($classes) }} data-flux-text @if ($color) data-color="{{ $color }}" @endif>{{ $slot }}</p><?php endif; ?>


### PR DESCRIPTION
# The scenario

Currently if you use the `<flux:text>` component it renders a `<div>` instead of a `<p>` tag. It's currently documented in the `inline` prop section of that docs that it is a `<p>` tag by default `If true, the text element will be a span instead of a p.`.

<img width="971" alt="image" src="https://github.com/user-attachments/assets/9cb8eff3-996e-4086-ab1b-4c65dc5add3e" />

```blade
<flux:text>Some text</flux:text>
```

# The problem

The issue is that it is expected that it would render a `<p>` tag by default and render a `<span>` when it's inline.

But currently it outputs a `<div>`.

If you need a `<p>` tag, then you have to do the following which feels wrong.

```blade
<flux:text><p>Some text</p></flux:text>
```

# The solution

This PR changes it so it renders a `<p>` instead of a `<div>` which is more semantic anyway.

<img width="971" alt="image" src="https://github.com/user-attachments/assets/fec3a277-3011-4daf-81c3-d119ca783d71" />

Fixes livewire/flux#1735