### PR TITLE
Fix button group with modal trigger

### DIFF
--- a/stubs/resources/views/flux/button/group.blade.php
+++ b/stubs/resources/views/flux/button/group.blade.php
@@ -15,9 +15,9 @@ $classes = Flux::classes()
         '[&>[data-flux-input]:has(+[data-flux-input-group-suffix])>[data-flux-group-target]:not([data-invalid])]:border-e-0',
 
         // Selects and date pickers borders...
-        '[&>*:last-child:not(:first-child)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-        '[&>*:not(:first-child):not(:last-child)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-        '[&>*:has(+[data-flux-input-group-suffix])>[data-flux-group-target]:not([data-invalid])]:border-e-0',
+        '[&>*:last-child:not(:first-child)_[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:not(:first-child):not(:last-child)_[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:has(+[data-flux-input-group-suffix])_[data-flux-group-target]:not([data-invalid])]:border-e-0',
 
         // Buttons borders...
         '[&>[data-flux-group-target]:last-child:not(:first-child)]:border-s-0',
@@ -30,14 +30,9 @@ $classes = Flux::classes()
         '[&>[data-flux-group-target]:last-child:not(:first-child)]:rounded-s-none',
 
         // "Weld" borders for sub-children of group targets (button element inside ui-select element, etc.)...
-        '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-group-target]]:rounded-none',
-        '[&>*:first-child:not(:last-child)>[data-flux-group-target]]:rounded-e-none',
-        '[&>*:last-child:not(:first-child)>[data-flux-group-target]]:rounded-s-none',
-
-        // "Weld" borders for sub-sub-children of group targets (input element inside div inside ui-select element (combobox))...
-        '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-input]>[data-flux-group-target]]:rounded-none',
-        '[&>*:first-child:not(:last-child)>[data-flux-input]>[data-flux-group-target]]:rounded-e-none',
-        '[&>*:last-child:not(:first-child)>[data-flux-input]>[data-flux-group-target]]:rounded-s-none',
+        '[&>*:not(:first-child):not(:last-child):not(:only-child)_[data-flux-group-target]]:rounded-none',
+        '[&>*:first-child:not(:last-child)_[data-flux-group-target]]:rounded-e-none',
+        '[&>*:last-child:not(:first-child)_[data-flux-group-target]]:rounded-s-none',
     ])
     ;
 @endphp

--- a/stubs/resources/views/flux/input/group/index.blade.php
+++ b/stubs/resources/views/flux/input/group/index.blade.php
@@ -18,9 +18,9 @@ $classes = Flux::classes()
         '[&>[data-flux-input]:has(+[data-flux-input-group-suffix])>[data-flux-group-target]:not([data-invalid])]:border-e-0',
 
         // Selects and date pickers borders...
-        '[&>*:last-child:not(:first-child)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-        '[&>*:not(:first-child):not(:last-child)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-        '[&>*:has(+[data-flux-input-group-suffix])>[data-flux-group-target]:not([data-invalid])]:border-e-0',
+        '[&>*:last-child:not(:first-child)_[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:not(:first-child):not(:last-child)_[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:has(+[data-flux-input-group-suffix])_[data-flux-group-target]:not([data-invalid])]:border-e-0',
 
         // Buttons borders...
         '[&>[data-flux-group-target]:last-child:not(:first-child)]:border-s-0',
@@ -33,14 +33,9 @@ $classes = Flux::classes()
         '[&>[data-flux-group-target]:last-child:not(:first-child)]:rounded-s-none',
 
         // "Weld" borders for sub-children of group targets (button element inside ui-select element, etc.)...
-        '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-group-target]]:rounded-none',
-        '[&>*:first-child:not(:last-child)>[data-flux-group-target]]:rounded-e-none',
-        '[&>*:last-child:not(:first-child)>[data-flux-group-target]]:rounded-s-none',
-
-        // "Weld" borders for sub-sub-children of group targets (input element inside div inside ui-select element (combobox))...
-        '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-input]>[data-flux-group-target]]:rounded-none',
-        '[&>*:first-child:not(:last-child)>[data-flux-input]>[data-flux-group-target]]:rounded-e-none',
-        '[&>*:last-child:not(:first-child)>[data-flux-input]>[data-flux-group-target]]:rounded-s-none',
+        '[&>*:not(:first-child):not(:last-child):not(:only-child)_[data-flux-group-target]]:rounded-none',
+        '[&>*:first-child:not(:last-child)_[data-flux-group-target]]:rounded-e-none',
+        '[&>*:last-child:not(:first-child)_[data-flux-group-target]]:rounded-s-none',
     ])
     ;
 @endphp


### PR DESCRIPTION
# The scenario

Currently if you have a button group, with buttons that have both a tooltip and are a modal trigger, then the buttons borders aren't rendered correctly to match the group.

<img width="808" height="156" alt="Screenshot 2025-10-13 at 02 12 33PM@2x" src="https://github.com/user-attachments/assets/538686b0-edd5-4807-9a38-e29c98356dc1" />

```blade
<flux:button.group>
    <flux:modal.trigger name="page-details">
        <flux:button icon="bars-3-bottom-left" tooltip="Left align" />
    </flux:modal.trigger>
    <flux:modal.trigger name="page-details">
        <flux:button icon="bars-3" tooltip="Center align" />
    </flux:modal.trigger>
    <flux:modal.trigger name="page-details">
        <flux:button icon="bars-3-bottom-right" tooltip="Right align" />
    </flux:modal.trigger>
</flux:button.group>
```

# The problem

The issue is that the CSS selectors which remove the rounded and excess borders on inner buttons is scoped to only apply these styles for immediate children of the button group. There are also selectors which account for a button group with a tooltip that contains a button (1 level of nesting).

But when using a modal trigger, the button itself ends up a few levels below the button group in the DOM and as such isn't being targeted by the child selectors.

# The solution

The solution is to update the selectors to detect any buttons within the group and apply the correct styles.

So for example, this PR changes the selector from:

```
[&>*:last-child:not(:first-child)>[data-flux-group-target]:not([data-invalid])]:border-s-0
```

To

```
[&>*:last-child:not(:first-child)_[data-flux-group-target]:not([data-invalid])]:border-s-0
```

The main difference is before the `[data-flux-group-target]` instead of a `>` which is direct children, we now use `_` which means any children.

One bonus we get by making this change is we had a selector for `sub-sub-children of input groups` which is now no longer needed as it is covered by these selector changes.

Now it all works as expected.

<img width="802" height="144" alt="Screenshot 2025-10-13 at 02 12 07PM@2x" src="https://github.com/user-attachments/assets/73b77c46-6a0f-40c8-9980-3d740727f0bf" />

I also added this scenario to our `groups` test page and checked all the other groups still worked as expected.

<img width="2834" height="2652" alt="Screenshot 2025-10-13 at 02 11 31PM@2x" src="https://github.com/user-attachments/assets/595d8a48-66bc-44fd-ab91-31e5aa9c3a31" />

Fixes livewire/flux#2021
Fixes livewire/flux#2072