### PR TITLE
Display outline on pillbox combobox variant

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -255,3 +255,11 @@ Utilties
 .flux-no-scrollbar::-webkit-scrollbar{
     display:none
 }
+
+.has-focus-visible\:outline-default {
+    &:has(*:focus-visible) {
+        outline: auto;
+        outline-color: Highlight;
+        outline-color: -webkit-focus-ring-color;
+    }
+}


### PR DESCRIPTION
Because the pillbox itself isn't an input but only acts as one, it doesnt' display browser outline by default.

This class mimics the default browser outline.

It has already been added on the component itself but was missing in flux.css.

<img width="1035" height="353" alt="SCR-20251212-msmq" src="https://github.com/user-attachments/assets/98eb8d02-d77f-49c4-9a5e-ddf9f3435cd0" />
