### PR TITLE
Added supplementary events for input actions

### DIFF
--- a/stubs/resources/views/flux/input/clearable.blade.php
+++ b/stubs/resources/views/flux/input/clearable.blade.php
@@ -13,7 +13,7 @@ $attributes = $attributes->merge([
     :$attributes
     :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
     x-data
-    x-on:click="let input = $el.closest('[data-flux-input]').querySelector('input'); input.value = ''; input.dispatchEvent(new Event('input', { bubbles: false })); input.dispatchEvent(new Event('change', { bubbles: false })); input.focus()"
+    x-on:click="let input = $el.closest('[data-flux-input]').querySelector('input'); input.value = ''; input.dispatchEvent(new Event('input', { bubbles: false })); input.dispatchEvent(new Event('change', { bubbles: false })); input.dispatchEvent(new Event('cleared', { bubbles: false })); input.focus()"
     tabindex="-1"
     aria-label="Clear input"
     data-flux-clear-button

--- a/stubs/resources/views/flux/input/copyable.blade.php
+++ b/stubs/resources/views/flux/input/copyable.blade.php
@@ -13,7 +13,7 @@ $attributes = $attributes->merge([
     :$attributes
     :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
     x-data="{ copied: false }"
-    x-on:click="copied = ! copied; navigator.clipboard && navigator.clipboard.writeText($el.closest('[data-flux-input]').querySelector('input').value); setTimeout(() => copied = false, 2000)"
+    x-on:click="copied = ! copied; navigator.clipboard && navigator.clipboard.writeText($el.closest('[data-flux-input]').querySelector('input').value); input.dispatchEvent(new Event('copied', { bubbles: false })); setTimeout(() => copied = false, 2000)"
     x-bind:data-copyable-copied="copied"
     aria-label="{{ __('Copy to clipboard') }}"
 >

--- a/stubs/resources/views/flux/input/expandable.blade.php
+++ b/stubs/resources/views/flux/input/expandable.blade.php
@@ -12,7 +12,7 @@ $attributes = $attributes->merge([
 <flux:button
     :$attributes
     :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
-    x-on:click="$el.closest('[data-flux-input]').querySelector('input').value = ''"
+    x-on:click="$el.closest('[data-flux-input]').querySelector('input').value = '' input.dispatchEvent(new Event('expanded', { bubbles: false }));"
 >
     <flux:icon.chevron-down variant="micro" />
 </flux:button>

--- a/stubs/resources/views/flux/input/viewable.blade.php
+++ b/stubs/resources/views/flux/input/viewable.blade.php
@@ -13,7 +13,7 @@ $attributes = $attributes->merge([
     :$attributes
     :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
     x-data="{ open: false }"
-    x-on:click="open = ! open; $el.closest('[data-flux-input]').querySelector('input').setAttribute('type', open ? 'text' : 'password')"
+    x-on:click="open = ! open; $el.closest('[data-flux-input]').querySelector('input').setAttribute('type', open ? 'text' : 'password') input.dispatchEvent(new Event('viewed', { bubbles: false }));"
     x-bind:data-viewable-open="open"
     aria-label="{{ __('Toggle password visibility') }}"
 


### PR DESCRIPTION
# Scenario

I needed to trigger custom logic after an input field was cleared.

# Problem

Currently, there are no built-in events emitted when input actions (such as clearing or copying) occur. This makes it impossible to hook into these behaviors directly.

Discussion opened here: https://github.com/livewire/flux/discussions/2013

# Solution

I introduced new events that are dispatched using the past-tense form of the corresponding action:

clearable → emits cleared

copyable → emits copied

This naming convention keeps the API intuitive and consistent.

To listen for these events, you can attach them directly in your component:
```blade
<flux:input
    id="search"
    name="search"
    icon="magnifying-glass"
    placeholder="Search for an item"
    value="{{ $searchQuery }}"
    clearable
    @cleared="() => console.log('cleared')"
/>
```