### PR TITLE
Update flux.css to fix error of scroll bar and loading mode of button

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -240,3 +240,33 @@ Utilties
 .flux-no-scrollbar::-webkit-scrollbar{
     display:none
 }
+
+/* Show and center the Flux loading spinner inside disabled buttons */
+button[disabled] [data-flux-loading-indicator] {
+    position: relative !important;
+    inset: auto !important;
+    opacity: 1 !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    vertical-align: middle;
+    transform: translateY(1px);
+}
+
+/* Keep label text visible and collapse gap while loading (when button is disabled) */
+button[disabled] > span {
+    opacity: 1 !important;
+    gap: 0 !important;
+}
+
+/* Ensure Flux dropdowns are not clipped by page container scroll */
+html,
+body,
+[data-flux-page-container] {
+    overflow: visible !important;
+}
+
+/* Prevent layout shift when Flux unlocks body scroll (avoid padding compensation) */
+html[data-flux-scroll-unlock] {
+    padding-right: 0 !important;
+}


### PR DESCRIPTION
# The scenario

- Prepare a dropdown like avatar:

`<flux:select variant="listbox" label="Assign to">
    <flux:select.option selected>
        <div class="flex items-center gap-2 whitespace-nowrap">
            <flux:avatar circle size="xs" src="https://unavatar.io/github/calebporzio" /> Caleb Porzio
        </div>
    </flux:select.option>
</flux:select>`

- Prepare a submit type button to make "loading" style when clicked:

`<flux:button variant="primary" icon="paper-airplane" class="w-full" type="submit">Submit</flux:button>`

# The problem

- Scroll bar is disappeared and screen width is increased which will break the layout when click at dropdown or a select element.
- Perform a loading mode of a button does not disable text and show loading icon as it should be.

# The solution

- Override css to ensure Flux dropdowns are not clipped by page container scroll with "important" and prevent layout shift when Flux unlocks body scroll (avoid padding compensation).
- Show and center the Flux loading spinner inside disabled buttons and keep label text visible and collapse gap while loading (when button is disabled).



Fixes livewire/flux#