### PR TITLE
Fix implicit nullable argument

### DIFF
--- a/src/DateRangePreset.php
+++ b/src/DateRangePreset.php
@@ -25,7 +25,7 @@ enum DateRangePreset: string
     case AllTime = 'allTime';
     case Custom = 'custom';
 
-    public function dates(Carbon $start = null)
+    public function dates(?Carbon $start = null)
     {
         return match ($this) {
             static::Today => [ Carbon::now()->startOfDay(), Carbon::now()->endOfDay() ],


### PR DESCRIPTION
This fixes deprecation errors in php 8.4. See https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated.

```
PHP Deprecated:  Flux\DateRangePreset::dates(): Implicitly marking parameter $start as nullable is deprecated, the explicit nullable type must be used instead in vendor/livewire/flux/src/DateRangePreset.php on line 28
```

Fixes #1978