### PR TITLE
Add support for sidebar group icon slot

### DIFF
--- a/stubs/resources/views/flux/sidebar/group.blade.php
+++ b/stubs/resources/views/flux/sidebar/group.blade.php
@@ -17,7 +17,11 @@
         <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} @if ($expanded === true) open @endif data-flux-sidebar-group>
             <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button mb-[2px] rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
                 <div class="px-3">
-                    <flux:icon :icon="$icon" :variant="$iconVariant" class="size-4" />
+                    <?php if (is_string($icon) && $icon !== ''): ?>
+                        <flux:icon :icon="$icon" :variant="$iconVariant" class="size-4" />
+                    <?php else: ?>
+                        {{ $icon }}
+                    <?php endif; ?>
                 </div>
 
                 <span class="flex-1 text-left rtl:text-right text-sm font-medium leading-none">{{ $heading }}</span>
@@ -38,7 +42,11 @@
         <flux:dropdown hover class="in-data-flux-sidebar-on-mobile:hidden not-in-data-flux-sidebar-collapsed-desktop:hidden" position="right" align="start" data-flux-sidebar-group-dropdown>
             <button type="button" class="border-1 border-transparent w-full px-3 h-8 flex items-center group/disclosure-button mb-[2px] rounded-lg in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:justify-center hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
                 <div class="relative">
-                <flux:icon :icon="$icon" :variant="$iconVariant" class="size-4" />
+                    <?php if (is_string($icon) && $icon !== ''): ?>
+                        <flux:icon :icon="$icon" :variant="$iconVariant" class="size-4" />
+                    <?php else: ?>
+                        {{ $icon }}
+                    <?php endif; ?>
                 </div>
             </button>
 


### PR DESCRIPTION
# The problem

Currently, you can pass icons as a slot on a sidebar item component, but you can't do it on a sidebar group component. Which means you can't use custom icons with the sidebar group.

# The solution

The solution is to add icon slot support to sidebar group, so custom icons can be used.

Fixes livewire/flux#1925