### PR TITLE
Deduplicate package check in `ensurePro` method

### DIFF
--- a/src/FluxManager.php
+++ b/src/FluxManager.php
@@ -26,7 +26,7 @@ class FluxManager
 
     public function ensurePro()
     {
-        if (! InstalledVersions::isInstalled('livewire/flux-pro')) {
+        if (! $this->pro()) {
             throw new \Exception('Your install of Flux is not activated. Visit https://fluxui.dev/pricing to purchase a license key.');
         }
     }


### PR DESCRIPTION
# The scenario

When reviewing the `FluxManager` class, I noticed that the `ensurePro()` method directly calls `InstalledVersions::isInstalled('livewire/flux-pro')` to check if Flux Pro is installed, while there's already a dedicated `pro()` method that performs the same check.

# The problem

deduplicate package check in `ensurePro` method

# The solution

Refactor `ensurePro()` to call the existing `pro()` method instead of duplicating the package check



Fixes livewire/flux#