### PR TITLE
Fix nav badge variants

### DIFF
--- a/stubs/resources/views/flux/navbar/badge.blade.php
+++ b/stubs/resources/views/flux/navbar/badge.blade.php
@@ -1,12 +1,36 @@
 @props([
+    'variant' => null,
     'color' => null,
 ])
 
 @php
 $class = Flux::classes()
     ->add('text-xs font-medium rounded-sm px-1 py-0.5')
-    ->add(match ($color) {
-        default => 'text-zinc-700 dark:text-zinc-200 bg-zinc-400/15 dark:bg-white/10',
+    /**
+     * We can't compile classes for each color because of variants color to color and Tailwind's JIT compiler.
+     * We instead need to write out each one by hand. Sorry...
+     */
+    ->add($variant === 'solid' ? match ($color) {
+        default => 'text-white dark:text-white bg-zinc-600 dark:bg-zinc-600',
+        'red' => 'text-white dark:text-white bg-red-500 dark:bg-red-600',
+        'orange' => 'text-white dark:text-white bg-orange-500 dark:bg-orange-600',
+        'amber' => 'text-white dark:text-zinc-950 bg-amber-500 dark:bg-amber-500',
+        'yellow' => 'text-white dark:text-zinc-950 bg-yellow-500 dark:bg-yellow-400',
+        'lime' => 'text-white dark:text-white bg-lime-500 dark:bg-lime-600',
+        'green' => 'text-white dark:text-white bg-green-500 dark:bg-green-600',
+        'emerald' => 'text-white dark:text-white bg-emerald-500 dark:bg-emerald-600',
+        'teal' => 'text-white dark:text-white bg-teal-500 dark:bg-teal-600',
+        'cyan' => 'text-white dark:text-white bg-cyan-500 dark:bg-cyan-600',
+        'sky' => 'text-white dark:text-white bg-sky-500 dark:bg-sky-600',
+        'blue' => 'text-white dark:text-white bg-blue-500 dark:bg-blue-600',
+        'indigo' => 'text-white dark:text-white bg-indigo-500 dark:bg-indigo-600',
+        'violet' => 'text-white dark:text-white bg-violet-500 dark:bg-violet-600',
+        'purple' => 'text-white dark:text-white bg-purple-500 dark:bg-purple-600',
+        'fuchsia' => 'text-white dark:text-white bg-fuchsia-500 dark:bg-fuchsia-600',
+        'pink' => 'text-white dark:text-white bg-pink-500 dark:bg-pink-600',
+        'rose' => 'text-white dark:text-white bg-rose-500 dark:bg-rose-600',
+    } :  match ($color) {
+        default => 'text-zinc-700 dark:text-zinc-200 bg-zinc-400/15 dark:bg-zinc-400/40',
         'red' => 'text-red-700 dark:text-red-200 bg-red-400/20 dark:bg-red-400/40',
         'orange' => 'text-orange-700 dark:text-orange-200 bg-orange-400/20 dark:bg-orange-400/40',
         'amber' => 'text-amber-700 dark:text-amber-200 bg-amber-400/25 dark:bg-amber-400/40',

--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -6,7 +6,6 @@
 @props([
     'iconVariant' => 'outline',
     'iconTrailing' => null,
-    'badgeVariant' => null,
     'badgeColor' => null,
     'variant' => null,
     'iconDot' => null,
@@ -77,6 +76,6 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if (isset($badge) && $badge !== ''): ?>
-        <flux:navbar.badge :color="$badgeColor" :variant="$badgeVariant" class="ms-2">{{ $badge }}</flux:navbar.badge>
+        <flux:navbar.badge :attributes="Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor, 'class' => 'ms-2'])">{{ $badge }}</flux:navbar.badge>
     <?php endif; ?>
 </flux:button-or-link>

--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -6,6 +6,7 @@
 @props([
     'iconVariant' => 'outline',
     'iconTrailing' => null,
+    'badgeVariant' => null,
     'badgeColor' => null,
     'variant' => null,
     'iconDot' => null,
@@ -76,6 +77,6 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if (isset($badge) && $badge !== ''): ?>
-        <flux:navbar.badge :color="$badgeColor" class="ms-2">{{ $badge }}</flux:navbar.badge>
+        <flux:navbar.badge :color="$badgeColor" :variant="$badgeVariant" class="ms-2">{{ $badge }}</flux:navbar.badge>
     <?php endif; ?>
 </flux:button-or-link>

--- a/stubs/resources/views/flux/navlist/badge.blade.php
+++ b/stubs/resources/views/flux/navlist/badge.blade.php
@@ -6,8 +6,31 @@
 @php
 $class = Flux::classes()
     ->add('text-xs font-medium rounded-sm px-1 py-0.5')
-    ->add(match ($color) {
-        default => 'text-zinc-700 dark:text-zinc-200 bg-zinc-400/15 dark:bg-white/10',
+    /**
+     * We can't compile classes for each color because of variants color to color and Tailwind's JIT compiler.
+     * We instead need to write out each one by hand. Sorry...
+     */
+    ->add($variant === 'solid' ? match ($color) {
+        default => 'text-white dark:text-white bg-zinc-600 dark:bg-zinc-600',
+        'red' => 'text-white dark:text-white bg-red-500 dark:bg-red-600',
+        'orange' => 'text-white dark:text-white bg-orange-500 dark:bg-orange-600',
+        'amber' => 'text-white dark:text-zinc-950 bg-amber-500 dark:bg-amber-500',
+        'yellow' => 'text-white dark:text-zinc-950 bg-yellow-500 dark:bg-yellow-400',
+        'lime' => 'text-white dark:text-white bg-lime-500 dark:bg-lime-600',
+        'green' => 'text-white dark:text-white bg-green-500 dark:bg-green-600',
+        'emerald' => 'text-white dark:text-white bg-emerald-500 dark:bg-emerald-600',
+        'teal' => 'text-white dark:text-white bg-teal-500 dark:bg-teal-600',
+        'cyan' => 'text-white dark:text-white bg-cyan-500 dark:bg-cyan-600',
+        'sky' => 'text-white dark:text-white bg-sky-500 dark:bg-sky-600',
+        'blue' => 'text-white dark:text-white bg-blue-500 dark:bg-blue-600',
+        'indigo' => 'text-white dark:text-white bg-indigo-500 dark:bg-indigo-600',
+        'violet' => 'text-white dark:text-white bg-violet-500 dark:bg-violet-600',
+        'purple' => 'text-white dark:text-white bg-purple-500 dark:bg-purple-600',
+        'fuchsia' => 'text-white dark:text-white bg-fuchsia-500 dark:bg-fuchsia-600',
+        'pink' => 'text-white dark:text-white bg-pink-500 dark:bg-pink-600',
+        'rose' => 'text-white dark:text-white bg-rose-500 dark:bg-rose-600',
+    } :  match ($color) {
+        default => 'text-zinc-700 dark:text-zinc-200 bg-zinc-400/15 dark:bg-zinc-400/40',
         'red' => 'text-red-700 dark:text-red-200 bg-red-400/20 dark:bg-red-400/40',
         'orange' => 'text-orange-700 dark:text-orange-200 bg-orange-400/20 dark:bg-orange-400/40',
         'amber' => 'text-amber-700 dark:text-amber-200 bg-amber-400/25 dark:bg-amber-400/40',
@@ -25,49 +48,6 @@ $class = Flux::classes()
         'fuchsia' => 'text-fuchsia-700 dark:text-fuchsia-200 bg-fuchsia-400/20 dark:bg-fuchsia-400/40',
         'pink' => 'text-pink-700 dark:text-pink-200 bg-pink-400/20 dark:bg-pink-400/40',
         'rose' => 'text-rose-700 dark:text-rose-200 bg-rose-400/20 dark:bg-rose-400/40',
-    })
-    /**
-     * We can't compile classes for each color because of variants color to color and Tailwind's JIT compiler.
-     * We instead need to write out each one by hand. Sorry...
-     */
-    ->add($variant === 'solid' ? match ($color) {
-        default => 'text-white dark:text-white bg-zinc-600 dark:bg-zinc-600 [&:is(button)]:hover:bg-zinc-700 dark:[button]:hover:bg-zinc-500',
-        'red' => 'text-white dark:text-white bg-red-500 dark:bg-red-600 [&:is(button)]:hover:bg-red-600 dark:[button]:hover:bg-red-500',
-        'orange' => 'text-white dark:text-white bg-orange-500 dark:bg-orange-600 [&:is(button)]:hover:bg-orange-600 dark:[button]:hover:bg-orange-500',
-        'amber' => 'text-white dark:text-zinc-950 bg-amber-500 dark:bg-amber-500 [&:is(button)]:hover:bg-amber-600 dark:[button]:hover:bg-amber-400',
-        'yellow' => 'text-white dark:text-zinc-950 bg-yellow-500 dark:bg-yellow-400 [&:is(button)]:hover:bg-yellow-600 dark:[button]:hover:bg-yellow-300',
-        'lime' => 'text-white dark:text-white bg-lime-500 dark:bg-lime-600 [&:is(button)]:hover:bg-lime-600 dark:[button]:hover:bg-lime-500',
-        'green' => 'text-white dark:text-white bg-green-500 dark:bg-green-600 [&:is(button)]:hover:bg-green-600 dark:[button]:hover:bg-green-500',
-        'emerald' => 'text-white dark:text-white bg-emerald-500 dark:bg-emerald-600 [&:is(button)]:hover:bg-emerald-600 dark:[button]:hover:bg-emerald-500',
-        'teal' => 'text-white dark:text-white bg-teal-500 dark:bg-teal-600 [&:is(button)]:hover:bg-teal-600 dark:[button]:hover:bg-teal-500',
-        'cyan' => 'text-white dark:text-white bg-cyan-500 dark:bg-cyan-600 [&:is(button)]:hover:bg-cyan-600 dark:[button]:hover:bg-cyan-500',
-        'sky' => 'text-white dark:text-white bg-sky-500 dark:bg-sky-600 [&:is(button)]:hover:bg-sky-600 dark:[button]:hover:bg-sky-500',
-        'blue' => 'text-white dark:text-white bg-blue-500 dark:bg-blue-600 [&:is(button)]:hover:bg-blue-600 dark:[button]:hover:bg-blue-500',
-        'indigo' => 'text-white dark:text-white bg-indigo-500 dark:bg-indigo-600 [&:is(button)]:hover:bg-indigo-600 dark:[button]:hover:bg-indigo-500',
-        'violet' => 'text-white dark:text-white bg-violet-500 dark:bg-violet-600 [&:is(button)]:hover:bg-violet-600 dark:[button]:hover:bg-violet-500',
-        'purple' => 'text-white dark:text-white bg-purple-500 dark:bg-purple-600 [&:is(button)]:hover:bg-purple-600 dark:[button]:hover:bg-purple-500',
-        'fuchsia' => 'text-white dark:text-white bg-fuchsia-500 dark:bg-fuchsia-600 [&:is(button)]:hover:bg-fuchsia-600 dark:[button]:hover:bg-fuchsia-500',
-        'pink' => 'text-white dark:text-white bg-pink-500 dark:bg-pink-600 [&:is(button)]:hover:bg-pink-600 dark:[button]:hover:bg-pink-500',
-        'rose' => 'text-white dark:text-white bg-rose-500 dark:bg-rose-600 [&:is(button)]:hover:bg-rose-600 dark:[button]:hover:bg-rose-500',
-    } :  match ($color) {
-        default => 'text-zinc-700 [&_button]:text-zinc-700! dark:text-zinc-200 dark:[&_button]:text-zinc-200! bg-zinc-400/15 dark:bg-zinc-400/40 [&:is(button)]:hover:bg-zinc-400/25 dark:[button]:hover:bg-zinc-400/50',
-        'red' => 'text-red-700 [&_button]:text-red-700! dark:text-red-200 dark:[&_button]:text-red-200! bg-red-400/20 dark:bg-red-400/40 [&:is(button)]:hover:bg-red-400/30 dark:[button]:hover:bg-red-400/50',
-        'orange' => 'text-orange-700 [&_button]:text-orange-700! dark:text-orange-200 dark:[&_button]:text-orange-200! bg-orange-400/20 dark:bg-orange-400/40 [&:is(button)]:hover:bg-orange-400/30 dark:[button]:hover:bg-orange-400/50',
-        'amber' => 'text-amber-700 [&_button]:text-amber-700! dark:text-amber-200 dark:[&_button]:text-amber-200! bg-amber-400/25 dark:bg-amber-400/40 [&:is(button)]:hover:bg-amber-400/40 dark:[button]:hover:bg-amber-400/50',
-        'yellow' => 'text-yellow-800 [&_button]:text-yellow-800! dark:text-yellow-200 dark:[&_button]:text-yellow-200! bg-yellow-400/25 dark:bg-yellow-400/40 [&:is(button)]:hover:bg-yellow-400/40 dark:[button]:hover:bg-yellow-400/50',
-        'lime' => 'text-lime-800 [&_button]:text-lime-800! dark:text-lime-200 dark:[&_button]:text-lime-200! bg-lime-400/25 dark:bg-lime-400/40 [&:is(button)]:hover:bg-lime-400/35 dark:[button]:hover:bg-lime-400/50',
-        'green' => 'text-green-800 [&_button]:text-green-800! dark:text-green-200 dark:[&_button]:text-green-200! bg-green-400/20 dark:bg-green-400/40 [&:is(button)]:hover:bg-green-400/30 dark:[button]:hover:bg-green-400/50',
-        'emerald' => 'text-emerald-800 [&_button]:text-emerald-800! dark:text-emerald-200 dark:[&_button]:text-emerald-200! bg-emerald-400/20 dark:bg-emerald-400/40 [&:is(button)]:hover:bg-emerald-400/30 dark:[button]:hover:bg-emerald-400/50',
-        'teal' => 'text-teal-800 [&_button]:text-teal-800! dark:text-teal-200 dark:[&_button]:text-teal-200! bg-teal-400/20 dark:bg-teal-400/40 [&:is(button)]:hover:bg-teal-400/30 dark:[button]:hover:bg-teal-400/50',
-        'cyan' => 'text-cyan-800 [&_button]:text-cyan-800! dark:text-cyan-200 dark:[&_button]:text-cyan-200! bg-cyan-400/20 dark:bg-cyan-400/40 [&:is(button)]:hover:bg-cyan-400/30 dark:[button]:hover:bg-cyan-400/50',
-        'sky' => 'text-sky-800 [&_button]:text-sky-800! dark:text-sky-200 dark:[&_button]:text-sky-200! bg-sky-400/20 dark:bg-sky-400/40 [&:is(button)]:hover:bg-sky-400/30 dark:[button]:hover:bg-sky-400/50',
-        'blue' => 'text-blue-800 [&_button]:text-blue-800! dark:text-blue-200 dark:[&_button]:text-blue-200! bg-blue-400/20 dark:bg-blue-400/40 [&:is(button)]:hover:bg-blue-400/30 dark:[button]:hover:bg-blue-400/50',
-        'indigo' => 'text-indigo-700 [&_button]:text-indigo-700! dark:text-indigo-200 dark:[&_button]:text-indigo-200! bg-indigo-400/20 dark:bg-indigo-400/40 [&:is(button)]:hover:bg-indigo-400/30 dark:[button]:hover:bg-indigo-400/50',
-        'violet' => 'text-violet-700 [&_button]:text-violet-700! dark:text-violet-200 dark:[&_button]:text-violet-200! bg-violet-400/20 dark:bg-violet-400/40 [&:is(button)]:hover:bg-violet-400/30 dark:[button]:hover:bg-violet-400/50',
-        'purple' => 'text-purple-700 [&_button]:text-purple-700! dark:text-purple-200 dark:[&_button]:text-purple-200! bg-purple-400/20 dark:bg-purple-400/40 [&:is(button)]:hover:bg-purple-400/30 dark:[button]:hover:bg-purple-400/50',
-        'fuchsia' => 'text-fuchsia-700 [&_button]:text-fuchsia-700! dark:text-fuchsia-200 dark:[&_button]:text-fuchsia-200! bg-fuchsia-400/20 dark:bg-fuchsia-400/40 [&:is(button)]:hover:bg-fuchsia-400/30 dark:[button]:hover:bg-fuchsia-400/50',
-        'pink' => 'text-pink-700 [&_button]:text-pink-700! dark:text-pink-200 dark:[&_button]:text-pink-200! bg-pink-400/20 dark:bg-pink-400/40 [&:is(button)]:hover:bg-pink-400/30 dark:[button]:hover:bg-pink-400/50',
-        'rose' => 'text-rose-700 [&_button]:text-rose-700! dark:text-rose-200 dark:[&_button]:text-rose-200! bg-rose-400/20 dark:bg-rose-400/40 [&:is(button)]:hover:bg-rose-400/30 dark:[button]:hover:bg-rose-400/50',
     });
 @endphp
 

--- a/stubs/resources/views/flux/navlist/item.blade.php
+++ b/stubs/resources/views/flux/navlist/item.blade.php
@@ -6,7 +6,6 @@
 @props([
     'iconVariant' => 'outline',
     'iconTrailing' => null,
-    'badgeVariant' => null,
     'badgeColor' => null,
     'variant' => null,
     'iconDot' => null,
@@ -85,6 +84,6 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if (isset($badge) && $badge !== ''): ?>
-        <flux:navlist.badge :color="$badgeColor" :variant="$badgeVariant">{{ $badge }}</flux:navlist.badge>
+        <flux:navlist.badge :attributes="Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor])">{{ $badge }}</flux:navlist.badge>
     <?php endif; ?>
 </flux:button-or-link>


### PR DESCRIPTION
This PR is an extension of PR #1690 which added support for `badgeVariant` to `navlist.item` and added solid variant styles to `navlist.badge`.

That PR had a duplication of styles in `navlist.badge` and some extra copied styles from the main badge component that aren't used in the nav badges. So this PR cleans that up.

It also only applied the changes to the navlist and not the navbar, so this PR also adds support for badge variant to the `navbar.item` component and adds the solid variant classes to the `navbar.badge`.

Finally this PR refactors both `navbar.item` and `navlist.item` away from using `badgeVariant` as a prop and instead makes use of badge attribute forwarding, so instead we can do `badge:variant` to pass through the variant.

Now the following is possible for both navbar and navlist:

```blade
<flux:navbar.item href="#" badge="Pro" badge:variant="solid" badge:color="lime">Calendar</flux:navbar.item>

<flux:navlist.item href="#" badge="Pro" badge:variant="solid" badge:color="lime">Calendar</flux:navlist.item>
```

Fixes livewire/flux#