### PR TITLE
Fix profile avatar colour seed

### DIFF
--- a/stubs/resources/views/flux/profile.blade.php
+++ b/stubs/resources/views/flux/profile.blade.php
@@ -33,7 +33,8 @@ $classes = Flux::classes()
         <?php if ($avatar instanceof \Illuminate\View\ComponentSlot): ?>
             {{ $avatar }}
         <?php else: ?>
-            <flux:avatar :attributes="Flux::attributesAfter('avatar:', $attributes, ['src' => $avatar, 'size' => 'sm', 'circle' => $circle, 'name' => $name, 'initials' => $initials])" />
+            <?php $avatarAttributes = Flux::attributesAfter('avatar:', $attributes, ['src' => $avatar, 'size' => 'sm', 'circle' => $circle, 'name' => $name, 'initials' => $initials]); ?>
+            <flux:avatar :attributes="$avatarAttributes" />
         <?php endif; ?>
     </div>
 


### PR DESCRIPTION
# The scenario

Currently if you pass the same parameters (including `avatar:color:seed`) to the sidebar profile component and the normal profile component, the colours are different.

<img width="1228" height="978" alt="Screenshot 2025-11-25 at 05 55 59PM@2x" src="https://github.com/user-attachments/assets/db235b29-6699-43ce-900a-27e1c1431caf" />

```blade
<?php

use Livewire\Component;

new class extends Component {
    //
}; ?>

<div>
    <flux:sidebar.profile name="Donnie" initials="D" avatar:color="auto" avatar:color:seed="1" />

    <flux:profile name="Donnie" initials="D" avatar:color="auto" avatar:color:seed="1" />
</div>
```

# The problem

The issue is actually in the profile component. The sidebar.profile is working as expected.

When I dug into it, I found the `avatar:color:seed` attribute wasn't getting to the avatar component when used in the profile component.

The issue is actually the same issue as the problem fixed in PR #2089 where data was getting striped when using `Flux::attributesAfter()` inline on a Blade component call instead of using a temporary variable first.

```blade
<flux:avatar :attributes="Flux::attributesAfter('avatar:', $attributes, ['src' => $avatar, 'size' => 'sm', 'circle' => $circle, 'name' => $name, 'initials' => $initials])" />
```

# The solution

The solution is to update the profile component to extract the avatar attributes to a temporary variable first.

```blade
<?php $avatarAttributes = Flux::attributesAfter('avatar:', $attributes, ['src' => $avatar, 'size' => 'sm', 'circle' => $circle, 'name' => $name, 'initials' => $initials]); ?>
<flux:avatar :attributes="$avatarAttributes" />
```

Now everything works as expected.

Not sure how profile was missed, but I've done a search in Flux and Flux Pro to make sure all other instances of `Flux::attributesAfter()` are covered.

<img width="1228" height="978" alt="Screenshot 2025-11-25 at 05 55 25PM@2x" src="https://github.com/user-attachments/assets/2552c9e0-0838-4ebe-879e-5313fbb77871" />

Fixes livewire/flux#2166