### PR TITLE
Add logo:dark support to flux:brand

### DIFF
--- a/stubs/resources/views/flux/brand.blade.php
+++ b/stubs/resources/views/flux/brand.blade.php
@@ -1,8 +1,11 @@
 @blaze
 
+@php $logoDark ??= $attributes->pluck('logo:dark'); @endphp
+
 @props([
     'name' => null,
     'logo' => null,
+    'logoDark' => null,
     'alt' => null,
     'href' => '/',
 ])
@@ -25,7 +28,10 @@ $textClasses = Flux::classes()
             </div>
         <?php else: ?>
             <div class="flex items-center justify-center h-6 rounded-sm overflow-hidden shrink-0">
-                <?php if ($logo): ?>
+                <?php if ($logoDark): ?>
+                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6 dark:hidden" />
+                    <img src="{{ $logoDark }}" alt="{{ $alt }}" class="h-6 hidden dark:block" />
+                <?php elseif ($logo): ?>
                     <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6" />
                 <?php else: ?>
                     {{ $slot }}
@@ -43,7 +49,10 @@ $textClasses = Flux::classes()
             </div>
         <?php else: ?>
             <div class="flex items-center justify-center h-6 rounded-sm overflow-hidden shrink-0">
-                <?php if ($logo): ?>
+                <?php if ($logoDark): ?>
+                    <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6 dark:hidden" />
+                    <img src="{{ $logoDark }}" alt="{{ $alt }}" class="h-6 hidden dark:block" />
+                <?php elseif ($logo): ?>
                     <img src="{{ $logo }}" alt="{{ $alt }}" class="h-6" />
                 <?php else: ?>
                     {{ $slot }}


### PR DESCRIPTION
# The scenario

The `logo:dark` prop is not supported in `flux:brand`.

```blade
<flux:brand logo="{{ asset('logo.svg') }}" logo:dark="{{ asset('logo.svg') }}" />
```

Users expect this to work the same way as `flux:sidebar.brand`, where this does work:

```blade
<flux:sidebar.brand logo="{{ asset('logo.svg') }}" logo:dark="{{ asset('logo.svg') }}" />
```

# The problem

The `flux:brand` doesn't have `logo:dark` prop.

# The solution

Add `logo:dark` prop that renders both logos and switches between them based on the theme.

Also includes fix from https://github.com/livewire/flux/pull/2231

Fixes livewire/flux#2240