### PR TITLE
Add `@pure` annotation to Lucide IconCommand stub

### DIFF
--- a/src/Console/IconCommand.php
+++ b/src/Console/IconCommand.php
@@ -95,6 +95,8 @@ class IconCommand extends Command
             SVG)->toString();
 
         $stub = <<<'HTML'
+        @pure
+
         {{-- Credit: Lucide (https://lucide.dev) --}}
 
         @props([


### PR DESCRIPTION
When creating a lucide icon using the artisan command, the `@pure` directive was missing.