### PR TITLE
Fix modal close button aria label

### DIFF
--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -88,7 +88,7 @@ if ($dismissible === false) {
         <?php if ($closable): ?>
             <div class="absolute top-0 end-0 mt-4 me-4">
                 <flux:modal.close>
-                    <flux:button variant="ghost" icon="x-mark" size="sm" alt="Close modal" class="text-zinc-400! hover:text-zinc-800! dark:text-zinc-500! dark:hover:text-white!"></flux:button>
+                    <flux:button variant="ghost" icon="x-mark" size="sm" aria-label="Close modal" class="text-zinc-400! hover:text-zinc-800! dark:text-zinc-500! dark:hover:text-white!"></flux:button>
                 </flux:modal.close>
             </div>
         <?php endif; ?>


### PR DESCRIPTION
# The scenario

Currently the modal close button doesn't have the correct label for screen readers, it just reads "Button".

<img width="3360" height="1864" alt="image" src="https://github.com/user-attachments/assets/2343a36d-1196-46ae-872e-e0771ce0c8e7" />

# The problem

The issue is that the close button has `alt="Close modal"` but it should be `aria-label="Close modal"`.

# The solution

This PR changes the `alt="Close modal"` to `aria-label="Close modal"

<img width="3360" height="1864" alt="image" src="https://github.com/user-attachments/assets/2ad0f689-acb4-4a35-9f4d-51a776782e6b" />

Fixes livewire/flux#1943