### PR TITLE
Fix Blade directive parsing error in modal component

### DIFF
--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -59,14 +59,12 @@ if (($wireModel = $attributes->wire('model')) && $wireModel->directive && ! $wir
     $attributes = $attributes->merge([$wireModel->directive => $wireModel->value]);
 }
 
-// Support <flux:modal ... @close="?"> syntax...
 if ($attributes['@close'] ?? null) {
     $attributes['wire:close'] = $attributes['@close'];
 
     unset($attributes['@close']);
 }
 
-// Support <flux:modal ... @cancel="?"> syntax...
 if ($attributes['@cancel'] ?? null) {
     $attributes['wire:cancel'] = $attributes['@cancel'];
 


### PR DESCRIPTION
The @close and @cancel in PHP comments were being interpreted as Blade directives, causing a "syntax error, unexpected token endif" parse error.

Removed the problematic comments:
- // Support <flux:modal ... @close="?"> syntax...
- // Support <flux:modal ... @cancel="?"> syntax...

Fixes the ParseError that occurs when using the modal component.

# The scenario

When using the `<flux:modal>` component in a Livewire/Volt page, Laravel throws a parse error:

```
ParseError
vendor/livewire/flux/stubs/resources/views/flux/modal/index.blade.php:1
syntax error, unexpected token "endif", expecting end of file
```

**Steps to reproduce:**
1. Create a Livewire component
2. Add a basic Flux modal:
```blade
<flux:modal.trigger name="test">
    <flux:button>Open</flux:button>
</flux:modal.trigger>

<flux:modal name="test">
    <p>Hello</p>
</flux:modal>
```
3. Visit the page - ParseError is thrown

# The problem

In index.blade.php, lines 62-74 contain PHP comments with `@close` and `@cancel`:

```php
// Support <flux:modal ... @close="?"> syntax...
if ($attributes['@close'] ?? null) {
    // ...
}

// Support <flux:modal ... @cancel="?"> syntax...
if ($attributes['@cancel'] ?? null) {
    // ...
}
```

The `@close` and `@cancel` inside these PHP comments are being interpreted by Laravel's Blade compiler as Blade directives, even though they're within PHP comments. This causes the Blade parser to generate invalid PHP code.

# The solution

Removing the comments was the cleanest fix since they were purely documentation. Here are the screenshots, you can see even my editor (VS Code) is tweaking with the syntax highlighting because of those comments.

Maybe it's my OS, Windows 11 and VSCode, but I don't know, I couldn't use the Modal components until now.

<img width="1276" height="726" alt="Screenshot 2026-01-09 153741" src="https://github.com/user-attachments/assets/25175d70-dd7d-4ffb-b7e7-5ff12b06df17" />
<img width="1084" height="884" alt="Screenshot 2026-01-09 154748" src="https://github.com/user-attachments/assets/df902ce9-e6e9-4ef2-99ee-5373e9f11c4f" />
