### PR TITLE
Make inputs more consistent

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -125,11 +125,11 @@ $classes = Flux::classes()
     <flux:with-field :$attributes :$name>
         <div {{ $attributes->only('class')->class('w-full relative block group/input') }} data-flux-input>
             <?php if (is_string($iconLeading)): ?>
-                <div class="pointer-events-none absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 dark:text-white/60 ps-3 start-0">
+                <div class="pointer-events-none absolute top-0 bottom-0 border-s border-transparent flex items-center justify-center text-xs text-zinc-400/75 dark:text-white/60 ps-3 start-0">
                     <flux:icon :icon="$iconLeading" :variant="$iconVariant" :class="$iconClasses" />
                 </div>
             <?php elseif ($iconLeading): ?>
-                <div {{ $iconLeading->attributes->class('absolute top-0 bottom-0 flex items-center justify-center text-xs text-zinc-400/75 dark:text-white/60 ps-3 start-0') }}>
+                <div {{ $iconLeading->attributes->class('absolute top-0 bottom-0 border-s border-transparent flex items-center justify-center text-xs text-zinc-400/75 dark:text-white/60 ps-3 start-0') }}>
                     {{ $iconLeading }}
                 </div>
             <?php endif; ?>
@@ -149,7 +149,7 @@ $classes = Flux::classes()
             >
 
             <?php if ($loading || $countOfTrailingIcons > 0): ?>
-                <div class="absolute top-0 bottom-0 flex items-center gap-x-1.5 pe-3 -me-1 border-r border-transparent end-0 text-xs text-zinc-400">
+                <div class="absolute top-0 bottom-0 flex items-center gap-x-1.5 pe-3 -me-1 border-e border-transparent end-0 text-xs text-zinc-400">
                     {{-- Icon should be text-zinc-400/75 --}}
                     <?php if ($loading): ?>
                         <flux:icon name="loading" :variant="$iconVariant" :class="$iconClasses" wire:loading :wire:target="$wireTarget" />


### PR DESCRIPTION
There is a corresponding Flux Pro PR livewire/flux-pro#346.

# The scenario

Currently if you have a date picker and an input with icons next to each other, the colours don't match and the icons don't line up perfectly.

You can see below in the light mode screenshot that the leading and trailing icons are a different colour on the input to what they are on the date picker and select. The chevron on the input also doesn't line up with the others.

<img width="2602" height="1268" alt="image" src="https://github.com/user-attachments/assets/2cc543dd-2b1d-4b60-88b3-3bf7f14fe9d0" />

With dark mode, it has the same issue where the icon colours on the input don't match.

<img width="2600" height="1286" alt="image" src="https://github.com/user-attachments/assets/ff95ffa1-430e-4c89-a7e6-5889b51e8b39" />

```blade
<?php

use Livewire\Component;

new class extends Component {
    //
};

?>

<div class="mt-4 mx-auto max-w-xs space-y-4">
    <flux:input icon="calendar" icon:trailing="chevron-down" placeholder="Input..."  />
    <flux:date-picker  />
    <flux:select variant="listbox" placeholder="Select...">
        <flux:select.option>Photography</flux:select.option>
        <flux:select.option>Design services</flux:select.option>
        <flux:select.option>Web development</flux:select.option>
        <flux:select.option>Accounting</flux:select.option>
        <flux:select.option>Legal services</flux:select.option>
        <flux:select.option>Consulting</flux:select.option>
        <flux:select.option>Other</flux:select.option>
    </flux:select>
</div>
```

# The problem

The issue is that input icons are using `text-zinc-400/75` where as the date picker and select are using `text-zinc-300` in light mode.

For dark mode, input icons don't have a specific dark class set, so are still using `text-zinc-400/75`, where as date/select are using `text-white/60`.

The issue with the icon alignments is that date and select are both buttons, so can have padding applied and the icons will set inside that (which includes the border thickness). Where as the input icons are within absolutely positioned divs.

# The solution

There is a corresponding Flux Pro PR livewire/flux-pro#346.

The solution is to fix date and select icon colours to match those of the input when in light mode and add input icon dark mode classes to match date/select.

<img width="2598" height="1264" alt="image" src="https://github.com/user-attachments/assets/ae6b0d89-78ec-4506-a2c3-2e3a7d8f7ae3" />

<img width="2594" height="1264" alt="image" src="https://github.com/user-attachments/assets/1f04e6c1-74ed-4c69-bd73-372fd4165231" />

I chose use the light mode icon colours from the input instead of date/select as it gives a stronger contrast when the controls are disabled, as the icon changes colour more. See screenshot below with enabled vs disabled for date and select.

<img width="2596" height="1710" alt="image" src="https://github.com/user-attachments/assets/3dfe6e07-e9af-4c95-a5fd-1a81931d3fbe" />

<img width="2606" height="1728" alt="image" src="https://github.com/user-attachments/assets/44d4f68e-2118-48c4-9bb7-98aa7f77411f" />

I also fixed the padding on the input leading and trailing icon groups to match date and select. 

<img width="2878" height="1444" alt="image" src="https://github.com/user-attachments/assets/75279a88-96b7-4262-8500-07ff9e52c216" />

Fixes livewire/flux#1466