### PR TITLE
Fix forced dark mode switch

### DIFF
--- a/stubs/resources/views/flux/switch.blade.php
+++ b/stubs/resources/views/flux/switch.blade.php
@@ -30,6 +30,7 @@ $indicatorClasses = Flux::classes()
     ->add('bg-white')
     ->add([
         'group-data-checked:translate-x-[15px] rtl:group-data-checked:-translate-x-[15px]',
+        'dark:group-data-checked:translate-x-[15px] dark:rtl:group-data-checked:-translate-x-[15px]',
         'group-data-checked:bg-(--color-accent-foreground)',
     ]);
 @endphp


### PR DESCRIPTION
# The scenario

Currently if you have a forced dark/light mode, which allows you to add `dark` or `light` class on components, to just change that section of a page, the switch doesn't work in dark mode.

![Screenshot 2025-11-21 at 06 40 44PM](https://github.com/user-attachments/assets/803d49b5-885e-4319-b9ea-82fc0e723c93)

```blade
<div>
    <div class="dark p-3 bg-zinc-900">
       <flux:switch label="Dark mode switch" />
    </div>

    <div class="light p-3">
       <flux:switch label="Lightmode switch" />
    </div>
</div>
```

# The problem

The issue is that because there is already a `dark:translate-x-[2px]` on the element, when using a dark class on an element wrapping the switch (instead of the root `<html>` element), that dark translate class takes priority over the `group-data-checked:translate-x-[15px]` which makes the switch move when toggled.

# The solution

The solution is to also add `dark:` classes for the checked translation.

```
'dark:group-data-checked:translate-x-[15px] dark:rtl:group-data-checked:-translate-x-[15px]',
```

Now everything works as expected.

![Screenshot 2025-11-21 at 06 45 25PM](https://github.com/user-attachments/assets/f89e0892-e61b-4260-a6f9-770c2f4763c5)

Fixes livewire/flux#2050