### PR TITLE
Fix DateRange end date to use endOfDay for consistency with presets

### DIFF
--- a/src/DateRangeSynth.php
+++ b/src/DateRangeSynth.php
@@ -2,6 +2,7 @@
 
 namespace Flux;
 
+use Carbon\Carbon;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 
 class DateRangeSynth extends Synth
@@ -79,7 +80,7 @@ class DateRangeSynth extends Synth
     function set(&$target, $key, $value) {
         $target = match ($key) {
             'start' => new DateRange($value, $target->end()),
-            'end' => new DateRange($target->start(), $value),
+            'end' => new DateRange($target->start(), Carbon::parse($value)->endOfDay()),
             'preset' => $value === DateRangePreset::AllTime->value
                 ? DateRange::allTime($target->start())
                 : DateRange::fromPreset(DateRangePreset::from($value)),


### PR DESCRIPTION
# The scenario

When using `<flux:daterange />` with a datepicker, users can either:
1. Select a preset (Today, Yesterday, Last 7 Days, etc.)
2. Manually select dates using the `<flux:datepicker />` component

However, these two methods produce inconsistent end times:
- **Presets**: End dates are set to 23:59:59 (end of day)
- **Manual selection**: End dates are set to 00:00:00 (start of day)

This inconsistency causes issues when querying data, as the same date range selected via preset vs. datepicker produces different results.

# The problem

https://github.com/user-attachments/assets/d0842bde-da75-4f55-814b-155cee5e5c9a

In `src/DateRangeSynth.php`, the `set()` method creates a new DateRange when the end date is updated via the datepicker:

```php
function set(&$target, $key, $value) {
    $target = match ($key) {
        'start' => new DateRange($value, $target->end()),
        'end' => new DateRange($target->start(), $value),  // ← Problem: no endOfDay()
        'preset' => ...
    };
}
```

Meanwhile, all presets in `src/DateRangePreset.php` use `endOfDay()` for their end dates:

```php
static::Today => [ Carbon::now()->startOfDay(), Carbon::now()->endOfDay() ],
static::Yesterday => [ Carbon::now()->subDay()->startOfDay(), Carbon::now()->subDay()->endOfDay() ],
// ... all other presets also use endOfDay()
```

# The solution

Updated the `set()` method in `DateRangeSynth.php` to apply `endOfDay()` when setting the end date:

```php
function set(&$target, $key, $value) {
    $target = match ($key) {
        'start' => new DateRange($value, $target->end()),
        'end' => new DateRange($target->start(), Carbon::parse($value)->endOfDay()),  // ← Fixed
        'preset' => ...
    };
}
```

This ensures that whether users select dates via presets or the datepicker, the end date is consistently set to 23:59:59, making date range queries work as expected.

**Benefits:**
- Consistent behavior between presets and manual date selection
- More intuitive for users (selecting "Jan 10" as end date now includes all of Jan 10)
- Prevents off-by-one errors in date range queries