### PR TITLE
Fix alignment of brand component icon in sidebar

### DIFF
--- a/stubs/resources/views/flux/sidebar/brand.blade.php
+++ b/stubs/resources/views/flux/sidebar/brand.blade.php
@@ -12,7 +12,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('h-10 flex items-center px-2 in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:px-2')
+    ->add('h-10 flex items-center justify-center px-2 in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:px-2')
     ->add('in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:absolute')
     ->add('in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:opacity-0')
     ;


### PR DESCRIPTION
This pull request makes a minor update to the sidebar brand component's layout by adding center alignment to its contents. This ensures that the items within the sidebar brand are properly centered.

* Added the `justify-center` class to the sidebar brand container in `brand.blade.php` to center its contents horizontally.

When I use the collapsible sidebar icon is misaligned! b/c that component doesn't have 'justify-center'

<img width="390" height="310" alt="Screenshot 2569-01-23 at 18 20 04" src="https://github.com/user-attachments/assets/b4068037-5db4-4523-8ef2-159cca4c81fd" />
