### PR TITLE
Reassigns tooltip

### DIFF
--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -18,7 +18,7 @@
 ])
 
 @php
-$tooltip = $tooltip ?? $slot->isNotEmpty() ? (string) $slot : null;
+$tooltip ??= $slot->isNotEmpty() ? (string) $slot : null;
 
 // Size-up icons in square/icon-only buttons...
 $iconClasses = Flux::classes('size-4');


### PR DESCRIPTION
# The scenario

From the collapsible sidebar demo:

```blade
<flux:sidebar.item icon="home" href="#" current>Home</flux:sidebar.item>
```
The tooltip here will be Home, as pulled from the component slot. 

```blade
<flux:sidebar.item icon="home" href="#" tooltip="Dashboard" current>Home</flux:sidebar.item>
```
The tooltip here will still be Home, as `$tooltip` is overwritten by `$slot` in the component.

# The problem

```blade
$tooltip = $tooltip ?? $slot->isNotEmpty() ? (string) $slot : null;
```

While this looks right, it's actually setting the `$slot` value to `$tooltip`.

# The solution

```blade
$tooltip ??= $slot->isNotEmpty() ? (string) $slot : null;
```

Shifting to a slightly modified syntax solves the issue.

Example screenshot provided from simplified tinkerwell code, with result.

<img width="404" height="310" alt="Image" src="https://github.com/user-attachments/assets/ae84e5dd-efea-4319-84ff-9021a43269e6" />

Fixes livewire/flux#1914