### PR TITLE
Add sidebar group icon dropdowns

### DIFF
--- a/stubs/resources/views/flux/sidebar/group.blade.php
+++ b/stubs/resources/views/flux/sidebar/group.blade.php
@@ -34,6 +34,20 @@
                 {{ $slot }}
             </div>
         </ui-disclosure>
+
+        <flux:dropdown hover class="in-data-flux-sidebar-on-mobile:hidden not-in-data-flux-sidebar-collapsed-desktop:hidden" position="right" align="start" data-flux-sidebar-group-dropdown>
+            <button type="button" class="border-1 border-transparent w-full px-3 h-8 flex items-center group/disclosure-button mb-[2px] rounded-lg in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:justify-center hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
+                <div class="relative">
+                <flux:icon :icon="$icon" :variant="$iconVariant" class="size-4" />
+                </div>
+            </button>
+
+            <flux:menu>
+                <flux:menu.group :$heading>
+                    {{ $slot }}
+                </flux:menu.group>
+            </flux:menu>
+        </flux:dropdown>
     <?php else: ?>
         <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} @if ($expanded === true) open @endif data-flux-sidebar-group>
             <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button mb-[2px] rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">

--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -41,6 +41,10 @@ $classes = Flux::classes()
             'hover:text-zinc-800 dark:hover:text-white',
         ],
     })
+    // Override the default styles to match dropdowns for when the item is inside a collapsed group dropdown...
+    ->add('in-data-flux-sidebar-group-dropdown:w-auto! in-data-flux-sidebar-group-dropdown:px-2!')
+    ->add('in-data-flux-sidebar-group-dropdown:text-zinc-800! in-data-flux-sidebar-group-dropdown:bg-white! in-data-flux-sidebar-group-dropdown:hover:bg-zinc-50!')
+    ->add('dark:in-data-flux-sidebar-group-dropdown:text-white! dark:in-data-flux-sidebar-group-dropdown:bg-transparent! dark:in-data-flux-sidebar-group-dropdown:hover:bg-zinc-600!')
     ;
 @endphp
 
@@ -64,22 +68,22 @@ $classes = Flux::classes()
 
         <?php if ($slot->isNotEmpty()): ?>
             <div class="
-                in-data-flux-sidebar-collapsed-desktop:hidden
+                in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-sidebar-group-dropdown:hidden
                 flex-1 text-sm font-medium leading-none whitespace-nowrap [[data-nav-footer]_&]:hidden [[data-nav-sidebar]_[data-nav-footer]_&]:block" data-content>{{ $slot }}</div>
         <?php endif; ?>
 
         <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
-            <flux:icon :icon="$iconTrailing" :variant="$iconVariant" class="in-data-flux-sidebar-collapsed-desktop:hidden size-4!" />
+            <flux:icon :icon="$iconTrailing" :variant="$iconVariant" class="in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-sidebar-group-dropdown:hidden size-4!" />
         <?php elseif ($iconTrailing): ?>
             {{ $iconTrailing }}
         <?php endif; ?>
 
         <?php if (isset($badge) && $badge !== ''): ?>
-            <flux:navlist.badge :attributes="Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor])" class="in-data-flux-sidebar-collapsed-desktop:hidden">{{ $badge }}</flux:navlist.badge>
+            <flux:navlist.badge :attributes="Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor])" class="in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-sidebar-group-dropdown:hidden">{{ $badge }}</flux:navlist.badge>
         <?php endif; ?>
     </flux:button-or-link>
 
-    <flux:tooltip.content :kbd="$tooltipKbd" class="not-in-data-flux-sidebar-collapsed-desktop:hidden cursor-default">
+    <flux:tooltip.content :kbd="$tooltipKbd" class="not-in-data-flux-sidebar-collapsed-desktop:hidden in-data-flux-sidebar-group-dropdown:hidden cursor-default">
         {{ $tooltip }}
     </flux:tooltip.content>
 </flux:tooltip>


### PR DESCRIPTION
# The scenario

Currently, with the new collapsible sidebar, if we have a sidebar group, the group disappears when the sidebar is collapsed.

![Screenshot 2025-09-05 at 12 40 36PM](https://github.com/user-attachments/assets/dddef029-858d-405b-a0fa-5e13e1b8b620)

# The problem

The problem is that we have no handling for what to do with a group when it is collapsed. Unlike other sidebar items, which are still clickable to navigate when collapsed, a group needs extra handling as at the moment clicking it will just expand/collapse the group but nothing can be seen.

# The solution

The solution is to add support for showing a sidebar group's items in a dropdown when the sidebar is collapsed. The dropdown will open when the group's icon is hovered, which feels natural as the tooltips also appear on hover.

**Note:** One thing to note, the `sidebar.group` needs to have an icon (not the default chevron) otherwise it won't be shown, because a stack of chevrons won't look great and they have nothing to expand/collapse. You can see in the example, the favourites group has a "star" icon.

![Screenshot 2025-09-05 at 12 38 15PM](https://github.com/user-attachments/assets/cf3b4d41-92e9-48c7-8bbf-256a056e08d9)

Fixes livewire/flux#1917
Fixes livewire/flux#1919