### PR TITLE
Fix avatar image cover

### DIFF
--- a/stubs/resources/views/flux/avatar/index.blade.php
+++ b/stubs/resources/views/flux/avatar/index.blade.php
@@ -173,7 +173,7 @@ $label = $alt ?? $name;
 <flux:with-tooltip :$tooltip :$attributes>
     <flux:button-or-link :attributes="$attributes->class($classes)->merge($circle ? ['data-circle' => 'true'] : [])" :$as :$href data-flux-avatar data-slot="avatar" data-size="{{ $size }}">
         <?php if ($src): ?>
-            <img src="{{ $src }}" alt="{{ $alt ?? $name }}" class="rounded-[var(--avatar-radius)]">
+            <img src="{{ $src }}" alt="{{ $alt ?? $name }}" class="rounded-[var(--avatar-radius)] size-full object-cover">
         <?php elseif ($icon): ?>
             <flux:icon :name="$icon" :variant="$iconVariant" :class="$iconClasses" />
         <?php elseif ($hasTextContent): ?>


### PR DESCRIPTION
# The scenario

Currently if you have an avatar or profile component and the provided image isn't perfectly square, the displayed image doesn't look right and the background colour is being shown.

<img width="270" height="408" alt="Screenshot 2025-10-13 at 10 40 53AM@2x" src="https://github.com/user-attachments/assets/2cc23f7f-4fec-482d-8017-aa9137995f00" />

```blade
<?php

use Livewire\Component;

new class extends Component {
    //
};

?>

<div class="max-w-192 mx-auto p-6 space-y-4">
    <flux:avatar src="https://plus.unsplash.com/premium_photo-1760018690381-a8a38d50b55a?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=3271" />
    <flux:profile avatar="https://plus.unsplash.com/premium_photo-1760018690381-a8a38d50b55a?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=3271" />
</div>
```

# The problem

The issue is that the image is being shrunk to match the size of the wrapping element. But as it's not square, this means that the background is being shown above/below the image.

# The solution

The solution is to add `size-full object-cover` to the `<img>` element which ensures it fits the available space.

<img width="360" height="462" alt="Screenshot 2025-10-13 at 10 38 56AM@2x" src="https://github.com/user-attachments/assets/a8cceea4-8f53-4a98-9821-445c77114ad5" />

Fixes livewire/flux#2031