### PR TITLE
Fix sidebar RTL bugs

### DIFF
--- a/stubs/resources/views/flux/sidebar/index.blade.php
+++ b/stubs/resources/views/flux/sidebar/index.blade.php
@@ -32,7 +32,7 @@ if ($collapsibleOnMobile) {
     ])->class([
         // Prevent mobile sidebar from flashing on-load...
         'max-lg:data-flux-sidebar-cloak:hidden',
-        'data-flux-sidebar-on-mobile:data-flux-sidebar-collapsed-mobile:-translate-x-full data-flux-sidebar-on-mobile:data-flux-sidebar-collapsed-mobile:rtl:-translate-x-full',
+        'data-flux-sidebar-on-mobile:data-flux-sidebar-collapsed-mobile:-translate-x-full data-flux-sidebar-on-mobile:data-flux-sidebar-collapsed-mobile:rtl:translate-x-full',
         'z-20! data-flux-sidebar-on-mobile:start-0! data-flux-sidebar-on-mobile:fixed! data-flux-sidebar-on-mobile:top-0! data-flux-sidebar-on-mobile:min-h-dvh! data-flux-sidebar-on-mobile:max-h-dvh!'
     ]);
 }

--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -26,7 +26,7 @@ $iconClasses = Flux::classes('size-4');
 $classes = Flux::classes()
     ->add('h-8 in-data-flux-sidebar-on-mobile:h-10 relative flex items-center gap-3 rounded-lg')
     ->add('in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:justify-center')
-    ->add('py-0 text-start w-full px-3 has-data-flux-navlist-badge:not-in-data-flux-sidebar-collapsed-desktop:pr-1.5 my-px')
+    ->add('py-0 text-start w-full px-3 has-data-flux-navlist-badge:not-in-data-flux-sidebar-collapsed-desktop:pe-1.5 my-px')
     ->add('text-zinc-500 dark:text-white/80')
     ->add(match ($accent) {
         true => [


### PR DESCRIPTION
# The problem

Currently when using RTL, there is a small alignment bug when using badges and on mobile, it translates the wrong way.

# The solution

The solution is to fix the padding so it uses RTL safe values `pe` instead of `pr` and fix the RTL translate on mobile so it translates off the screen to the right.

Fixes livewire/flux#