### PR TITLE
Unify profile hover background color with button

### DIFF
--- a/stubs/resources/views/flux/profile.blade.php
+++ b/stubs/resources/views/flux/profile.blade.php
@@ -24,7 +24,7 @@ $classes = Flux::classes()
     ->add('group flex items-center')
     ->add('rounded-lg has-data-[circle=true]:rounded-full')
     ->add('[ui-dropdown>&]:w-full') // Without this, the "name" won't get truncated in a sidebar dropdown...
-    ->add('p-1 hover:bg-zinc-800/5 dark:hover:bg-white/10')
+    ->add('p-1 hover:bg-zinc-800/5 dark:hover:bg-white/15')
     ;
 @endphp
 


### PR DESCRIPTION
# The scenario

`<flux:profile>` next to `<flux:button variant="ghost">`, eg. in a header:

```blade
<flux:profile avatar="https://unavatar.io/x/calebporzio" />
<flux:button variant="ghost" icon="cog-6-tooth" />
```

# The problem

The hover background color is inconsistent.

# The solution

Update hover background color of `<flux:profile>` to match the button hover:

<img width="1295" height="876" alt="SCR-20260123-kxeg" src="https://github.com/user-attachments/assets/679440c1-f5dd-4886-bcdc-40169bb910a7" />


Fixes livewire/flux#2332