### PR TITLE
Fix last month date range preset

### DIFF
--- a/src/DateRangePreset.php
+++ b/src/DateRangePreset.php
@@ -34,7 +34,9 @@ enum DateRangePreset: string
             static::LastWeek => [ Carbon::now()->subWeek()->startOfWeek(), Carbon::now()->subWeek()->endOfWeek() ],
             static::Last7Days => [ Carbon::now()->subDays(7)->addDay()->startOfDay(), Carbon::now()->endOfDay() ],
             static::ThisMonth => [ Carbon::now()->startOfMonth(), Carbon::now()->endOfMonth() ],
-            static::LastMonth => [ Carbon::now()->subMonth()->startOfMonth(), Carbon::now()->subMonth()->endOfMonth() ],
+            // If it is currently the 31st of the month, and we do `subMonth()`, if the previous month has 30 days, it will return the 1st of
+            // the current month, not the 30th of the previous month. So we need to use `startOfMonth()` first before doing `subMonth()`...
+            static::LastMonth => [ Carbon::now()->startOfMonth()->subMonth(), Carbon::now()->startOfMonth()->subMonth()->endOfMonth() ],
             static::ThisQuarter => [ Carbon::now()->startOfQuarter(), Carbon::now()->endOfQuarter() ],
             static::LastQuarter => [ Carbon::now()->subQuarter()->startOfQuarter(), Carbon::now()->subQuarter()->endOfQuarter() ],
             static::ThisYear => [ Carbon::now()->startOfYear(), Carbon::now()->endOfYear() ],


### PR DESCRIPTION
# The scenario

Currently if you use the date picker with presets and the current date is the 31st of the month, if you click on current month or last month, the dates don't change.

![Screenshot 2025-10-31 at 08 56 08PM](https://github.com/user-attachments/assets/c9be5685-f262-4857-9a6a-e4b83ef9604f)


```blade
<?php

use Flux\DateRange;
use Livewire\Component;

new class extends Component {
    public $range;

    public function mount()
    {
        $this->range = DateRange::thisMonth();
    }
}; ?>

<div>
    <flux:text>Preset: {{ $range->preset()->label() }}</flux:text>
    <flux:text>Start Date: {{ $range->start()->toFormattedDateString() }}</flux:text>
    <flux:text>End Date: {{ $range->end()->toFormattedDateString() }}</flux:text>
    
    <flux:date-picker wire:model.live="range" mode="range" presets="lastMonth thisMonth" />
</div>
```

# The problem

The issue is that the way that the lastMonth preset is calculated. When it is selected, the following is run on the back end:

```php
static::LastMonth => [ Carbon::now()->subMonth()->startOfMonth(), Carbon::now()->subMonth()->endOfMonth() ],
```

What happens is that if the current date (`Carbon::now()`) is the 31st, like the 31st of October, if we then call `->subMonth()`, as there is no 31st of November, it instead returns the 1st of October.

So then when we call `startOfMonth()/endOfMonth()` we are getting 1st/31 October as the dates for the last month present.

# The solution

The solution is to call `startOfMonth()` first before we do any subtractions, that way the correct dates get calculated without worrying about the 31st of the month issues.

Now it all works as expected.

![Screenshot 2025-10-31 at 08 55 25PM](https://github.com/user-attachments/assets/b70f9128-395c-48a8-8dd6-ff50c349ce65)

Fixes livewire/flux#1647