### PR TITLE
Truncate sidebar item text

### DIFF
--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -71,7 +71,7 @@ $classes = Flux::classes()
         <?php if ($slot->isNotEmpty()): ?>
             <div class="
                 in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-sidebar-group-dropdown:hidden
-                flex-1 text-sm font-medium leading-none truncate [[data-nav-footer]_&]:hidden [[data-nav-sidebar]_[data-nav-footer]_&]:block" data-content>{{ $slot }}</div>
+                flex-1 text-sm font-medium truncate [[data-nav-footer]_&]:hidden [[data-nav-sidebar]_[data-nav-footer]_&]:block" data-content>{{ $slot }}</div>
         <?php endif; ?>
 
         <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>

--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -71,7 +71,7 @@ $classes = Flux::classes()
         <?php if ($slot->isNotEmpty()): ?>
             <div class="
                 in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-sidebar-group-dropdown:hidden
-                flex-1 text-sm font-medium leading-none whitespace-nowrap [[data-nav-footer]_&]:hidden [[data-nav-sidebar]_[data-nav-footer]_&]:block" data-content>{{ $slot }}</div>
+                flex-1 text-sm font-medium leading-none truncate [[data-nav-footer]_&]:hidden [[data-nav-sidebar]_[data-nav-footer]_&]:block" data-content>{{ $slot }}</div>
         <?php endif; ?>
 
         <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>


### PR DESCRIPTION
# The scenario

A sidebar item with long text will overflow

```blade
<flux:sidebar sticky>
    <flux:sidebar.item href="#">This is some really long text that will not fit</flux:sidebar.item>
</flux:sidebar>
```

# The problem

The user can't just apply `truncate` to the sidebar item because the class will be applied to a parent div:

```blade
<flux:sidebar.item class="truncate">
```

```blade
<div class="truncate">
    <div data-content class="whitespace-nowrap">...</div>
</div>
```

To make this work the user needs to target the child element which is not intuitive.

```blade
<flux:sidebar.item class="*:data-content:truncate">
```

# The solution

I think it's reasonable to truncate by default, which is what this PR does.

I also had to remove `leading-none` to prevent descenders from clipping.

<img width="894" height="487" alt="SCR-20260123-ldzq" src="https://github.com/user-attachments/assets/50fca46b-5998-4f4c-b2da-8a1d76ef1edc" />

# An alternative

`<flux:sidebar.item truncate>`

Fixes livewire/flux#2336