### PR TITLE
Fix modal outside Livewire

### DIFF
--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -90,7 +90,7 @@ if ($dismissible === false) {
         {{ $styleAttributes->class($classes) }}
         @if ($name) data-modal="{{ $name }}" @endif
         @if ($flyout) data-flux-flyout @endif
-        x-data="fluxModal(@js($name), @js($__livewire?->getId()))"
+        x-data="fluxModal(@js($name), @js(isset($__livewire) ? $__livewire->getId() : null))"
         x-on:modal-show.document="handleShow($event)"
         x-on:modal-close.document="handleClose($event)"
     >


### PR DESCRIPTION
# The scenario

Using `<flux:modal>` outside Livewire throws `$__livewire is not defined` error.

# The problem

`@if(isset($__livewire))` was refactored to `$__livewire?->getId()` in #2277.

# The solution

`isset($__livewire) ? $__livewire->getId() : null`

Added a test in Flux Pro: livewire/flux-pro#427

Fixes livewire/flux#2329