### PR TITLE
Remove flex from floating flyout

### DIFF
--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -35,7 +35,7 @@ if ($flyout) {
         })
         ->add(match ($variant) {
             default => 'bg-white dark:bg-zinc-800 border-transparent dark:border-zinc-700',
-            'floating' => 'flex flex-col bg-white dark:bg-zinc-800 ring ring-black/5 dark:ring-zinc-700 shadow-lg rounded-xl',
+            'floating' => 'bg-white dark:bg-zinc-800 ring ring-black/5 dark:ring-zinc-700 shadow-lg rounded-xl',
             'bare' => 'bg-transparent',
         });
 } else {


### PR DESCRIPTION
In addition to the animations, this also fixes #2214.

I'm not completely sure why though, might be worth investigating. 

# The scenario

The new floating flyout causes jank during open transition in Safari.

**In Livewire starter kit (layout shift):**

https://github.com/user-attachments/assets/625a256e-8a4e-4fc6-8e06-fe85c7243236

**In the docs (skipped frames):**

https://github.com/user-attachments/assets/4349e84d-fc43-4d01-8b8e-31a8ac936d1f

# The problem

The floating variant adds `flex flex-col` to the dialog element.

This is different from all other variants which don't set the display property.

# The solution

Removing `flex flex-col` fixes this issue.

I can't see any particular reason the modal should have a display preference. It doesn't affect its appearance and the user can always add these classes to a div inside the modal.

https://github.com/user-attachments/assets/8265364d-0315-4f93-bdbc-5bd3ab9bffca

https://github.com/user-attachments/assets/3f0e5574-44ec-4688-8a30-514f3f4f4169

Fixes livewire/flux#