### PR TITLE
Fix flash file-upload component on wire:navigate

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -249,7 +249,7 @@ File upload styles...
 */
 ui-file-upload {
     & > * {
-        transition: opacity 0.35s allow-discrete, transform 0.35s allow-discrete, height 0.35s allow-discrete;
+        transition: none;
     }
 }
 


### PR DESCRIPTION
# The scenario

When using file-upload component on the page and then do wire:navigate it will flash when on dark mode.


# The problem


https://github.com/user-attachments/assets/23702c0e-998f-4295-9377-25442f5360b6



# The solution
```
ui-file-upload {
    & > * {
        transition: none;
    }
}
```


https://github.com/user-attachments/assets/549f64dc-5610-48df-9afd-de0eb2d5a80b


