### PR TITLE
Allow forcing of `data-current` in links

### DIFF
--- a/stubs/resources/views/flux/button-or-link.blade.php
+++ b/stubs/resources/views/flux/button-or-link.blade.php
@@ -15,7 +15,6 @@ extract(Flux::forwardedAttributes($attributes, [
 ])
 
 @php
-
 $hrefForCurrentDetection = str($href)->startsWith(trim(config('app.url')))
     ? (string) str($href)->after(trim(config('app.url'), '/'))
     : $href;
@@ -40,11 +39,11 @@ $current = $current === null ? ($hrefForCurrentDetection
     </div>
 <?php elseif ($as === 'a' || $href): ?>
     {{-- We are using e() here to escape the href attribute value instead of "{{ }}" because the latter will escape the entire attribute value, including the "&" character... --}}
-    <a href="{!! e($href) !!}" {{ $attributes->merge(['data-current' => $current]) }}>
+    <a href="{!! e($href) !!}" {{ $attributes->merge(['data-current' => $current, 'wire:current.ignore' => $current !== null]) }}>
         {{ $slot }}
     </a>
 <?php else: ?>
-    <button {{ $attributes->merge(['type' => $type, 'data-current' => $current]) }}>
+    <button {{ $attributes->merge(['type' => $type, 'data-current' => $current, 'wire:current.ignore' => $current !== null]) }}>
         {{ $slot }}
     </button>
 <?php endif; ?>


### PR DESCRIPTION
# The scenario

A link with `:current="true"` and `wire:navigate` using Livewire v4:

```
<flux:sidebar.item href="/admin" :current="true" wire:navigate>Admin</flux:sidebar.item>
```

# The problem

The `current` prop will be ignored.

Under the hood, this prop simply adds `data-current` attribute on the link. Because Livewire v4 manages `data-current` automatically on all links with `wire:navigate` based on the current url, it will remove the attribute on page load.

# The solution

Adding the [newly introduced](https://github.com/livewire/livewire) `wire:current.ignore` directive when `current` is present fixes the issue.


Fixes livewire/flux#2233