### PR TITLE
Add named error bag support to error component

### DIFF
--- a/stubs/resources/views/flux/error.blade.php
+++ b/stubs/resources/views/flux/error.blade.php
@@ -2,13 +2,15 @@
     'name' => null,
     'message' => null,
     'nested' => true,
+    'bag' => 'default',
 ])
 
 @php
-$message ??= $name ? $errors->first($name) : null;
+$errorBag = $errors->getBag($bag);
+$message ??= $name ? $errorBag->first($name) : null;
 
 if ($name && (is_null($message) || $message === '') && filter_var($nested, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== false) {
-    $message = $errors->first($name . '.*');
+    $message = $errorBag->first($name . '.*');
 }
 
 $classes = Flux::classes('mt-3 text-sm font-medium text-red-500 dark:text-red-400')


### PR DESCRIPTION
# The scenario

Currently if you are using Laravel's named error bag feature, the error component can't show errors from a named error bag.

```blade
@php
    $errorBag = $errors->getBag('other');
    $errorBag->add('name', 'Other Bag: Name is required');

    $errors->put('other', $errorBag);
@endphp

<flux:error name="name" />
```

# The problem

The issue is that the error component doesn't support named error bags. It accesses error messages by calling `$errors->first($name)` which will always resolve from the `default` error bag.

# The solution

This PR adds a `bag` prop to the error component so a named error bag can be specified.

```blade
<flux:error name="name" bag="other" />
```

I originally had `errorBag`, but I didn't like the multiword, so changed it to just `bag`.

Fixes livewire/flux#1841