### PR TITLE
Fix toast stack dark mode navigate flash

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -132,12 +132,12 @@ ui-toast {
     [data-flux-toast-dialog] {
         opacity: 0;
         transform: translate(0);
-        transition: all 0.35s allow-discrete;
+        transition: opacity 0.35s allow-discrete, transform 0.35s allow-discrete, height 0.35s allow-discrete;
 
         &.showing {
             opacity: 1;
             transform: translate(0);
-            transition: all 0.2s allow-discrete;
+            transition: opacity 0.2s allow-discrete, transform 0.2s allow-discrete, height 0.2s allow-discrete;
         }
     }
 

--- a/dist/flux.css
+++ b/dist/flux.css
@@ -211,7 +211,7 @@ ui-toast-group {
     [data-flux-toast-dialog] {
         position: absolute;
         transform: translate(0);
-        transition: all 0.35s allow-discrete;
+        transition: opacity 0.35s allow-discrete, transform 0.35s allow-discrete, height 0.35s allow-discrete;
 
         [position*="top"] & {
             top: 0;
@@ -224,7 +224,7 @@ ui-toast-group {
         }
 
         & > * {
-            transition: all 0.35s allow-discrete;
+            transition: opacity 0.35s allow-discrete, transform 0.35s allow-discrete, height 0.35s allow-discrete;
         }
     }
 }


### PR DESCRIPTION
# The scenario

Currently if you have a toast stack inside `@persist` with dark mode enabled, and you navigate to a new page, the toast will flash white for a moment before during dark again.

![Screenshot 2025-08-27 at 11 45 39AM](https://github.com/user-attachments/assets/1eca850f-97c8-4908-97cd-f14294418206)

```blade
@persist('toast')
    <flux:toast.group>
        <flux:toast /> 
    </flux:toast.group>
@endpersist
```

```blade
<div>
    <flux:button x-on:click="window.Flux.toast({
        heading: 'Changes saved',
        text: 'Your changes have been saved.',
        variant: 'success',
        duration: 0,
    })">
        Dispatch toast
    </flux:button>
    <flux:link href="/toasts-flash" class="block! mt-4" wire:navigate>Navigate to toasts page</flux:link>
</div>
```

# The problem

This issue sent me down a rabbit hole of navigate requests and dark mode flashes which there is a deeper issue in how Livewire and Flux handle re-applying dark mode after a navigate (see #1501 and #1842). But I was finding, for the most part, most elements would retain their dark styling between navigates if the navigate happened quickly enough.

But where as for toasts in a stack, no matter what I changed, they would always flash white.

As it turns out, the issue is that we are transitioning `all` on the toast dialog element as that is causing the colours to also transition. So in the moment when navigate applies the new dom and Flux hasn't re-added `dark` to the html element, the toast is white and then when `dark` is added, it's transitioning to dark styles, hence why we notice the flash.

```css
[data-flux-toast-dialog] {
     transition: all 0.35s allow-discrete;
}
```

# The solution

The solution is to be more specific with the transition CSS styles to ensure we're only transitioning the properties that we actually need.

```css
[data-flux-toast-dialog] {
    transition: opacity 0.35s allow-discrete, transform 0.35s allow-discrete, height 0.35s allow-discrete;
}
```

Now there is no flashing for toasts on navigate.

![Screenshot 2025-08-27 at 11 53 51AM](https://github.com/user-attachments/assets/749a7cf7-feee-4614-93fd-04aeccdabde9)

Fixes livewire/flux#1887