### PR TITLE
Add attributes to modal close component

### DIFF
--- a/stubs/resources/views/flux/modal/close.blade.php
+++ b/stubs/resources/views/flux/modal/close.blade.php
@@ -1,5 +1,3 @@
-@props(['class' => ''])
-
 @blaze
 
 <ui-close data-flux-modal-close {{ $attributes }}>


### PR DESCRIPTION
# The scenario

I found impossible to have a button in full width inside the <flux:modal.close> component.

# The problem

It is impossible to pass classes to the <flux:modal.close> component.

# The solution

I added the class prop.


Fixes livewire/flux#