### PR TITLE
Add functional keyboard shortcuts to Flux buttons

### DIFF
--- a/ModifierParser.php
+++ b/ModifierParser.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Actions;
+
+class ModifierParser
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __invoke($kbd)
+    {
+        $modifiers = [
+            '⌘' => 'cmd',      // Command ( key)
+            '⇧' => 'shift',     // Shift
+            '⌥' => 'alt',       // Option/Alt
+            '⌃' => 'ctrl',      // Control
+            '⌫' => 'backspace', // Delete (backward)
+            '⌦' => 'delete',    // Forward Delete
+            '⎋' => 'escape',    // Escape
+            '↩' => 'enter',     // Return/Enter
+            '⇥' => 'tab',       // Tab
+            '␣' => 'space',     // Spacebar
+            '↑' => 'up',        // Up Arrow
+            '↓' => 'down',      // Down Arrow
+            '←' => 'left',      // Left Arrow
+            '→' => 'right',     // Right Arrow
+            '⇞' => 'pageup',    // Page Up
+            '⇟' => 'pagedown',  // Page Down
+            '↖' => 'home',      // Home
+            '↘' => 'end',       // End
+            '' => 'capslock',  // Caps Lock
+            '' => 'fn',        // Function key
+            'F1' => 'f1',
+            'F2' => 'f2',
+            'F3' => 'f3',
+            'F4' => 'f4',
+            'F5' => 'f5',
+            'F6' => 'f6',
+            'F7' => 'f7',
+            'F8' => 'f8',
+            'F9' => 'f9',
+            'F10' => 'f10',
+            'F11' => 'f11',
+            'F12' => 'f12',
+        ];
+
+        // Split into individual characters
+        $chars = preg_split('//u', $kbd, -1, PREG_SPLIT_NO_EMPTY);
+        // Extract modifiers and key
+        $alpineModifiers = [];
+        $key = '';
+
+        foreach ($chars as $char) {
+            if (isset($modifiers[$char])) {
+                $alpineModifiers[] = $modifiers[$char];
+            } else {
+                $key = strtolower($char);
+            }
+        }
+
+        return implode('.', [...$alpineModifiers, $key]);
+    }
+}

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -1,4 +1,4 @@
-@php $iconTrailing = $iconTrailing ??= $attributes->pluck('icon:trailing'); @endphp
+@php use App\Actions\ModifierParser;$iconTrailing = $iconTrailing ??= $attributes->pluck('icon:trailing'); @endphp
 @php $iconLeading = $iconLeading ??= $attributes->pluck('icon:leading'); @endphp
 @php $iconVariant = $iconVariant ??= $attributes->pluck('icon:variant'); @endphp
 
@@ -15,184 +15,194 @@
     'inset' => null,
     'icon' => null,
     'kbd' => null,
+    'xRef'=>"button_".Str::random(4),
 ])
 
 @php
-$iconLeading = $icon ??= $iconLeading;
 
-// Button should be a square if it has no text contents...
-$square ??= $slot->isEmpty();
+    $modifier = new ModifierParser();
+    $shortcut = $modifier($kbd);
+      $iconLeading = $icon ??= $iconLeading;
 
-// Size-up icons in square/icon-only buttons... (xs buttons just get micro size/style...)
-$iconVariant ??= ($size === 'xs')
-    ? ($square ? 'micro' : 'micro')
-    : ($square ? 'mini' : 'micro');
+      // Button should be a square if it has no text contents...
+      $square ??= $slot->isEmpty();
 
-$iconTrailingVariant ??= $attributes->pluck('icon-trailing:variant', $iconVariant);
+      // Size-up icons in square/icon-only buttons... (xs buttons just get micro size/style...)
+      $iconVariant ??= ($size === 'xs')
+          ? ($square ? 'micro' : 'micro')
+          : ($square ? 'mini' : 'micro');
 
-// When using the outline icon variant, we need to size it down to match the default icon sizes...
-$iconClasses = Flux::classes()
-    ->add($iconVariant === 'outline' ? ($square && $size !== 'xs' ? 'size-5' : 'size-4') : '')
-    ->add($attributes->pluck('icon:class'))
-    ;
+      $iconTrailingVariant ??= $attributes->pluck('icon-trailing:variant', $iconVariant);
 
