### PR TITLE
Fix `Flux::attributesAfter()` usages

### DIFF
--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -76,6 +76,7 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if (isset($badge) && $badge !== ''): ?>
-        <flux:navbar.badge :attributes="Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor, 'class' => 'ms-2'])">{{ $badge }}</flux:navbar.badge>
+        <?php $badgeAttributes = Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor, 'class' => 'ms-2']); ?>
+        <flux:navbar.badge :attributes="$badgeAttributes">{{ $badge }}</flux:navbar.badge>
     <?php endif; ?>
 </flux:button-or-link>

--- a/stubs/resources/views/flux/navlist/item.blade.php
+++ b/stubs/resources/views/flux/navlist/item.blade.php
@@ -84,6 +84,7 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if (isset($badge) && $badge !== ''): ?>
-        <flux:navlist.badge :attributes="Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor])">{{ $badge }}</flux:navlist.badge>
+        <?php $badgeAttributes = Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor]); ?>
+        <flux:navlist.badge :attributes="$badgeAttributes">{{ $badge }}</flux:navlist.badge>
     <?php endif; ?>
 </flux:button-or-link>

--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -81,7 +81,8 @@ $classes = Flux::classes()
         <?php endif; ?>
 
         <?php if (isset($badge) && $badge !== ''): ?>
-            <flux:navlist.badge :attributes="Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor])" class="in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-sidebar-group-dropdown:hidden">{{ $badge }}</flux:navlist.badge>
+            <?php $badgeAttributes = Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor]); ?>
+            <flux:navlist.badge :attributes="$badgeAttributes" class="in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-sidebar-group-dropdown:hidden">{{ $badge }}</flux:navlist.badge>
         <?php endif; ?>
     </flux:button-or-link>
 

--- a/stubs/resources/views/flux/sidebar/profile.blade.php
+++ b/stubs/resources/views/flux/sidebar/profile.blade.php
@@ -33,7 +33,8 @@ $classes = Flux::classes()
         <?php if ($avatar instanceof \Illuminate\View\ComponentSlot): ?>
             {{ $avatar }}
         <?php else: ?>
-            <flux:avatar :attributes="Flux::attributesAfter('avatar:', $attributes, ['src' => $avatar, 'size' => 'sm', 'circle' => $circle, 'name' => $name, 'initials' => $initials])" />
+            <?php $avatarAttributes = Flux::attributesAfter('avatar:', $attributes, ['src' => $avatar, 'size' => 'sm', 'circle' => $circle, 'name' => $name, 'initials' => $initials]); ?>
+            <flux:avatar :attributes="$avatarAttributes" />
         <?php endif; ?>
     </div>
 

--- a/stubs/resources/views/flux/with-field.blade.php
+++ b/stubs/resources/views/flux/with-field.blade.php
@@ -19,21 +19,28 @@ extract(Flux::forwardedAttributes($attributes, [
 ])
 
 <?php if (isset($label) || isset($description)): ?>
-    <flux:field :attributes="Flux::attributesAfter('field:', $attributes, [])">
+    <?php
+    
+        $fieldAttributes = Flux::attributesAfter('field:', $attributes, []);
+        $labelAttributes = Flux::attributesAfter('label:', $attributes, ['badge' => $badge]);
+        $descriptionAttributes = Flux::attributesAfter('description:', $attributes, []);
+        $errorAttributes = Flux::attributesAfter('error:', $attributes, ['name' => $name]);
+    ?>
+    <flux:field :attributes="$fieldAttributes">
         <?php if (isset($label)): ?>
-            <flux:label :attributes="Flux::attributesAfter('label:', $attributes, ['badge' => $badge])">{{ $label }}</flux:label>
+            <flux:label :attributes="$labelAttributes">{{ $label }}</flux:label>
         <?php endif; ?>
 
         <?php if (isset($description)): ?>
-            <flux:description :attributes="Flux::attributesAfter('description:', $attributes, [])">{{ $description }}</flux:description>
+            <flux:description :attributes="$descriptionAttributes">{{ $description }}</flux:description>
         <?php endif; ?>
 
         {{ $slot }}
 
-        <flux:error :attributes="Flux::attributesAfter('error:', $attributes, ['name' => $name])" />
+        <flux:error :attributes="$errorAttributes" />
 
         <?php if (isset($descriptionTrailing)): ?>
-            <flux:description :attributes="Flux::attributesAfter('description:', $attributes, [])">{{ $descriptionTrailing }}</flux:description>
+            <flux:description :attributes="$descriptionAttributes">{{ $descriptionTrailing }}</flux:description>
         <?php endif; ?>
     </flux:field>
 <?php else: ?>


### PR DESCRIPTION
# The scenario

Currently if you have a `label:class` attribute on an input, like `<flux:input label="Input 1" label:class="text-purple-500"/>`, the classes are no longer forwarded since v2.6.0, where as it used to work.

<img width="960" height="206" alt="Screenshot 2025-10-29 at 07 21 50PM@2x" src="https://github.com/user-attachments/assets/59b1266c-68da-4fd8-bfa5-4c81429b1578" />

```blade
<?php

use Livewire\Component;

new class extends Component {
    //
};

?>

<div class="mx-auto max-w-md">
    <flux:input label="Input 1" label:class="text-purple-500"/>
</div>
```

# The problem

The issue is that in v2.6.0 we released an update to `Flux::attributesAfter()` that stripped the matched values from existing `$attributes` to ensure they weren't also output/ doubled up where they shouldn't be.

The problem with stripping comes down to how `Flux::attributesAfter()` is used. One scenario works fine and the other is causing the problem described above.

The working solution is when used like this:

```blade
<?php $labelAttributes = Flux::attributesAfter('label', $attributes); ?>
<flux:label :attributes="$labelAttributes" />
```

The broken scenario is when it is used inline like this:

```blade
<flux:label :attributes="Flux::attributesAfter('label', $attributes)" />
```

To understand why this is broken, we have to dive into how Blade compiles components.

When a Blade component is found, Blade compiles it down to this string:

```php
<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'ab18b3e58a3b1bb5106ced208a8bd460::label','data' => ['attributes' => Flux::attributesAfter('label:', $attributes, ['badge' => $badge])]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
<?php $component->withName('flux::label'); ?>
<?php if ($component->shouldRender()): ?>
<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
<?php endif; ?>
<?php $component->withAttributes(['attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(Flux::attributesAfter('label:', $attributes, ['badge' => $badge]))]); ?>
```

If you look closely, you will see that `Flux::attributesAfter()` is actually being called twice for the label component. This is because Blade makes use of the `$attributes` bag twice when rendering a component.

What this means is that the first call is removing the label attributes from the `$attribute` bag. And the second one inside `->withAttributes()`, which is the one that actually passes the data to the component, can't actually find any label attributes in the `$attributes` bag. Hence why no attributes are being forwarded to the component.

# The solution

The solution is to remove the inline usages of `Flux::attributesAfter()` and make use of a temporary variable, to ensure the attributes are pulled and collected only once and then that bag is included with the component.

I have checked Flux Pro and all components that use `Flux::attributesAfter()` are already using temporary variables, so there was only a couple of components that needed to be updated on this repo.

Now it's all working as expected again.

<img width="940" height="194" alt="Screenshot 2025-10-29 at 07 35 03PM@2x" src="https://github.com/user-attachments/assets/986d5492-1607-49cd-835c-40452e557188" />

Fixes livewire/flux#2056