### PR TITLE
Fix input overflow

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -149,7 +149,7 @@ $classes = Flux::classes()
             >
 
             <?php if ($loading || $countOfTrailingIcons > 0): ?>
-                <div class="absolute top-0 bottom-0 flex items-center gap-x-1.5 pe-3 -me-1 border-e border-transparent end-0 text-xs text-zinc-400">
+                <div class="absolute top-0 bottom-0 flex items-center gap-x-1.5 pe-2 border-e border-transparent end-0 text-xs text-zinc-400">
                     {{-- Icon should be text-zinc-400/75 --}}
                     <?php if ($loading): ?>
                         <flux:icon name="loading" :variant="$iconVariant" :class="$iconClasses" wire:loading :wire:target="$wireTarget" />


### PR DESCRIPTION
# The scenario

An input inside a scrollable container causes overflow:

```html
<div class="mt-4 mx-auto max-w-xs">
    <div class="border border-red-500 overflow-x-scroll">
        <flux:input copyable />
    </div>
</div>
```

<img width="588" height="138" alt="SCR-20251212-shzv" src="https://github.com/user-attachments/assets/b7be5294-03bf-43de-8ca2-25dc533bf288" />

# The problem

In version 2.8.0 we made the icon alignment consistent across components.

The below screenshot shows the alignment issue before 2.8.0:

<img width="550" alt="SCR-20251212-sjwy-2" src="https://github.com/user-attachments/assets/dc68f9c9-902f-4c1b-b561-8f0e1a10a025" />

The chevron icon in input (first row) was slightly offset to the left.

To compensate for this a `-me-1` was added to the icon container, however this made it overflow its container

<img width="658" height="245" alt="SCR-20251212-sjwy" src="https://github.com/user-attachments/assets/ad189d64-71de-44a8-82fd-efb06aca30a5" />

# The solution

Removing negative margin and instead reducing the padding on the right side fixes the issue.

@joshhanley, this change was done in this PR of yours: https://github.com/livewire/flux/pull/2158.

Please let me know in case I'm missing something and the padding can't be reduced like this.

Fixes livewire/flux#2186