### PR TITLE
Remove whitespace-nowrap from navlist.item to allow wrapping on mobile

### DIFF
--- a/stubs/resources/views/flux/navlist/item.blade.php
+++ b/stubs/resources/views/flux/navlist/item.blade.php
@@ -74,7 +74,7 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if ($slot->isNotEmpty()): ?>
-        <div class="flex-1 text-sm font-medium leading-none whitespace-nowrap [[data-nav-footer]_&]:hidden [[data-nav-sidebar]_[data-nav-footer]_&]:block" data-content>{{ $slot }}</div>
+        <div class="flex-1 text-sm font-medium leading-none [[data-nav-footer]_&]:hidden [[data-nav-sidebar]_[data-nav-footer]_&]:block" data-content>{{ $slot }}</div>
     <?php endif; ?>
 
     <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>


### PR DESCRIPTION
# The scenario

Using the <flux:sidebar stackable> component and having <flux:navlist.item> with a long text.

# The problem

<img width="257" height="120" alt="image" src="https://github.com/user-attachments/assets/d32d6448-f3ec-43a9-ad0b-e5d3c8a07471" />

The text does an overflow instead of being wrapped on small screens. And the way the component was created prevented me to override the tailwind class.

# The solution

<img width="256" height="122" alt="image" src="https://github.com/user-attachments/assets/c4046511-2e5b-4678-8b9a-6dea2c3cac32" />

I had to publish the component (navlist.item) and edit manually the tailwind class. It worked well after the update.



Fixes livewire/flux#