### PR TITLE
Add future date range presets

### DIFF
--- a/src/DateRange.php
+++ b/src/DateRange.php
@@ -78,6 +78,16 @@ class DateRange extends CarbonPeriod
     public static function last3Months() { return static::fromPreset(DateRangePreset::Last3Months); }
     public static function last6Months() { return static::fromPreset(DateRangePreset::Last6Months); }
     public static function yearToDate() { return static::fromPreset(DateRangePreset::YearToDate); }
+    public static function tomorrow() { return static::fromPreset(DateRangePreset::Tomorrow); }
+    public static function nextWeek() { return static::fromPreset(DateRangePreset::NextWeek); }
+    public static function next7Days() { return static::fromPreset(DateRangePreset::Next7Days); }
+    public static function nextMonth() { return static::fromPreset(DateRangePreset::NextMonth); }
+    public static function nextQuarter() { return static::fromPreset(DateRangePreset::NextQuarter); }
+    public static function nextYear() { return static::fromPreset(DateRangePreset::NextYear); }
+    public static function next14Days() { return static::fromPreset(DateRangePreset::Next14Days); }
+    public static function next30Days() { return static::fromPreset(DateRangePreset::Next30Days); }
+    public static function next3Months() { return static::fromPreset(DateRangePreset::Next3Months); }
+    public static function next6Months() { return static::fromPreset(DateRangePreset::Next6Months); }
     public static function allTime($start) {
         $instance = new static(Carbon::parse($start), Carbon::now());
 

--- a/src/DateRangePreset.php
+++ b/src/DateRangePreset.php
@@ -22,6 +22,16 @@ enum DateRangePreset: string
     case Last3Months = 'last3Months';
     case Last6Months = 'last6Months';
     case YearToDate = 'yearToDate';
+    case Tomorrow = 'tomorrow';
+    case NextWeek = 'nextWeek';
+    case Next7Days = 'next7Days';
+    case NextMonth = 'nextMonth';
+    case NextQuarter = 'nextQuarter';
+    case NextYear = 'nextYear';
+    case Next14Days = 'next14Days';
+    case Next30Days = 'next30Days';
+    case Next3Months = 'next3Months';
+    case Next6Months = 'next6Months';
     case AllTime = 'allTime';
     case Custom = 'custom';
 
@@ -46,6 +56,16 @@ enum DateRangePreset: string
             static::Last3Months => [ Carbon::now()->subMonths(3)->addDay()->startOfDay(), Carbon::now()->endOfDay() ],
             static::Last6Months => [ Carbon::now()->subMonths(6)->addDay()->startOfDay(), Carbon::now()->endOfDay() ],
             static::YearToDate => [ Carbon::now()->startOfYear(), Carbon::now()->endOfDay() ],
+            static::Tomorrow => [ Carbon::now()->addDay()->startOfDay(), Carbon::now()->addDay()->endOfDay() ],
+            static::NextWeek => [ Carbon::now()->addWeek()->startOfWeek(), Carbon::now()->addWeek()->endOfWeek() ],
+            static::Next7Days => [ Carbon::now()->startOfDay(), Carbon::now()->addDays(6)->endOfDay() ],
+            static::NextMonth => [ Carbon::now()->endOfMonth()->addDay()->startOfDay(), Carbon::now()->endOfMonth()->addDay()->endOfMonth()->endOfDay() ],
+            static::NextQuarter => [ Carbon::now()->addQuarter()->startOfQuarter(), Carbon::now()->addQuarter()->endOfQuarter() ],
+            static::NextYear => [ Carbon::now()->addYear()->startOfYear(), Carbon::now()->addYear()->endOfYear() ],
+            static::Next14Days => [ Carbon::now()->startOfDay(), Carbon::now()->addDays(13)->endOfDay() ],
+            static::Next30Days => [ Carbon::now()->startOfDay(), Carbon::now()->addDays(29)->endOfDay() ],
+            static::Next3Months => [ Carbon::now()->startOfDay(), Carbon::now()->addMonths(3)->subDay()->endOfDay() ],
+            static::Next6Months => [ Carbon::now()->startOfDay(), Carbon::now()->addMonths(6)->subDay()->endOfDay() ],
             static::AllTime => [ $start, Carbon::now()->endOfDay() ],
         };
     }
@@ -69,6 +89,16 @@ enum DateRangePreset: string
             static::Last3Months => __('Last 3 Months'),
             static::Last6Months => __('Last 6 Months'),
             static::YearToDate => __('Year to Date'),
+            static::Tomorrow => __('Tomorrow'),
+            static::NextWeek => __('Next Week'),
+            static::Next7Days => __('Next 7 Days'),
+            static::NextMonth => __('Next Month'),
+            static::NextQuarter => __('Next Quarter'),
+            static::NextYear => __('Next Year'),
+            static::Next14Days => __('Next 14 Days'),
+            static::Next30Days => __('Next 30 Days'),
+            static::Next3Months => __('Next 3 Months'),
+            static::Next6Months => __('Next 6 Months'),
             static::AllTime => __('All Time'),
             static::Custom => __('Custom'),
         };


### PR DESCRIPTION
# The scenario

Scheduling and booking applications need future date range presets (Tomorrow, Next Week, Next 30 Days, etc.) in the date picker.

# The problem

The `DateRangePreset` enum only includes past and present presets (Yesterday, Last 7 Days, Last Month, etc.) and there's no built-in way to select future date ranges.

Requested in https://github.com/livewire/flux/discussions/1165.

# The solution

Add 10 future date range presets that mirror the existing past-facing ones:

| New Preset | Mirror of |
|-----------|-----------|
| `tomorrow` | `yesterday` |
| `nextWeek` | `lastWeek` |
| `next7Days` | `last7Days` |
| `nextMonth` | `lastMonth` |
| `nextQuarter` | `lastQuarter` |
| `nextYear` | `lastYear` |
| `next14Days` | `last14Days` |
| `next30Days` | `last30Days` |
| `next3Months` | `last3Months` |
| `next6Months` | `last6Months` |

```blade
<flux:date-picker mode="range" presets="today tomorrow nextWeek next30Days" />
```

```php
$this->range = DateRange::tomorrow();
$this->range = DateRange::next30Days();
```

<img width="817" height="451" alt="SCR-20260206-pkxz" src="https://github.com/user-attachments/assets/b8322def-7600-4ac0-b789-e9612e1c6ca7" />

Flux Pro: livewire/flux-pro#438
Flux Docs: livewire/flux-docs#148

Fixes livewire/flux#2343 livewire/flux#1156 