### PR TITLE
Add sidebar search `kbd` prop

### DIFF
--- a/stubs/resources/views/flux/sidebar/search.blade.php
+++ b/stubs/resources/views/flux/sidebar/search.blade.php
@@ -9,10 +9,13 @@
     'placeholder' => __('Search...'),
     'tooltipKbd' => null,
     'tooltip' => null,
+    'kbd' => null,
 ])
 
 @php
 $tooltip = $tooltip ?? $placeholder;
+
+$tooltipKbd ??= $kbd;
 
 $tooltipClasses = Flux::classes()
     ->add('w-full')
@@ -39,6 +42,12 @@ $classes = Flux::classes()
         <div class="in-data-flux-sidebar-collapsed-desktop:hidden block self-center text-start flex-1 font-medium text-zinc-400 dark:text-white/40">
             {{ $placeholder }}
         </div>
+
+        <?php if ($kbd): ?>
+            <div class="in-data-flux-sidebar-collapsed-desktop:hidden absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 pe-4 end-0">
+                {{ $kbd }}
+            </div>
+        <?php endif; ?>
     </button>
 
     <flux:tooltip.content :kbd="$tooltipKbd" class="not-in-data-flux-sidebar-collapsed-desktop:hidden cursor-default">


### PR DESCRIPTION
# The scenario

Currently if you add a keyboard shortcut to the sidebar search, nothing happens.

```blade
<flux:sidebar.search placeholder="Search..." kbd="⌘K" />
```

<img width="656" height="306" alt="Screenshot 2025-09-15 at 06 36 42PM@2x" src="https://github.com/user-attachments/assets/80b03563-9f0d-4f9b-a2e9-403d68225995" />

# The problem

The issue is that the new sidebar search component doesn't have a `kbd` prop, but it does have a `tooltipKbd` prop.

# The solution

This PR adds support for a `kbd` prop to display the keyboard shortcut on the search component in the expanded state, and if no `tooltipKbd` has been included, it will also set it to the passed in `kbd` value, so you don't need to set both.

<img width="642" height="312" alt="Screenshot 2025-09-15 at 06 36 26PM@2x" src="https://github.com/user-attachments/assets/b36c0f12-7adc-44b8-b647-7c62b3b1e504" />

<img width="354" height="306" alt="Screenshot 2025-09-15 at 06 38 43PM@2x" src="https://github.com/user-attachments/assets/d6bc9fc3-73da-4e06-8f2f-33af15683629" />

Fixes livewire/flux#1920