### PR TITLE
Revert "Allow forcing of `data-current` in links"

### DIFF
--- a/stubs/resources/views/flux/button-or-link.blade.php
+++ b/stubs/resources/views/flux/button-or-link.blade.php
@@ -15,6 +15,7 @@ extract(Flux::forwardedAttributes($attributes, [
 ])
 
 @php
+
 $hrefForCurrentDetection = str($href)->startsWith(trim(config('app.url')))
     ? (string) str($href)->after(trim(config('app.url'), '/'))
     : $href;
@@ -39,11 +40,11 @@ $current = $current === null ? ($hrefForCurrentDetection
     </div>
 <?php elseif ($as === 'a' || $href): ?>
     {{-- We are using e() here to escape the href attribute value instead of "{{ }}" because the latter will escape the entire attribute value, including the "&" character... --}}
-    <a href="{!! e($href) !!}" {{ $attributes->merge(['data-current' => $current, 'wire:current.ignore' => $current !== null]) }}>
+    <a href="{!! e($href) !!}" {{ $attributes->merge(['data-current' => $current]) }}>
         {{ $slot }}
     </a>
 <?php else: ?>
-    <button {{ $attributes->merge(['type' => $type, 'data-current' => $current, 'wire:current.ignore' => $current !== null]) }}>
+    <button {{ $attributes->merge(['type' => $type, 'data-current' => $current]) }}>
         {{ $slot }}
     </button>
 <?php endif; ?>


### PR DESCRIPTION
We're temporarily reverting this until we can get `wire:current.ignore` added to Livewire v3, then we will reintroduce it.

Reverts livewire/flux#2246