### PR TITLE
Require Blaze 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "laravel/prompts": "^0.1|^0.2|^0.3"
     },
     "conflict": {
-        "livewire/blaze": "<0.1.0"
+        "livewire/blaze": "<1.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# The scenario

Installing Blaze using `composer require livewire/blaze` requires the old 0.1 version.

# The problem

This version doesn't properly handle php blocks and throws an error when parsing the following code in `<flux:modal>`:

```php
<?php
// Support <flux:modal ... @close="?"> syntax...
if ($attributes['@close'] ?? null) {
    $attributes['wire:close'] = $attributes['@close'];
    unset($attributes['@close']);
}
```

The comment that contains component syntax is parsed as Blade and throws an error likely because of the three dots.

Users are running into this issue when trying Blaze with Flux: https://github.com/livewire/flux/issues/2121

# The solution

Updating composer.json to conflict with any version below 1.0 fixes this issue.

_However_, if the user requires `"minimum-stability": "stable"` in their composer.json, running `composer require livewire/blaze` will throw an error:

```
Your requirements could not be resolved to an installable set of packages.
````

This is because the latest `1.0-beta` version is marked as a pre-release and requires `"minimum-stability": "dev"`.

To get around this, one can specify the exact version during install:

```
composer require livewire/blaze:^1.0@beta
```

To eliminate this, we could also release a new version that's not marked as a pre-release.

Fixes livewire/flux#2121