### PR TITLE
Fix file input in a group

### DIFF
--- a/stubs/resources/views/flux/input/file.blade.php
+++ b/stubs/resources/views/flux/input/file.blade.php
@@ -17,7 +17,7 @@ extract(Flux::forwardedAttributes($attributes, [
 @php
 $classes = Flux::classes()
     ->add('w-full flex items-center gap-4')
-    ->add('[[data-flux-input-group]_&]:w-auto [[data-flux-input-group]_&]:items-stretch [[data-flux-input-group]_&]:gap-0')
+    ->add('[[data-flux-input-group]_&]:items-stretch [[data-flux-input-group]_&]:gap-0')
 
     // NOTE: We need to add relative positioning here to prevent odd overflow behaviors because of
     // "sr-only": https://github.com/tailwindlabs/tailwindcss/discussions/12429
@@ -70,7 +70,7 @@ $classes = Flux::classes()
         x-ref="name"
         @class([
             'cursor-default select-none truncate whitespace-nowrap text-sm text-zinc-500 dark:text-zinc-400 font-medium',
-            '[[data-flux-input-group]_&]:border-e [[data-flux-input-group]_&]:border-y [[data-flux-input-group]_&]:shadow-xs [[data-flux-input-group]_&]:border-zinc-200 dark:[[data-flux-input-group]_&]:border-zinc-600 [[data-flux-input-group]_&]:px-4 [[data-flux-input-group]_&]:bg-white dark:[[data-flux-input-group]_&]:bg-zinc-700 [[data-flux-input-group]_&]:flex [[data-flux-input-group]_&]:items-center dark:[[data-flux-input-group]_&]:text-zinc-300',
+            '[[data-flux-input-group]_&]:flex-1 [[data-flux-input-group]_&]:border-e [[data-flux-input-group]_&]:border-y [[data-flux-input-group]_&]:shadow-xs [[data-flux-input-group]_&]:border-zinc-200 dark:[[data-flux-input-group]_&]:border-zinc-600 [[data-flux-input-group]_&]:px-4 [[data-flux-input-group]_&]:bg-white dark:[[data-flux-input-group]_&]:bg-zinc-700 [[data-flux-input-group]_&]:flex [[data-flux-input-group]_&]:items-center dark:[[data-flux-input-group]_&]:text-zinc-300',
         ])
         aria-hidden="true"
     >


### PR DESCRIPTION
# The scenario

Currently, if you use a basic file input in an input group, the file input does not match the style of the group properly and the group on the right looks broken.

<img width="1912" height="264" alt="Screenshot 2025-10-13 at 03 46 19PM@2x" src="https://github.com/user-attachments/assets/13119261-3bc0-4d06-a7f4-9197039065a0" />

```blade
<?php

use Livewire\Component;

new class extends Component {
    //
};

?>

<div class="max-w-192 mx-auto p-6 space-y-4">
    <flux:field>
        <flux:label>File input in a group</flux:label>
        <flux:input.group>
            <flux:input type="file" wire:model="fileImport" />
            <flux:button icon="arrow-up-tray" wire:click="importFile">Import</flux:button>
        </flux:input.group>
    </flux:field>
</div>
```

# The problem

The issue is that the file name part of the file input doesn't have any styles applied to it that would make it look like an input or button (no border, shadow, etc).

So when it gets included in an input group, it then just looks out of place.

# The solution

The solution is to add custom styles to the file name part of the file input so it is styled correctly when used in a group. These should only be applied when it's in a group and not when used standalone.

**Light mode**
<img width="1892" height="488" alt="Screenshot 2025-10-13 at 03 51 12PM@2x" src="https://github.com/user-attachments/assets/057f27fe-617f-424a-bf0f-e5d1279fa7f2" />

I also made sure the styles worked in dark mode. But one thing that didn't look great is the contract between the file name and the background colour.

**Dark mode with existing text colour in file name section**
<img width="1866" height="472" alt="Screenshot 2025-10-13 at 03 52 07PM@2x" src="https://github.com/user-attachments/assets/4eb80087-3139-4380-b405-4043a405b265" />

So I made the file name text one shade lighter when it is used in a group, so the contrast is better between it and the background.

**Dark mode with slightly lighter text colour in file name section**
<img width="1860" height="464" alt="Screenshot 2025-10-13 at 03 51 37PM@2x" src="https://github.com/user-attachments/assets/63c9f015-3035-4581-b86a-bc78075cc55c" />

Fixes livewire/flux#1998