### PR TITLE
Fixed bug with input loading state that caused it to always show load…

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -63,6 +63,7 @@ $countOfTrailingIcons = collect([
 
 $iconClasses = Flux::classes()
     // When using the outline icon variant, we need to size it down to match the default icon sizes...
+    ->add('hidden')
     ->add($iconVariant === 'outline' ? 'size-5' : '')
     ;
 
@@ -152,7 +153,7 @@ $classes = Flux::classes()
                 <div class="absolute top-0 bottom-0 flex items-center gap-x-1.5 pe-3 -me-1 border-e border-transparent end-0 text-xs text-zinc-400">
                     {{-- Icon should be text-zinc-400/75 --}}
                     <?php if ($loading): ?>
-                        <flux:icon name="loading" :variant="$iconVariant" :class="$iconClasses" wire:loading :wire:target="$wireTarget" />
+                        <flux:icon name="loading" :variant="$iconVariant" :class="$iconClasses" wire:loading.class.remove="hidden" :wire:target="$wireTarget" />
                     <?php endif; ?>
 
                     <?php if ($clearable): ?>


### PR DESCRIPTION
…ing with wire:model.live

# The scenario

When using `wire:model.live`, the loading state is always active.

<!-- Describe as succinctly as possible what the bug/problem is. Be sure to include the steps to reproduce the bug, screenshots of the issue, and a self-contained Volt class component, which includes all Blade variable definitions, to reproduce the issue. -->

# The problem

Livewire and/or Flux was not correctly hiding the loading state when not needed.

<!-- Describe here in detail what you found is wrong with the current code in this package. Add snippets of code here so the maintainers don't need to search the codebase for the issue. -->

# The solution

Added default hidden class and updated the `wire:loading` property to remove the class when busy.

<!-- Describe here what you did to fix the problem, whether there were other possible solutions, and why you chose this one. Be sure to include snippets of the code changes you have made and screenshots of the problem fixed after your changes. -->



Fixes livewire/flux#