-$iconTrailingClasses = Flux::classes()
-    ->add($iconTrailingVariant === 'outline' ? ($square && $size !== 'xs' ? 'size-5' : 'size-4') : '')
-    ->add($attributes->pluck('icon-trailing:class'))
-    ;
+      // When using the outline icon variant, we need to size it down to match the default icon sizes...
+      $iconClasses = Flux::classes()
+          ->add($iconVariant === 'outline' ? ($square && $size !== 'xs' ? 'size-5' : 'size-4') : '')
+          ->add($attributes->pluck('icon:class'))
+          ;
 
-$isTypeSubmitAndNotDisabledOnRender = $type === 'submit' && ! $attributes->has('disabled');
+      $iconTrailingClasses = Flux::classes()
+          ->add($iconTrailingVariant === 'outline' ? ($square && $size !== 'xs' ? 'size-5' : 'size-4') : '')
+          ->add($attributes->pluck('icon-trailing:class'))
+          ;
 
-$isJsMethod = str_starts_with($attributes->whereStartsWith('wire:click')->first() ?? '', '$js.');
+      $isTypeSubmitAndNotDisabledOnRender = $type === 'submit' && ! $attributes->has('disabled');
 
-$loading ??= $loading ?? ($isTypeSubmitAndNotDisabledOnRender || $attributes->whereStartsWith('wire:click')->isNotEmpty() && ! $isJsMethod);
+      $isJsMethod = str_starts_with($attributes->whereStartsWith('wire:click')->first() ?? '', '$js.');
 
