### PR TITLE
Add support for assets in subfolders

### DIFF
--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -82,9 +82,9 @@ class AssetManager
         $nonce = isset($options) && isset($options['nonce']) ? ' nonce="' . $options['nonce'] . '"' : '';
 
         if (config('app.debug')) {
-            return '<script src="/flux/flux.js?id='. $versionHash . '" data-navigate-once' . $nonce . '></script>';
+            return '<script src="'. url('/flux/flux.js?id='. $versionHash) . '" data-navigate-once' . $nonce . '></script>';
         } else {
-            return '<script src="/flux/flux.min.js?id='. $versionHash . '" data-navigate-once' . $nonce . '></script>';
+            return '<script src="'. url('/flux/flux.min.js?id='. $versionHash) . '" data-navigate-once' . $nonce . '></script>';
         }
     }
 
@@ -135,9 +135,9 @@ HTML;
         $versionHash = $manifest['/editor.js'];
 
         if (config('app.debug')) {
-            return '<script src="/flux/editor.js?id='. $versionHash . '" defer></script>';
+            return '<script src="'. url('/flux/editor.js?id='. $versionHash) . '" defer></script>';
         } else {
-            return '<script src="/flux/editor.min.js?id='. $versionHash . '" defer></script>';
+            return '<script src="'. url('/flux/editor.min.js?id='. $versionHash) . '" defer></script>';
         }
     }
 
@@ -147,7 +147,7 @@ HTML;
 
         $versionHash = $manifest['/editor.css'];
 
-        return '<link rel="stylesheet" href="/flux/editor.css?id='. $versionHash . '">';
+        return '<link rel="stylesheet" href="'. url('/flux/editor.css?id='. $versionHash) . '">';
     }
 
     public function pretendResponseIsFile($file, $contentType = 'application/javascript; charset=utf-8')


### PR DESCRIPTION
# The scenario

Currently if you run Laravel from a subfolder, like `http://localhost:8080/test-site/`, Flux's assets return a 404.

<img width="2052" height="170" alt="Screenshot 2025-11-27 at 12 49 57PM@2x" src="https://github.com/user-attachments/assets/db5abe9a-c011-4ba4-a041-0c84ae7de13d" />


# The problem

The problem is that Flux's `<script>` and `<link>` tags reference a root-relative URL. This means that when rendered they look like:

```html
<script src="/flux/flux.js?id=6bd8aa7b" data-navigate-once=""></script>
```

So this means that it's actually looking for Flux's javascript in `localhost:8080/flux/flux.js`.

As you can see though, the subfolder of `test-site` isn't there and as that's where the Laravel app is being served from, it's returning a 404.

# The solution

The solution is actually quite simple, we can wrap the `/flux/flux.js` in the `url()` helper, like `url('/flux/flux.js')` which will actually give us an absolute URL including the domain name and any subfolders.

This PR adds the url helper to all of Flux's asset paths.

You can see in the screenshot below that I tested this on a standard setup, subdomains and subfolders and all are working happily.

**Standard install**
<img width="1294" height="76" alt="Screenshot 2025-11-27 at 12 43 33PM@2x" src="https://github.com/user-attachments/assets/1314c10b-6829-4462-bc5e-b294a6eb0538" />

**Subdomain**
<img width="1454" height="78" alt="Screenshot 2025-11-27 at 12 43 12PM@2x" src="https://github.com/user-attachments/assets/747f007b-307f-402c-91a5-f69e26ad1926" />

**Subfolder**
<img width="1652" height="84" alt="Screenshot 2025-11-27 at 12 41 11PM@2x" src="https://github.com/user-attachments/assets/8cc0ffd4-6ad0-48d4-83c5-710a6fac5055" />

I also checked this against the problems we have had with Livewire's assets/urls in the past (localisation, tenants, etc.) and the primary issue when its comes to localisation/tenants is Livewire's update route. The actual asset URLs don't need to be localised/tenanted from what I could find.

Because of that, I believe that this fix should be sufficient for Flux, as it only has assets and no update route.

Fixes livewire/flux#1617