### PR TITLE
Fix private OTP within a group

### DIFF
--- a/stubs/resources/views/flux/otp/index.blade.php
+++ b/stubs/resources/views/flux/otp/index.blade.php
@@ -19,7 +19,7 @@
     >
         <?php if($slot->isEmpty() && $length): ?>
             <?php for($i = 0; $i < $length; $i++): ?>
-                <flux:otp.input type="{{ $private ? 'password' : 'text' }}" />
+                <flux:otp.input />
             <?php endfor; ?>
         <?php else: ?>
             {{ $slot }}

--- a/stubs/resources/views/flux/otp/input.blade.php
+++ b/stubs/resources/views/flux/otp/input.blade.php
@@ -1,4 +1,4 @@
-@aware(['mode' => 'numeric'])
+@aware(['mode' => 'numeric', 'private' => false])
 
 @php
     $attributes = $attributes
@@ -11,6 +11,10 @@
 
     if ($mode == 'numeric') {
         $attributes = $attributes->merge(['inputmode' => 'numeric']);
+    }
+
+    if ($private) {
+        $attributes = $attributes->merge(['type' => 'password']);
     }
 @endphp
 


### PR DESCRIPTION
# The scenario

An OTP with manually defined inputs inside a group doesn't respect the `private` prop:

```
<flux:otp private label="PIN Code">
    <flux:otp.group>
        <flux:otp.input />
        <flux:otp.input />
        <flux:otp.input />
        <flux:otp.input />
    </flux:otp.group>
</flux:otp>
```

These will be displayed as regular text input without masking.

# The problem

The `private` prop only works for inputs rendered from inside the main `flux:otp` component (when `length` is used).

# The solution

Moving the `private` logic from the main component to the individual input components + `@aware` fixes this

Fixes livewire/flux#2199