### PR TITLE
Fix `@pure` directive breaking change

### DIFF
--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -48,6 +48,10 @@ class FluxServiceProvider extends ServiceProvider
     {
         Blade::directive('blaze', fn () => '');
 
+        // `@pure` directive has been replaced with `@blaze` in Blaze v1.0, but we need to keep it here for
+        // backwards compatibility as people could have published components or custom icons using it...
+        Blade::directive('pure', fn () => '');
+
         Blade::directive('unblaze', function ($expression) {
             return ''
                 . '<'.'?php $__getScope = fn($scope = []) => $scope; ?>'


### PR DESCRIPTION
# The scenario

Currently if you have published any Flux components or generated custom icons using `php artisan flux:icon` that were from before the `@pure` to `@blaze` change, then you will see `@pure` being rendered on the screen.

<img width="1516" height="942" alt="image" src="https://github.com/user-attachments/assets/084fe898-d6ad-4701-af7f-27853bffbd47" />

# The problem

The issue is that the `@pure` directive was included with the components when they were published or included in the icons when they got generated. But we're unable to update them. Because the directive is no longer registered with Blade, it's just rendering them verbatim on the screen.

# The solution

The solution is to re-add the `@pure` Blade directive fallback alongside `@blaze`, that way if Blade comes across one of them, it doesn't get rendered.

```php
// `@pure` directive has been replaced with `@blaze` in Blaze v1.0, but we need to keep it here for
// backwards compatibility as people could have published components or custom icons using it...
Blade::directive('pure', fn () => '');
```

Fixes livewire/flux#2097