### PR TITLE
Add height to input wrapper

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -119,6 +119,15 @@ $classes = Flux::classes()
     })
     ->add($attributes->pluck('class:input'))
     ;
+
+$wrapperClasses = Flux::classes()
+    ->add('w-full relative block group/input')
+    ->add(match ($size) {
+        default => 'h-10',
+        'sm' => 'h-8',
+        'xs' => 'h-6',
+    })
+    ;
 @endphp
 
 <?php if ($type === 'file'): ?>
@@ -127,7 +136,7 @@ $classes = Flux::classes()
     </flux:with-field>
 <?php elseif ($as !== 'button'): ?>
     <flux:with-field :$attributes :$name>
-        <div {{ $attributes->only('class')->class('w-full relative block group/input') }} data-flux-input>
+        <div {{ $attributes->only('class')->class($wrapperClasses) }} data-flux-input>
             <?php if (is_string($iconLeading)): ?>
                 <div class="pointer-events-none absolute top-0 bottom-0 border-s border-transparent flex items-center justify-center text-xs text-zinc-400/75 dark:text-white/60 ps-3 start-0">
                     <flux:icon :icon="$iconLeading" :variant="$iconVariant" :class="$iconClasses" />


### PR DESCRIPTION
# The scenario

When input's height is stretched beyond its original height, its icon becomes misaligned:

```blade
<div class="flex">
    <flux:input size="xs" icon:trailing="magnifying-glass"></flux:input>
    <flux:button variant="primary">Search</flux:button>
</div>
```

<img width="379" height="125" alt="SCR-20260119-paxn" src="https://github.com/user-attachments/assets/61116324-d98a-465c-b3a8-3c0f0c403535" />


# The problem

This happens because the input has a fixed height:

```php
$classes = Flux::classes()
    ->add(match ($size) {
        default => '... h-10 ...',
        'sm' => '... h-8 ...',
        'xs' => '... h-6 ...',
    })
```

However the icon is absolutely positioned inside input wrapper with auto height:

```blade
<div>
    <input class="{{ $classes }}">
    
    <div class="absolute top-0 bottom-0 flex items-center">
        <flux:icon :icon="$iconTrailing" />
    </div>
</div>
```

# The solution

Is to add matching fixed height to the wrapper:

```php
$wrapperClasses = Flux::classes()
    ->add(match ($size) {
        default => 'h-10',
        'sm' => 'h-8',
        'xs' => 'h-6',
    })
    ;
```

```blade
<div class="{{ $wrapperClasses }}">
    <input class="{{ $classes }}">
    
    ...
</div>
```

Fixes livewire/flux#2314