-if ($loading && $type !== 'submit' && ! $isJsMethod) {
-    $attributes = $attributes->merge(['wire:loading.attr' => 'data-flux-loading']);
+      $loading ??= $loading ?? ($isTypeSubmitAndNotDisabledOnRender || $attributes->whereStartsWith('wire:click')->isNotEmpty() && ! $isJsMethod);
 
-    // We need to add `wire:target` here because without it the loading indicator won't be scoped
-    // by method params, causing multiple buttons with the same method but different params to
-    // trigger each other's loading indicators...
-    if (! $attributes->has('wire:target') && $target = $attributes->whereStartsWith('wire:click')->first()) {
-        $attributes = $attributes->merge(['wire:target' => $target], escape: false);
-    }
-}
+      if ($loading && $type !== 'submit' && ! $isJsMethod) {
+          $attributes = $attributes->merge(['wire:loading.attr' => 'data-flux-loading']);
 
-$classes = Flux::classes()
-    ->add('relative items-center font-medium justify-center gap-2 whitespace-nowrap')
-    ->add('disabled:opacity-75 dark:disabled:opacity-75 disabled:cursor-default disabled:pointer-events-none')
-    ->add(match ($size) { // Size...    
-        'base' => 'h-10 text-sm rounded-lg' . ' ' . (
-            $square 
-                ? 'w-10' 
-                // If we have an icon, we want to reduce the padding on the side that has the icon...
-                : ($iconLeading && $iconLeading !== '' ? 'ps-3' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3' : 'pe-4')
-        ),
-        'sm' => 'h-8 text-sm rounded-md' . ' ' . ($square ? 'w-8' : 'px-3'),
-        'xs' => 'h-6 text-xs rounded-md' . ' ' . ($square ? 'w-6' : 'px-2'),
-    })
-    ->add('inline-flex') // Buttons are inline by default but links are blocks, so inline-flex is needed here to ensure link-buttons are displayed the same as buttons...
-    ->add($inset ? match ($size) { // Inset...
-        'base' => $square
-            ? Flux::applyInset($inset, top: '-mt-2.5', right: '-me-2.5', bottom: '-mb-2.5', left: '-ms-2.5')
-            : Flux::applyInset($inset, top: '-mt-2.5', right: '-me-4', bottom: '-mb-3', left: '-ms-4'),
-        'sm' => $square
-            ? Flux::applyInset($inset, top: '-mt-1.5', right: '-me-1.5', bottom: '-mb-1.5', left: '-ms-1.5')
-            : Flux::applyInset($inset, top: '-mt-1.5', right: '-me-3', bottom: '-mb-1.5', left: '-ms-3'),
-        'xs' => $square
-            ? Flux::applyInset($inset, top: '-mt-1', right: '-me-1', bottom: '-mb-1', left: '-ms-1')
-            : Flux::applyInset($inset, top: '-mt-1', right: '-me-2', bottom: '-mb-1', left: '-ms-2'),
-    } : '')
-    ->add(match ($variant) { // Background color...
-        'primary' => 'bg-[var(--color-accent)] hover:bg-[color-mix(in_oklab,_var(--color-accent),_transparent_10%)]',
-        'filled' => 'bg-zinc-800/5 hover:bg-zinc-800/10 dark:bg-white/10 dark:hover:bg-white/20',
-        'outline' => 'bg-white hover:bg-zinc-50 dark:bg-zinc-700 dark:hover:bg-zinc-600/75',
-        'danger' => 'bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-500',
-        'ghost' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
-        'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
-    })
-    ->add(match ($variant) { // Text color...
-        'primary' => 'text-[var(--color-accent-foreground)]',
-        'filled' => 'text-zinc-800 dark:text-white',
-        'outline' => 'text-zinc-800 dark:text-white',
-        'danger' => 'text-white',
-        'ghost' => 'text-zinc-800 dark:text-white',
-        'subtle' => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-white',
-    })
-    ->add(match ($variant) { // Border color...
-        'primary' => 'border border-black/10 dark:border-0',
-        'outline' => 'border border-zinc-200 hover:border-zinc-200 border-b-zinc-300/80 dark:border-zinc-600 dark:hover:border-zinc-600',
-         default => '',
-    })
-    ->add(match ($variant) { // Shadows...
-        'primary' => 'shadow-[inset_0px_1px_--theme(--color-white/.2)]',
-        'danger' => 'shadow-[inset_0px_1px_var(--color-red-500),inset_0px_2px_--theme(--color-white/.15)] dark:shadow-none',
-        'outline' => match ($size) {
-            'base' => 'shadow-xs',
-            'sm' => 'shadow-xs',
-            'xs' => 'shadow-none',
-        },
-        default => '',
-    })
-    ->add(match ($variant) { // Grouped border treatments...
-        'ghost' => '',
-        'subtle' => '',
-        'outline' => '[[data-flux-button-group]_&]:border-s-0 [:is([data-flux-button-group]>&:first-child,_[data-flux-button-group]_:first-child>&)]:border-s-[1px]',
-        'filled' => '[[data-flux-button-group]_&]:border-e [:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-e-0 [[data-flux-button-group]_&]:border-zinc-200/80 dark:[[data-flux-button-group]_&]:border-zinc-900/50',
-        'danger' => '[[data-flux-button-group]_&]:border-e [:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-e-0 [[data-flux-button-group]_&]:border-red-600 dark:[[data-flux-button-group]_&]:border-red-900/25',
-        'primary' => '[[data-flux-button-group]_&]:border-e-0 [:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-e-[1px] dark:[:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-e-0 dark:[:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-s-[1px] [:is([data-flux-button-group]>&:not(:first-child),_[data-flux-button-group]_:not(:first-child)>&)]:border-s-[color-mix(in_srgb,var(--color-accent-foreground),transparent_85%)]',
-    })
-    ->add($loading ? [ // Loading states...
-        '*:transition-opacity',
-        $type === 'submit' ? '[&[disabled]>:not([data-flux-loading-indicator])]:opacity-0' : '[&[data-flux-loading]>:not([data-flux-loading-indicator])]:opacity-0',
-        $type === 'submit' ? '[&[disabled]>[data-flux-loading-indicator]]:opacity-100' : '[&[data-flux-loading]>[data-flux-loading-indicator]]:opacity-100',
-        $type === 'submit' ? '[&[disabled]]:pointer-events-none' : 'data-flux-loading:pointer-events-none',
-    ] : [])
-    ->add($variant === 'primary' ? match ($color) {
-        'slate' => '[--color-accent:var(--color-slate-800)] [--color-accent-content:var(--color-slate-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-slate-800)]',
-        'gray' => '[--color-accent:var(--color-gray-800)] [--color-accent-content:var(--color-gray-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-gray-800)]',
-        'zinc' => '[--color-accent:var(--color-zinc-800)] [--color-accent-content:var(--color-zinc-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-zinc-800)]',
-        'neutral' => '[--color-accent:var(--color-neutral-800)] [--color-accent-content:var(--color-neutral-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-neutral-800)]',
-        'stone' => '[--color-accent:var(--color-stone-800)] [--color-accent-content:var(--color-stone-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-stone-800)]',
-        'red' => '[--color-accent:var(--color-red-500)] [--color-accent-content:var(--color-red-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-red-500)] dark:[--color-accent-content:var(--color-red-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'orange' => '[--color-accent:var(--color-orange-500)] [--color-accent-content:var(--color-orange-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-orange-400)] dark:[--color-accent-content:var(--color-orange-400)] dark:[--color-accent-foreground:var(--color-orange-950)]',
-        'amber' => '[--color-accent:var(--color-amber-400)] [--color-accent-content:var(--color-amber-600)] [--color-accent-foreground:var(--color-amber-950)] dark:[--color-accent:var(--color-amber-400)] dark:[--color-accent-content:var(--color-amber-400)] dark:[--color-accent-foreground:var(--color-amber-950)]',
-        'yellow' => '[--color-accent:var(--color-yellow-400)] [--color-accent-content:var(--color-yellow-600)] [--color-accent-foreground:var(--color-yellow-950)] dark:[--color-accent:var(--color-yellow-400)] dark:[--color-accent-content:var(--color-yellow-400)] dark:[--color-accent-foreground:var(--color-yellow-950)]',
-        'lime' => '[--color-accent:var(--color-lime-400)] [--color-accent-content:var(--color-lime-600)] [--color-accent-foreground:var(--color-lime-900)] dark:[--color-accent:var(--color-lime-400)] dark:[--color-accent-content:var(--color-lime-400)] dark:[--color-accent-foreground:var(--color-lime-950)]',
-        'green' => '[--color-accent:var(--color-green-600)] [--color-accent-content:var(--color-green-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-green-600)] dark:[--color-accent-content:var(--color-green-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'emerald' => '[--color-accent:var(--color-emerald-600)] [--color-accent-content:var(--color-emerald-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-emerald-600)] dark:[--color-accent-content:var(--color-emerald-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'teal' => '[--color-accent:var(--color-teal-600)] [--color-accent-content:var(--color-teal-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-teal-600)] dark:[--color-accent-content:var(--color-teal-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'cyan' => '[--color-accent:var(--color-cyan-600)] [--color-accent-content:var(--color-cyan-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-cyan-600)] dark:[--color-accent-content:var(--color-cyan-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'sky' => '[--color-accent:var(--color-sky-600)] [--color-accent-content:var(--color-sky-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-sky-600)] dark:[--color-accent-content:var(--color-sky-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'blue' => '[--color-accent:var(--color-blue-500)] [--color-accent-content:var(--color-blue-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-blue-500)] dark:[--color-accent-content:var(--color-blue-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'indigo' => '[--color-accent:var(--color-indigo-500)] [--color-accent-content:var(--color-indigo-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-indigo-500)] dark:[--color-accent-content:var(--color-indigo-300)] dark:[--color-accent-foreground:var(--color-white)]',
-        'violet' => '[--color-accent:var(--color-violet-500)] [--color-accent-content:var(--color-violet-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-violet-500)] dark:[--color-accent-content:var(--color-violet-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'purple' => '[--color-accent:var(--color-purple-500)] [--color-accent-content:var(--color-purple-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-purple-500)] dark:[--color-accent-content:var(--color-purple-300)] dark:[--color-accent-foreground:var(--color-white)]',
-        'fuchsia' => '[--color-accent:var(--color-fuchsia-600)] [--color-accent-content:var(--color-fuchsia-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-fuchsia-600)] dark:[--color-accent-content:var(--color-fuchsia-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'pink' => '[--color-accent:var(--color-pink-600)] [--color-accent-content:var(--color-pink-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-pink-600)] dark:[--color-accent-content:var(--color-pink-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        'rose' => '[--color-accent:var(--color-rose-500)] [--color-accent-content:var(--color-rose-500)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-rose-500)] dark:[--color-accent-content:var(--color-rose-400)] dark:[--color-accent-foreground:var(--color-white)]',
-        default => '',
-    } : '')
-    ;
+          // We need to add `wire:target` here because without it the loading indicator won't be scoped
+          // by method params, causing multiple buttons with the same method but different params to
+          // trigger each other's loading indicators...
+          if (! $attributes->has('wire:target') && $target = $attributes->whereStartsWith('wire:click')->first()) {
+              $attributes = $attributes->merge(['wire:target' => $target], escape: false);
+          }
+      }
 
-    // Exempt subtle and ghost buttons from receiving border roundness overrides from button.group...
-    $attributes = $attributes->merge([
-        'data-flux-group-target' => ! in_array($variant, ['subtle', 'ghost']),
-    ]);
+      $classes = Flux::classes()
+          ->add('relative items-center font-medium justify-center gap-2 whitespace-nowrap')
+          ->add('disabled:opacity-75 dark:disabled:opacity-75 disabled:cursor-default disabled:pointer-events-none')
+          ->add(match ($size) { // Size...
+              'base' => 'h-10 text-sm rounded-lg' . ' ' . (
+                  $square
+                      ? 'w-10'
+                      // If we have an icon, we want to reduce the padding on the side that has the icon...
+                      : ($iconLeading && $iconLeading !== '' ? 'ps-3' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3' : 'pe-4')
+              ),
+              'sm' => 'h-8 text-sm rounded-md' . ' ' . ($square ? 'w-8' : 'px-3'),
+              'xs' => 'h-6 text-xs rounded-md' . ' ' . ($square ? 'w-6' : 'px-2'),
+          })
+          ->add('inline-flex') // Buttons are inline by default but links are blocks, so inline-flex is needed here to ensure link-buttons are displayed the same as buttons...
+          ->add($inset ? match ($size) { // Inset...
+              'base' => $square
+                  ? Flux::applyInset($inset, top: '-mt-2.5', right: '-me-2.5', bottom: '-mb-2.5', left: '-ms-2.5')
+                  : Flux::applyInset($inset, top: '-mt-2.5', right: '-me-4', bottom: '-mb-3', left: '-ms-4'),
+              'sm' => $square
+                  ? Flux::applyInset($inset, top: '-mt-1.5', right: '-me-1.5', bottom: '-mb-1.5', left: '-ms-1.5')
+                  : Flux::applyInset($inset, top: '-mt-1.5', right: '-me-3', bottom: '-mb-1.5', left: '-ms-3'),
+              'xs' => $square
+                  ? Flux::applyInset($inset, top: '-mt-1', right: '-me-1', bottom: '-mb-1', left: '-ms-1')
+                  : Flux::applyInset($inset, top: '-mt-1', right: '-me-2', bottom: '-mb-1', left: '-ms-2'),
+          } : '')
+          ->add(match ($variant) { // Background color...
+              'primary' => 'bg-[var(--color-accent)] hover:bg-[color-mix(in_oklab,_var(--color-accent),_transparent_10%)]',
+              'filled' => 'bg-zinc-800/5 hover:bg-zinc-800/10 dark:bg-white/10 dark:hover:bg-white/20',
+              'outline' => 'bg-white hover:bg-zinc-50 dark:bg-zinc-700 dark:hover:bg-zinc-600/75',
+              'danger' => 'bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-500',
+              'ghost' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
+              'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
+          })
+          ->add(match ($variant) { // Text color...
+              'primary' => 'text-[var(--color-accent-foreground)]',
+              'filled' => 'text-zinc-800 dark:text-white',
+              'outline' => 'text-zinc-800 dark:text-white',
+              'danger' => 'text-white',
+              'ghost' => 'text-zinc-800 dark:text-white',
+              'subtle' => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-white',
+          })
+          ->add(match ($variant) { // Border color...
+              'primary' => 'border border-black/10 dark:border-0',
+              'outline' => 'border border-zinc-200 hover:border-zinc-200 border-b-zinc-300/80 dark:border-zinc-600 dark:hover:border-zinc-600',
+               default => '',
+          })
+          ->add(match ($variant) { // Shadows...
+              'primary' => 'shadow-[inset_0px_1px_--theme(--color-white/.2)]',
+              'danger' => 'shadow-[inset_0px_1px_var(--color-red-500),inset_0px_2px_--theme(--color-white/.15)] dark:shadow-none',
+              'outline' => match ($size) {
+                  'base' => 'shadow-xs',
+                  'sm' => 'shadow-xs',
+                  'xs' => 'shadow-none',
+              },
+              default => '',
+          })
+          ->add(match ($variant) { // Grouped border treatments...
+              'ghost' => '',
+              'subtle' => '',
+              'outline' => '[[data-flux-button-group]_&]:border-s-0 [:is([data-flux-button-group]>&:first-child,_[data-flux-button-group]_:first-child>&)]:border-s-[1px]',
+              'filled' => '[[data-flux-button-group]_&]:border-e [:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-e-0 [[data-flux-button-group]_&]:border-zinc-200/80 dark:[[data-flux-button-group]_&]:border-zinc-900/50',
+              'danger' => '[[data-flux-button-group]_&]:border-e [:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-e-0 [[data-flux-button-group]_&]:border-red-600 dark:[[data-flux-button-group]_&]:border-red-900/25',
+              'primary' => '[[data-flux-button-group]_&]:border-e-0 [:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-e-[1px] dark:[:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-e-0 dark:[:is([data-flux-button-group]>&:last-child,_[data-flux-button-group]_:last-child>&)]:border-s-[1px] [:is([data-flux-button-group]>&:not(:first-child),_[data-flux-button-group]_:not(:first-child)>&)]:border-s-[color-mix(in_srgb,var(--color-accent-foreground),transparent_85%)]',
+          })
+          ->add($loading ? [ // Loading states...
+              '*:transition-opacity',
+              $type === 'submit' ? '[&[disabled]>:not([data-flux-loading-indicator])]:opacity-0' : '[&[data-flux-loading]>:not([data-flux-loading-indicator])]:opacity-0',
+              $type === 'submit' ? '[&[disabled]>[data-flux-loading-indicator]]:opacity-100' : '[&[data-flux-loading]>[data-flux-loading-indicator]]:opacity-100',
+              $type === 'submit' ? '[&[disabled]]:pointer-events-none' : 'data-flux-loading:pointer-events-none',
+          ] : [])
+          ->add($variant === 'primary' ? match ($color) {
+              'slate' => '[--color-accent:var(--color-slate-800)] [--color-accent-content:var(--color-slate-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-slate-800)]',
+              'gray' => '[--color-accent:var(--color-gray-800)] [--color-accent-content:var(--color-gray-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-gray-800)]',
+              'zinc' => '[--color-accent:var(--color-zinc-800)] [--color-accent-content:var(--color-zinc-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-zinc-800)]',
+              'neutral' => '[--color-accent:var(--color-neutral-800)] [--color-accent-content:var(--color-neutral-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-neutral-800)]',
+              'stone' => '[--color-accent:var(--color-stone-800)] [--color-accent-content:var(--color-stone-800)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-white)] dark:[--color-accent-content:var(--color-white)] dark:[--color-accent-foreground:var(--color-stone-800)]',
+              'red' => '[--color-accent:var(--color-red-500)] [--color-accent-content:var(--color-red-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-red-500)] dark:[--color-accent-content:var(--color-red-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'orange' => '[--color-accent:var(--color-orange-500)] [--color-accent-content:var(--color-orange-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-orange-400)] dark:[--color-accent-content:var(--color-orange-400)] dark:[--color-accent-foreground:var(--color-orange-950)]',
+              'amber' => '[--color-accent:var(--color-amber-400)] [--color-accent-content:var(--color-amber-600)] [--color-accent-foreground:var(--color-amber-950)] dark:[--color-accent:var(--color-amber-400)] dark:[--color-accent-content:var(--color-amber-400)] dark:[--color-accent-foreground:var(--color-amber-950)]',
+              'yellow' => '[--color-accent:var(--color-yellow-400)] [--color-accent-content:var(--color-yellow-600)] [--color-accent-foreground:var(--color-yellow-950)] dark:[--color-accent:var(--color-yellow-400)] dark:[--color-accent-content:var(--color-yellow-400)] dark:[--color-accent-foreground:var(--color-yellow-950)]',
+              'lime' => '[--color-accent:var(--color-lime-400)] [--color-accent-content:var(--color-lime-600)] [--color-accent-foreground:var(--color-lime-900)] dark:[--color-accent:var(--color-lime-400)] dark:[--color-accent-content:var(--color-lime-400)] dark:[--color-accent-foreground:var(--color-lime-950)]',
+              'green' => '[--color-accent:var(--color-green-600)] [--color-accent-content:var(--color-green-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-green-600)] dark:[--color-accent-content:var(--color-green-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'emerald' => '[--color-accent:var(--color-emerald-600)] [--color-accent-content:var(--color-emerald-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-emerald-600)] dark:[--color-accent-content:var(--color-emerald-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'teal' => '[--color-accent:var(--color-teal-600)] [--color-accent-content:var(--color-teal-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-teal-600)] dark:[--color-accent-content:var(--color-teal-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'cyan' => '[--color-accent:var(--color-cyan-600)] [--color-accent-content:var(--color-cyan-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-cyan-600)] dark:[--color-accent-content:var(--color-cyan-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'sky' => '[--color-accent:var(--color-sky-600)] [--color-accent-content:var(--color-sky-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-sky-600)] dark:[--color-accent-content:var(--color-sky-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'blue' => '[--color-accent:var(--color-blue-500)] [--color-accent-content:var(--color-blue-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-blue-500)] dark:[--color-accent-content:var(--color-blue-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'indigo' => '[--color-accent:var(--color-indigo-500)] [--color-accent-content:var(--color-indigo-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-indigo-500)] dark:[--color-accent-content:var(--color-indigo-300)] dark:[--color-accent-foreground:var(--color-white)]',
+              'violet' => '[--color-accent:var(--color-violet-500)] [--color-accent-content:var(--color-violet-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-violet-500)] dark:[--color-accent-content:var(--color-violet-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'purple' => '[--color-accent:var(--color-purple-500)] [--color-accent-content:var(--color-purple-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-purple-500)] dark:[--color-accent-content:var(--color-purple-300)] dark:[--color-accent-foreground:var(--color-white)]',
+              'fuchsia' => '[--color-accent:var(--color-fuchsia-600)] [--color-accent-content:var(--color-fuchsia-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-fuchsia-600)] dark:[--color-accent-content:var(--color-fuchsia-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'pink' => '[--color-accent:var(--color-pink-600)] [--color-accent-content:var(--color-pink-600)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-pink-600)] dark:[--color-accent-content:var(--color-pink-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              'rose' => '[--color-accent:var(--color-rose-500)] [--color-accent-content:var(--color-rose-500)] [--color-accent-foreground:var(--color-white)] dark:[--color-accent:var(--color-rose-500)] dark:[--color-accent-content:var(--color-rose-400)] dark:[--color-accent-foreground:var(--color-white)]',
+              default => '',
+          } : '')
+          ;
+
+          // Exempt subtle and ghost buttons from receiving border roundness overrides from button.group...
+          $attributes = $attributes->merge([
+              'data-flux-group-target' => ! in_array($variant, ['subtle', 'ghost']),
+          ]);
 @endphp
 
-<flux:with-tooltip :$attributes>
-    <flux:button-or-link :$type :attributes="$attributes->class($classes)" data-flux-button>
-        <?php if ($loading): ?>
+<flux:with-tooltip :$attributes
+>
+    <div @if($shortcut) x-data
+         @keydown.window.{{$shortcut}}.prevent="$refs.{{ $xRef }}.click()"
+        @endif
+    >
+        <flux:button-or-link :$type x-ref="{{ $xRef }}" :attributes="$attributes->class($classes)" data-flux-button>
+            <?php if ($loading): ?>
             <div class="absolute inset-0 flex items-center justify-center opacity-0" data-flux-loading-indicator>
-                <flux:icon icon="loading" :variant="$iconVariant" :class="$iconClasses" />
+                <flux:icon icon="loading" :variant="$iconVariant" :class="$iconClasses"/>
             </div>
-        <?php endif; ?>
+            <?php endif; ?>
 
-        <?php if (is_string($iconLeading) && $iconLeading !== ''): ?>
-            <flux:icon :icon="$iconLeading" :variant="$iconVariant" :class="$iconClasses" />
-        <?php elseif ($iconLeading): ?>
+            <?php if (is_string($iconLeading) && $iconLeading !== ''): ?>
+            <flux:icon :icon="$iconLeading" :variant="$iconVariant" :class="$iconClasses"/>
+            <?php elseif ($iconLeading): ?>
             {{ $iconLeading }}
-        <?php endif; ?>
+            <?php endif; ?>
 
-        <?php if (($loading || $iconLeading || $iconTrailing) && ! $slot->isEmpty()): ?>
+            <?php if (($loading || $iconLeading || $iconTrailing) && !$slot->isEmpty()): ?>
             {{-- If we have a loading indicator, we need to wrap it in a span so it can be a target of *:opacity-0... --}}
             {{-- Also, if we have an icon, we need to wrap it in a span so it can be recognized as a child of the button for :first-child selectors... --}}
             <span>{{ $slot }}</span>
-        <?php else: ?>
+            <?php else: ?>
             {{ $slot }}
-        <?php endif; ?>
+            <?php endif; ?>
 
-        <?php if ($kbd): ?>
+            <?php if ($kbd): ?>
             <div class="text-xs text-zinc-400 dark:text-zinc-400">{{ $kbd }}</div>
-        <?php endif; ?>
+            <?php endif; ?>
 
-        <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
+            <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
             {{-- Adding the extra margin class inline on the icon component below was causing a double up, so it needs to be added here first... --}}
-            <?php $iconClasses->add($square ? '' : '-ms-1'); ?>
-            <flux:icon :icon="$iconTrailing" :variant="$iconTrailingVariant" :class="$iconTrailingClasses" />
-        <?php elseif ($iconTrailing): ?>
+                <?php $iconClasses->add($square ? '' : '-ms-1'); ?>
+            <flux:icon :icon="$iconTrailing" :variant="$iconTrailingVariant" :class="$iconTrailingClasses"/>
+            <?php elseif ($iconTrailing): ?>
             {{ $iconTrailing }}
-        <?php endif; ?>
-    </flux:button-or-link>
+            <?php endif; ?>
+        </flux:button-or-link>
+    </div>
 </flux:with-tooltip>


### PR DESCRIPTION

## What this does

I don't know if that's something that already exists and I haven't made things more complicated, but I use this in any project I make on a daily basis. I wanted to share it with you.
it Adds working keyboard shortcuts to buttons. Flux already shows keyboard hints in tooltips, but this makes them actually **trigger the button action** when pressed.

With `kbd="⌘S"` you get:
- Visual hint: "Save ⌘S" displayed on the button
- **Functional shortcut**: Button actually clicks when Cmd+S is pressed

## Why we need this

Flux tooltips can show `kbd="⌘S"` hints, but the shortcuts don't work. To make them functional, you have to:
1. Write custom Alpine.js code for each button
2. Convert ⌘S symbols into "cmd.s" Alpine format manually
3. Connect keyboard events to button actions yourself

This is tedious and inconsistent across projects.

## How it works

Just add the `kbd` prop to any button:

```php
<flux:button kbd="⌘S" wire:click="save">Save</flux:button>
```

Now when users press Cmd+S, the button automatically clicks and triggers your `wire:click="save"` action.

The shortcut also shows visually on the button so users know it exists.

## More examples

```php
<!-- Simple shortcuts -->
<flux:button kbd="⌘B" wire:click="bold">Bold</flux:button>
<flux:button kbd="⌘I" wire:click="italic">Italic</flux:button>

<!-- Multiple keys -->
<flux:button kbd="⌘⇧Z" wire:click="redo">Redo</flux:button>

<!-- Function keys -->
<flux:button kbd="F5" wire:click="refresh">Refresh</flux:button>
```

## What keys work

- **Mac symbols**: ⌘ ⇧ ⌥ ⌃ (Command, Shift, Option, Control)
- **Special keys**: F1-F12, Enter, Escape, Tab, Arrows
- **Regular keys**: A-Z, 0-9

## Technical details

Added a `ModifierParser` class that converts symbols like ⌘S into Alpine.js format (cmd.s). The button component now wraps itself in a div with Alpine.js keyboard listeners when a `kbd` prop is provided.

## Benefits

- **Easy to use**: Just add one prop
- **Shows shortcuts**: Users can see what keys to press
- **No breaking changes**: Completely optional
- **Works everywhere**: Any button, any action

thanks.