### PR TITLE
Fix sidebar brand dark mode logo

### DIFF
--- a/stubs/resources/views/flux/sidebar/brand.blade.php
+++ b/stubs/resources/views/flux/sidebar/brand.blade.php
@@ -51,7 +51,10 @@ $textClasses = Flux::classes()
             </div>
         <?php else: ?>
             <div class="flex items-center justify-center h-6 rounded-sm overflow-hidden shrink-0">
-                <?php if ($logo): ?>
+                <?php if ($logoDark): ?>
+                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6 dark:hidden" />
+                    <img src="{{ $logoDark }}" alt="{{ $alt }}" class="h-6 hidden dark:block" />
+                <?php elseif ($logo): ?>
                     <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6" />
                 <?php else: ?>
                     {{ $slot }}


### PR DESCRIPTION
# The scenario

Currently if you have the sidebar brand component with no name, but both light and dark logos, only the light logo is shown in dark mode.

**Light mode**
<img width="1258" height="1000" alt="Screenshot 2025-12-11 at 11 42 11AM@2x" src="https://github.com/user-attachments/assets/104ae26f-4384-4e7e-93ce-07586e1d70e7" />

**Dark mode**
<img width="1258" height="1000" alt="Screenshot 2025-12-11 at 11 42 03AM@2x" src="https://github.com/user-attachments/assets/6c8ca202-4dd9-420a-a492-75e802ed65c6" />

```blade
<flux:sidebar.brand
    href="/"
    logo="{{ asset('images/flux-light.png') }}"
    logoDark="{{ asset('images/flux-dark.png') }}"
/>
```

# The problem

The issue is that when a `name` prop is provided, there is a conditional to check if a dark logo exists, and if so, shows that. But that same conditional doesn't exist if there is no name.

```blade
<?php if ($name): ?>
    ...
                <?php if ($logoDark): ?>
                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6 min-w-6 dark:hidden" />
                    <img src="{{ $logoDark }}" alt="{{ $alt }}" class="h-6 min-w-6 hidden dark:block" />
                <?php elseif ($logo): ?>
                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6 min-w-6" />
                <?php else: ?>
                    {{ $slot }}
                <?php endif; ?>
    ...
<?php else: ?>
    ...
                <?php if ($logo): ?>
                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6" />
                <?php else: ?>
                    {{ $slot }}
                <?php endif; ?>
    ...
<?php endif; ?>
```

# The solution

The solution is to add the `if ($logoDark)` check also when there is no name.

```blade
<?php if ($name): ?>
    ...
                <?php if ($logoDark): ?>
                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6 min-w-6 dark:hidden" />
                    <img src="{{ $logoDark }}" alt="{{ $alt }}" class="h-6 min-w-6 hidden dark:block" />
                <?php elseif ($logo): ?>
                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6 min-w-6" />
                <?php else: ?>
                    {{ $slot }}
                <?php endif; ?>
    ...
<?php else: ?>
    ...
                <?php if ($logoDark): ?>
                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6 dark:hidden" />
                    <img src="{{ $logoDark }}" alt="{{ $alt }}" class="h-6 hidden dark:block" />
                <?php elseif ($logo): ?>
                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6" />
                <?php else: ?>
                    {{ $slot }}
                <?php endif; ?>
    ...
<?php endif; ?>
```

Now it all works as expected.

**Light mode**
<img width="1258" height="1000" alt="Screenshot 2025-12-11 at 11 41 41AM@2x" src="https://github.com/user-attachments/assets/7e0ba21c-e989-4fd2-a1ca-063f023dab3d" />

**Dark mode**
<img width="1258" height="1000" alt="Screenshot 2025-12-11 at 11 41 56AM@2x" src="https://github.com/user-attachments/assets/6ae5b402-b495-4f1b-9513-37e16a4219e1" />

Fixes livewire/flux#2219