### PR TITLE
Add support for inline field with inputs

### DIFF
--- a/stubs/resources/views/flux/field.blade.php
+++ b/stubs/resources/views/flux/field.blade.php
@@ -14,11 +14,18 @@ $classes = Flux::classes()
         default => 'block',
         'inline' => [
             'grid gap-x-3 gap-y-1.5',
+            // Support for inline controls...
             'has-[[data-flux-label]~[data-flux-control]]:grid-cols-[1fr_auto]',
             'has-[[data-flux-control]~[data-flux-label]]:grid-cols-[auto_1fr]',
             '[&>[data-flux-control]~[data-flux-description]]:row-start-2 [&>[data-flux-control]~[data-flux-description]]:col-start-2',
             '[&>[data-flux-control]~[data-flux-error]]:col-span-2 [&>[data-flux-control]~[data-flux-error]]:mt-1', // Position error messages...
             '[&>[data-flux-label]~[data-flux-control]]:row-start-1 [&>[data-flux-label]~[data-flux-control]]:col-start-2',
+            // Support for inline inputs...
+            'has-[[data-flux-label]~[data-flux-input]]:grid-cols-[auto_1fr]',
+            'has-[[data-flux-input]~[data-flux-label]]:grid-cols-[1fr_auto]',
+            '[&>[data-flux-input]~[data-flux-description]]:row-start-2 [&>[data-flux-input]~[data-flux-description]]:col-start-2',
+            '[&>[data-flux-input]~[data-flux-error]]:col-span-2 [&>[data-flux-input]~[data-flux-error]]:mt-1', // Position error messages...
+            '[&>[data-flux-label]~[data-flux-input]]:row-start-1 [&>[data-flux-label]~[data-flux-input]]:col-start-2',
         ],
     })
     ->add(match ($variant) {


### PR DESCRIPTION
# The scenario

Currently if you wrap an input in field and add `variant="inline"` nothing happens.

<img width="966" height="248" alt="Screenshot 2025-11-25 at 01 41 03PM@2x" src="https://github.com/user-attachments/assets/5429ff24-2442-4211-9081-93e51645ad89" />

```blade
<flux:field variant="inline">
    <flux:label>Email</flux:label>
    <flux:input wire:model="email" type="email" />
    <flux:error name="email" />
</flux:field>
```

# The problem

When investigating this, I looked up to see how inline was being handled for radios/checkboxes and found that the following classes were added to the field component to support it.

```php
'has-[[data-flux-label]~[data-flux-control]]:grid-cols-[1fr_auto]',
'has-[[data-flux-control]~[data-flux-label]]:grid-cols-[auto_1fr]',
'[&>[data-flux-control]~[data-flux-description]]:row-start-2 [&>[data-flux-control]~[data-flux-description]]:col-start-2',
'[&>[data-flux-control]~[data-flux-error]]:col-span-2 [&>[data-flux-control]~[data-flux-error]]:mt-1', // Position error messages...
'[&>[data-flux-label]~[data-flux-control]]:row-start-1 [&>[data-flux-label]~[data-flux-control]]:col-start-2',
```

The thing to note is these styles are being applied based on the existence of a `data-flux-control` element inside the field.

But if we have a look at how an input is structured, we can see that while the input has `data-flux-control` on it, it's wrapped in a div that has `data-flux-input` on it.

```
<div ... data-flux-input>
    ....

    <input
        ...
        data-flux-control
        data-flux-group-target
        ...
    >

    ...
</div>
```

This means that the above classes don't apply as there is no `data-flux-control` as a direct child of the field.

# The solution

The solution is to add classes that add support for a field with a `data-flux-input` inside of it.

So this PR adds the following classes (in addition to the ones above already on the field component).

```
'has-[[data-flux-label]~[data-flux-input]]:grid-cols-[auto_1fr]',
'has-[[data-flux-input]~[data-flux-label]]:grid-cols-[1fr_auto]',
'[&>[data-flux-input]~[data-flux-description]]:row-start-2 [&>[data-flux-input]~[data-flux-description]]:col-start-2',
'[&>[data-flux-input]~[data-flux-error]]:col-span-2 [&>[data-flux-input]~[data-flux-error]]:mt-1', // Position error messages...
'[&>[data-flux-label]~[data-flux-input]]:row-start-1 [&>[data-flux-label]~[data-flux-input]]:col-start-2',
```

Now inline works as expected.

<img width="966" height="176" alt="Screenshot 2025-11-25 at 01 40 44PM@2x" src="https://github.com/user-attachments/assets/01f5270a-e36e-4e9e-b458-b212a48b4ff2" />

You might be wondering, can we not just do this all in the same set of classes? And yes, it might be possible, especially if we were to move the `data-flux-control` from the input to it's wrapping div.

But that would be a breaking change and currently the Laravel starter kits have CSS selectors targeting input with `data-flux-control` specifically. https://github.com/laravel/livewire-starter-kit/blob/7c00af994b1c87f6775011b9fa428b0d5a5cf176/resources/css/app.css#L58

There is also another problem.

In the scenario of a checkbox, the following would get applied `has-[[data-flux-label]~[data-flux-control]]:grid-cols-[1fr_auto]`.

This means that the label would take up all of the available space and the checkbox control would shrink.

If we were to apply this to an input though, it would mean the label takes up a lot of space and the input is tiny.

So the classes applied above for the input have also been tweaked to ensure they work properly with inputs, such as the grid cols being swapped `has-[[data-flux-label]~[data-flux-input]]:grid-cols-[auto_1fr]`.

Fixes livewire/flux#1784