### PR TITLE
Add icons support to switch component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ composer.lock
 .phpunit.result.cache
 node_modules/**
 test-results/**
-.idea

--- a/stubs/resources/views/flux/switch.blade.php
+++ b/stubs/resources/views/flux/switch.blade.php
@@ -10,61 +10,61 @@
 ])
 
 @php
-    // We only want to show the name attribute it has been set manually
-    // but not if it has been set from the `wire:model` attribute...
-    $showName = isset($name);
-    if (! isset($name)) {
-        $name = $attributes->whereStartsWith('wire:model')->first();
-    }
+// We only want to show the name attribute it has been set manually
+// but not if it has been set from the `wire:model` attribute...
+$showName = isset($name);
+if (! isset($name)) {
+    $name = $attributes->whereStartsWith('wire:model')->first();
+}
 
-    // Icons: show ONLY if `icons` attribute is present.
-    if ($icons) {
-        $hasIconOnAttr = $attributes->has('icon:on');
-        $hasIconOffAttr = $attributes->has('icon:off');
+// Icons: show ONLY if `icons` attribute is present.
+if ($icons) {
+    $hasIconOnAttr = $attributes->has('icon:on');
+    $hasIconOffAttr = $attributes->has('icon:off');
 
-        if ($hasIconOnAttr && $hasIconOffAttr) {
-            $iconOn = $attributes->pluck('icon:on');
-            $iconOff = $attributes->pluck('icon:off');
-        } elseif ($hasIconOnAttr) {
-            $iconOn = $attributes->pluck('icon:on');
-            $iconOff = null;
-        } elseif ($hasIconOffAttr) {
-            $iconOn = null;
-            $iconOff = $attributes->pluck('icon:off');
-        } else {
-            $iconOn = is_object($iconOn) ? $iconOn?->attributes?->pluck('on') : $iconOn;
-            $iconOff = is_object($iconOff) ? $iconOff?->attributes?->pluck('off') : $iconOff;
-        }
-    } else {
-        $iconOn = null;
+    if ($hasIconOnAttr && $hasIconOffAttr) {
+        $iconOn = $attributes->pluck('icon:on');
+        $iconOff = $attributes->pluck('icon:off');
+    } elseif ($hasIconOnAttr) {
+        $iconOn = $attributes->pluck('icon:on');
         $iconOff = null;
+    } elseif ($hasIconOffAttr) {
+        $iconOn = null;
+        $iconOff = $attributes->pluck('icon:off');
+    } else {
+        $iconOn = is_object($iconOn) ? $iconOn?->attributes?->pluck('on') : $iconOn;
+        $iconOff = is_object($iconOff) ? $iconOff?->attributes?->pluck('off') : $iconOff;
     }
+} else {
+    $iconOn = null;
+    $iconOff = null;
+}
 
-    $classes = Flux::classes()
-        ->add('group h-5 w-8 min-w-8 relative inline-flex items-center outline-offset-2')
-        ->add('rounded-full')
-        ->add('transition')
-        ->add('bg-zinc-800/15 [&[disabled]]:opacity-50 dark:bg-transparent dark:border dark:border-white/20 dark:[&[disabled]]:border-white/10')
-        ->add('[print-color-adjust:exact]')
-        ->add([
-            'data-checked:bg-(--color-accent)',
-            'data-checked:border-0',
-        ])
-        ;
+$classes = Flux::classes()
+    ->add('group h-5 w-8 min-w-8 relative inline-flex items-center outline-offset-2')
+    ->add('rounded-full')
+    ->add('transition')
+    ->add('bg-zinc-800/15 [&[disabled]]:opacity-50 dark:bg-transparent dark:border dark:border-white/20 dark:[&[disabled]]:border-white/10')
+    ->add('[print-color-adjust:exact]')
+    ->add([
+        'data-checked:bg-(--color-accent)',
+        'data-checked:border-0',
+    ])
+    ;
 
-    $indicatorClasses = Flux::classes()
-        ->add('grid place-items-center')
-        ->add('size-3.5')
-        ->add('rounded-full')
-        ->add('transition translate-x-[3px] dark:translate-x-[2px] rtl:-translate-x-[3px] dark:rtl:-translate-x-[2px]')
-        ->add('bg-white')
-        ->add([
-            'group-data-checked:translate-x-[15px] rtl:group-data-checked:-translate-x-[15px]',
-            'group-data-checked:bg-(--color-accent-foreground)',
-        ]);
+$indicatorClasses = Flux::classes()
+    ->add('grid place-items-center')
+    ->add('size-3.5')
+    ->add('rounded-full')
+    ->add('transition translate-x-[3px] dark:translate-x-[2px] rtl:-translate-x-[3px] dark:rtl:-translate-x-[2px]')
+    ->add('bg-white')
+    ->add([
+        'group-data-checked:translate-x-[15px] rtl:group-data-checked:-translate-x-[15px]',
+        'group-data-checked:bg-(--color-accent-foreground)',
+    ]);
 
-    $iconClasses = Flux::classes()
-        ->add('size-2.5');
+$iconClasses = Flux::classes()
+    ->add('size-2.5');
 @endphp
 
 @if ($align === 'left' || $align === 'start')


### PR DESCRIPTION
# The scenario

The Switch component only provides the on/off status via the background

`<flux:switch />`
<img width="138" height="52" alt="Screenshot 2025-08-30 alle 11 29 00" src="https://github.com/user-attachments/assets/10f80d57-61bb-4763-a01a-1df8e9bc09bd" />

# The problem

The current Switch component only provides a simple toggle state without any visual hint beyond the background color.
This leads to two main issues:
Low visual clarity: Users may not always understand the meaning of the toggle (e.g., “enabled” vs “disabled”) without an additional label.
Limited customization: Unlike other components in Flux, the Switch did not support icons or variants, forcing developers to manually extend or override it when they wanted richer UI/UX.

This PR adds support for icons within the Switch component.

# The solution

This PR extends the Switch component with icon support for both states:
	•	Developers can now display an icon for the on state and another for the off state.
	•	Both icons are fully customizable: you can choose the specific icon and its style variant (outline, solid, micro (default) and mini).
	•	Maintains backward compatibility: if no icons are provided, the switch behaves as before.


https://github.com/user-attachments/assets/71239651-b706-4186-ac93-ae5e4cbdb23d

Ecco la lista dei componenti utilizzati nel video:
```
<flux:switch label="Normal state" align="start"/>
<flux:switch icons label="With default icons" align="start"/>
<flux:switch icons icon:off="bell-slash" label="Only with icon:off" align="start" />
<flux:switch icons icon:on="bell" label="Only with icon:on" align="start" />
<flux:switch icons icon:on="bell" icon:off="bell-slash" icon:variant="outline" label="With custom icons and outline variant" align="start" />
```

	
## Benefits
	•	Improves clarity of toggle meaning by providing visual context.
	•	Offers more flexibility and aligns the Switch with the customization level of other Flux components.
	•	Makes the component easier to use out of the box in real-world applications without requiring overrides.

Everything is working correctly, there are no malfunctions, and no changes are required.

Everything also works in dark mode.

Thanks :)

Fixes livewire/flux#