### PR TITLE
Fix sortable column hover area

### DIFF
--- a/stubs/resources/views/flux/table/column.blade.php
+++ b/stubs/resources/views/flux/table/column.blade.php
@@ -20,6 +20,7 @@ $classes = Flux::classes()
         'right' => 'group/end-align',
         default => '',
     })
+    ->add($sortable ? 'group/sortable' : '')
     ->add($sticky ? [
         'z-10',
         'first:sticky first:left-0',

--- a/stubs/resources/views/flux/table/sortable.blade.php
+++ b/stubs/resources/views/flux/table/sortable.blade.php
@@ -7,7 +7,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('group/sortable flex items-center gap-1 -my-1 -ms-2 -me-2 px-2 py-1 ')
+    ->add('flex items-center gap-1 -my-1 -ms-2 -me-2 px-2 py-1 ')
     ->add('in-[.group\/end-align]:flex-row-reverse in-[.group\/end-align]:-me-2 in-[.group\/end-align]:-ms-8')
     ;
 @endphp


### PR DESCRIPTION
# The scenario

Hovering over sortable column only affects the nested button, not the full header cell.

But clicking works on the entire cell.

https://github.com/user-attachments/assets/9892ba6c-c037-441d-9b3b-648c1b871cd2

# The problem

The `wire:click` is added to the `th`, but the hover group is on the `<button>`:

```blade
<th {{ $attributes->class($classes) }}> {{-- wire:click --}}
    <button class="group/sortable ..."> {{-- hover area --}}
        <div class="group-hover/sortable:opacity-100"> ... </div>
    </button>
</th>
```

# The solution

Move `group/sortable` from the `<button>` to the `<th>`.

```blade
<th class="... group/sortable">
    <button class="flex items-center ...">
</th>
```

https://github.com/user-attachments/assets/ff53b9bd-27eb-4485-bf7c-96f675ec4543


Fixes livewire/flux#2362