### PR TITLE
Fix sidebar nested groups in icon collapsed view

### DIFF
--- a/stubs/resources/views/flux/sidebar/group.blade.php
+++ b/stubs/resources/views/flux/sidebar/group.blade.php
@@ -41,7 +41,7 @@
 
         <flux:dropdown hover class="in-data-flux-sidebar-on-mobile:hidden not-in-data-flux-sidebar-collapsed-desktop:hidden" position="right" align="start" data-flux-sidebar-group-dropdown>
             <button type="button" class="border-1 border-transparent w-full px-3 in-data-flux-menu:px-2 h-8 flex items-center group/disclosure-button mb-[2px] rounded-lg in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-menu:w-10 in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-menu:justify-center hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
-                <div class="relative in-data-flux-sidebar-group-dropdown:in-data-flux-menu:hidden">
+                <div class="relative in-data-flux-menu:hidden">
                     <?php if (is_string($icon) && $icon !== ''): ?>
                         <flux:icon :icon="$icon" :variant="$iconVariant" class="size-4" />
                     <?php else: ?>
@@ -49,7 +49,7 @@
                     <?php endif; ?>
                 </div>
 
-                <span class="hidden in-data-flux-sidebar-group-dropdown:in-data-flux-menu:block in-data-flux-sidebar-group-dropdown:in-data-flux-menu:blockflex-1 text-sm font-medium leading-none text-zinc-800 dark:text-white">{{ $heading }}</span>
+                <span class="hidden in-data-flux-menu:block in-data-flux-menu:blockflex-1 text-sm font-medium leading-none text-zinc-800 dark:text-white">{{ $heading }}</span>
             </button>
 
             <flux:menu>


### PR DESCRIPTION
# The scenario

Currently if you have a sidebar group inside another sidebar group, when the sidebar is collapsed down to icons, the nested group is missing it's heading and only showing icon in the dropdown.

<img width="2300" height="1414" alt="Screenshot 2025-09-15 at 02 59 13PM@2x" src="https://github.com/user-attachments/assets/467e4a46-32cb-4f87-a63a-fd5e03cc57af" />

# The problem

The issue is that we detect if the group is inside of a icon collapsed sidebar and if it is, we don't show the heading.

But if the group is within another group, then it should be shown.

# The solution

The solution is to add a check to see if the sidebar group is actually inside another sidebar group's dropdown, and if so, it hides the icon and only shows the heading.

<img width="2300" height="1414" alt="Screenshot 2025-09-15 at 02 58 44PM@2x" src="https://github.com/user-attachments/assets/1fc4a44b-c40e-4272-b9ad-c5091759acd9" />

Fixes livewire/flux#1936