### PR TITLE
Update flux.css to fix loading state error of a submit button

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -240,3 +240,21 @@ Utilties
 .flux-no-scrollbar::-webkit-scrollbar{
     display:none
 }
+
+/* Show and center the Flux loading spinner inside disabled buttons */
+button[disabled] [data-flux-loading-indicator] {
+    position: relative !important;
+    inset: auto !important;
+    opacity: 1 !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    vertical-align: middle;
+    transform: translateY(1px);
+}
+
+/* Keep label text visible and collapse gap while loading (when button is disabled) */
+button[disabled] > span {
+    opacity: 1 !important;
+    gap: 0 !important;
+}


### PR DESCRIPTION
Fix error that the text of a button which has `type="submit"` disappeared as also the state "loading" does not appear as properly.

# The scenario

1. Prepare a submit button to make "loading" state when clicked:

`<flux:button variant="primary" icon="paper-airplane" class="w-full" type="submit">Submit now</flux:button>`

2. Click the button to submit form or perform long action, then you will see the text "Submit now" is disappeared or might have some unnecessary spaces between.

# The problem

- Perform a loading mode of a submit button does not show text and the state "loading" does not appear as properly.
- Reported at https://github.com/livewire/flux/issues/1639.
- Video of the error before apply PR:

https://github.com/user-attachments/assets/33a0763e-11e2-463c-8546-e5128c2662a4

# The solution

- Override css to show and center the Flux loading spinner inside disabled buttons and keep label text visible and collapse gap while loading (when button is disabled).
- Video of successfully fixed after apply PR:

https://github.com/user-attachments/assets/ac06e912-db70-4839-915e-17bf4da0e761



Fixes livewire/flux#