### PR TITLE
Fix trailing badge icon size

### DIFF
--- a/stubs/resources/views/flux/badge/index.blade.php
+++ b/stubs/resources/views/flux/badge/index.blade.php
@@ -24,7 +24,8 @@ if ($variant === 'pill') {
 $insetClasses = Flux::applyInset($inset, top: '-mt-1', right: '-me-2', bottom: '-mb-1', left: '-ms-2');
 
 // When using the outline icon variant, we need to size it down to match the default icon sizes...
-$iconClasses = Flux::classes()->add($iconVariant === 'outline' ? 'size-4' : '');
+$iconClasses = Flux::classes()
+    ->add($size === 'sm' ? 'size-3' : ($iconVariant === 'outline' ? 'size-4' : ''));
 
 $classes = Flux::classes()
     ->add('inline-flex items-center font-medium whitespace-nowrap')
@@ -33,7 +34,7 @@ $classes = Flux::classes()
     ->add(match ($size) {
         'lg' => 'text-sm py-1.5 **:data-flux-badge-icon:me-2',
         default => 'text-sm py-1 **:data-flux-badge-icon:me-1.5',
-        'sm' => 'text-xs py-1 **:data-flux-badge-icon:size-3 **:data-flux-badge-icon:me-1',
+        'sm' => 'text-xs py-1 **:data-flux-badge-icon:me-1',
     })
     ->add(match ($rounded) {
         true => 'rounded-full px-3',


### PR DESCRIPTION
# The scenario

Trailing icon on `<flux:badge size="sm">` is bigger than the leading one.

```blade
<flux:badge size="sm" icon="document-text" icon:trailing="document-text">
    Small
</flux:badge>
```

<img width="445" height="172" alt="SCR-20260206-olrk" src="https://github.com/user-attachments/assets/affc34ef-a19c-412d-9269-f78946f15ae4" />

# The problem

The icon size is applied via `**:data-flux-badge-icon:size-3`, but this only matches the leading icon.

# The solution

Move the `size-3` override from the CSS selector into `$iconClasses`, which is already applied directly to both icons.

https://github.com/user-attachments/assets/c2da2419-778e-4e72-81b6-000bbcd1335d

Fixes livewire/flux#2357