### PR TITLE
Fix label/slot precedence

### DIFF
--- a/stubs/resources/views/flux/checkbox/variants/buttons.blade.php
+++ b/stubs/resources/views/flux/checkbox/variants/buttons.blade.php
@@ -61,7 +61,7 @@ $iconAttributes = Flux::attributesAfter('icon:', $attributes, [
         {{ $icon }}
     <?php endif; ?>
 
-    @if (isset($label) || $slot->isNotEmpty())
-        <span>{{ $label ?? $slot }}</span>
+    @if ($slot->isNotEmpty() || isset($label))
+        <span>{{ $slot->isNotEmpty() ? $slot : $label }}</span>
     @endif
 </ui-checkbox>

--- a/stubs/resources/views/flux/checkbox/variants/cards.blade.php
+++ b/stubs/resources/views/flux/checkbox/variants/cards.blade.php
@@ -63,7 +63,7 @@ $classes = Flux::classes()
             <?php endif; ?>
 
             <div class="flex-1">
-                <flux:heading>{{ $label ?? $slot }}</flux:heading>
+                <flux:heading>{{ $slot->isNotEmpty() ? $slot : $label }}</flux:heading>
 
                 <?php if ($description): ?>
                     <flux:subheading size="sm">{{ $description }}</flux:subheading>

--- a/stubs/resources/views/flux/checkbox/variants/pills.blade.php
+++ b/stubs/resources/views/flux/checkbox/variants/pills.blade.php
@@ -25,5 +25,5 @@ $classes = Flux::classes()
 {{-- even with durable attributes for some reason... --}}
 {{-- We have to put "data-flux-field" so that a single box can be disabled without "disabling" the group field label... --}}
 <ui-checkbox {{ $attributes->class($classes) }} data-flux-control data-flux-checkbox-pills tabindex="-1" data-flux-field>
-    {{ $label ?? $slot }}
+    {{ $slot->isNotEmpty() ? $slot : $label }}
 </ui-checkbox>

--- a/stubs/resources/views/flux/menu/checkbox/index.blade.php
+++ b/stubs/resources/views/flux/menu/checkbox/index.blade.php
@@ -46,7 +46,7 @@ $classes = Flux::classes()
         </div>
     </div>
 
-    {{ $label ?? $slot }}
+    {{ $slot->isNotEmpty() ? $slot : $label }}
 
     <?php if ($suffix): ?>
         <div class="ms-auto opacity-50 text-xs">

--- a/stubs/resources/views/flux/menu/radio/index.blade.php
+++ b/stubs/resources/views/flux/menu/radio/index.blade.php
@@ -46,7 +46,7 @@ $classes = Flux::classes()
         </div>
     </div>
 
-    {{ $label ?? $slot }}
+    {{ $slot->isNotEmpty() ? $slot : $label }}
 
     <?php if ($suffix): ?>
         <div class="ms-auto opacity-50 text-xs">

--- a/stubs/resources/views/flux/radio/variants/buttons.blade.php
+++ b/stubs/resources/views/flux/radio/variants/buttons.blade.php
@@ -61,7 +61,7 @@ $iconAttributes = Flux::attributesAfter('icon:', $attributes, [
         {{ $icon }}
     <?php endif; ?>
 
-    @if (isset($label) || $slot->isNotEmpty())
-        <span>{{ $label ?? $slot }}</span>
+    @if ($slot->isNotEmpty() || isset($label))
+        <span>{{ $slot->isNotEmpty() ? $slot : $label }}</span>
     @endif
 </ui-radio>

--- a/stubs/resources/views/flux/radio/variants/cards.blade.php
+++ b/stubs/resources/views/flux/radio/variants/cards.blade.php
@@ -62,7 +62,7 @@ $classes = Flux::classes()
             <?php endif; ?>
 
             <div class="flex-1">
-                <flux:heading>{{ $label ?? $slot }}</flux:heading>
+                <flux:heading>{{ $slot->isNotEmpty() ? $slot : $label }}</flux:heading>
 
                 <?php if ($description): ?>
                     <flux:subheading size="sm">{{ $description }}</flux:subheading>

--- a/stubs/resources/views/flux/radio/variants/pills.blade.php
+++ b/stubs/resources/views/flux/radio/variants/pills.blade.php
@@ -25,5 +25,5 @@ $classes = Flux::classes()
 {{-- even with durable attributes for some reason... --}}
 {{-- We have to put "data-flux-field" so that a single box can be disabled without "disabling" the group field label... --}}
 <ui-radio {{ $attributes->class($classes) }} data-flux-control data-flux-radio-pills tabindex="-1" data-flux-field>
-    {{ $label ?? $slot }}
+    {{ $slot->isNotEmpty() ? $slot : $label }}
 </ui-radio>

--- a/stubs/resources/views/flux/radio/variants/segmented.blade.php
+++ b/stubs/resources/views/flux/radio/variants/segmented.blade.php
@@ -44,7 +44,7 @@ $iconClasses = Flux::classes('text-zinc-500 dark:text-zinc-400 [ui-radio[data-ch
         {{ $icon }}
     <?php endif; ?>
 
-    {{ $label ?? $slot }}
+    {{ $slot->isNotEmpty() ? $slot : $label }}
 
     <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
         <flux:icon :icon="$iconTrailing" variant="micro" />


### PR DESCRIPTION
# The scenario

A user-land component with a `label` prop renders select options incorrectly:

```blade
<x-select label="Industry" />
```

```blade
{{-- resources/views/components/select.blade.php --}}
@props(['label'])

<flux:select :$label variant="listbox">
    <flux:select.option>Photography</flux:select.option>
    <flux:select.option>Design services</flux:select.option>
    <flux:select.option>Web development</flux:select.option>
</flux:select>
```

<img width="698" height="286" alt="SCR-20260209-nimv-2" src="https://github.com/user-attachments/assets/9b7979c0-aa01-4726-af6f-92003f59a168" />


# The problem

The `label` prop leaks from the parent component into all children.

This happens because `<flux:delegate-component>` forwards inherited data from the entire component stack.

Combined with `{{ $label ?? $slot }}`, every option displays "Industry".

# The solution

Reverse the priority from `{{ $label ?? $slot }}` to `{{ $slot->isNotEmpty() ? $slot : $label }}` across 9 files where this pattern occurs. Slot content now wins when present; `label` prop still works as fallback for self-closing tags.

# Risk assessment

* The `$slot->isNotEmpty()` pattern is already used elsewhere in the codebase
* The docs never show both being passed simultaneously
* Self-closing tags (`<flux:radio label="Foo" />`) produce an empty slot, so `$label` is still used as fallback

The problematic pattern would be:

```blade
<flux:menu.radio label="Foo">Bar</flux:menu.radio>
```

Before this change: Renders `Foo`
After this change: Renders `Bar`

Flux Pro PR: livewire/flux-pro#436

Fixes livewire/flux#2300