### PR TITLE
Fix sidebar search icon alignment

### DIFF
--- a/stubs/resources/views/flux/sidebar/search.blade.php
+++ b/stubs/resources/views/flux/sidebar/search.blade.php
@@ -23,7 +23,7 @@ $tooltipClasses = Flux::classes()
     ;
 
 $classes = Flux::classes()
-    ->add('h-10 py-2 px-3 w-full border rounded-lg block disabled:shadow-none dark:shadow-none appearance-none text-base sm:text-sm leading-[1.375rem] bg-zinc-800/5 dark:bg-white/10 dark:disabled:bg-white/[7%] text-zinc-700 placeholder-zinc-500 disabled:placeholder-zinc-400 dark:text-zinc-200 dark:placeholder-white/60 dark:disabled:placeholder-white/40 border-0 relative flex gap-3')
+    ->add('h-10 py-2 px-3 w-full rounded-lg disabled:shadow-none dark:shadow-none appearance-none text-base sm:text-sm leading-[1.375rem] bg-zinc-800/5 dark:bg-white/10 dark:disabled:bg-white/[7%] text-zinc-700 placeholder-zinc-500 disabled:placeholder-zinc-400 dark:text-zinc-200 dark:placeholder-white/60 dark:disabled:placeholder-white/40 border-0 relative flex items-center gap-3')
     ->add('in-data-flux-sidebar-on-mobile:h-10 in-data-flux-sidebar-collapsed-desktop:px-3')
     ->add('in-data-flux-sidebar-header:in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:hidden')
     ;


### PR DESCRIPTION
# The problem

The search icon in the sidebar is not aligned in the center.

<img width="691" height="372" alt="SCR-20251023-sygk" src="https://github.com/user-attachments/assets/f537196d-1518-40ac-8e7e-a434d146312d" />

Before / After

# The solution

Added `items-center` to the button.

Additionally, the PR removes conflicting classes:

<img width="901" height="204" alt="SCR-20251023-taww" src="https://github.com/user-attachments/assets/2641cb13-7fed-4abc-a687-db1d140c40ba" />