### PR TITLE
Only activate the placeholder active styles when not focused.

### DIFF
--- a/stubs/resources/views/flux/select/variants/default.blade.php
+++ b/stubs/resources/views/flux/select/variants/default.blade.php
@@ -22,7 +22,7 @@ $classes = Flux::classes()
     ->add('bg-white dark:bg-white/10 dark:disabled:bg-white/[7%]')
     ->add('text-zinc-700 dark:text-zinc-300 disabled:text-zinc-500 dark:disabled:text-zinc-400')
     // Make the placeholder match the text color of standard input placeholders...
-    ->add('has-[option.placeholder:checked]:text-zinc-400 dark:has-[option.placeholder:checked]:text-zinc-400')
+    ->add('not-focus:has-[option.placeholder:checked]:text-zinc-400 dark:not-focus:has-[option.placeholder:checked]:text-zinc-400')
     // Options on Windows don't inherit dark mode styles, so we need to force them...
     ->add('dark:[&>option]:bg-zinc-700 dark:[&>option]:text-white')
     ->add('disabled:shadow-none')


### PR DESCRIPTION
# The scenario

Whilst this likely affects both light and dark mode, it was most noticable in Light mode, where `has-[option.placeholder:checked]:text-zinc-400` would cause all options to appear as if they were disabled.

<!-- Describe as succinctly as possible what the bug/problem is. Be sure to include the steps to reproduce the bug, screenshots of the issue, and a self-contained Volt class component, which includes all Blade variable definitions, to reproduce the issue. -->

# The problem

Applied styles were active as long as the placeholder was selected, causing all other options to appear as if they were placeholders.

<!-- Describe here in detail what you found is wrong with the current code in this package. Add snippets of code here so the maintainers don't need to search the codebase for the issue. -->

# The solution

Updated the applied styles to only activate when the select is not focused. When open (focused) the browser will handle the presentation of the disabled placeholder, allowing the options to be visible as they should be.

<!-- Describe here what you did to fix the problem, whether there were other possible solutions, and why you chose this one. Be sure to include snippets of the code changes you have made and screenshots of the problem fixed after your changes. -->



Fixes livewire/flux#