### PR TITLE
Fix brand icon alignment in collapsed sidebar

### DIFF
--- a/stubs/resources/views/flux/sidebar/brand.blade.php
+++ b/stubs/resources/views/flux/sidebar/brand.blade.php
@@ -12,7 +12,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('h-10 flex items-center px-2 in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:px-2')
+    ->add('h-10 flex items-center px-2 in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:px-0 in-data-flux-sidebar-collapsed-desktop:justify-center')
     ->add('in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:absolute')
     ->add('in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:opacity-0')
     ;


### PR DESCRIPTION
# The scenario

In Livewire Starter Kit, enabling the sidebar to collapse on desktop

```diff
<!-- resources/views/layouts/app/sidebar.blade.php -->

- <flux:sidebar sticky collapsible="mobile" ...>
+ <flux:sidebar sticky ...>
    ...
-   <flux:sidebar.collapse class="lg:hidden" />
+   <flux:sidebar.collapse />
```

makes the brand icon misaligned when the sidebar is collapsed:

https://github.com/user-attachments/assets/5e0a9c6d-0dd1-4423-ae94-a0b3d7dcb70e


# The problem

The problem is that the starter kit customizes the width of the logo to `w-8` whereas Flux only accounts for `w-6`.

```blade
<flux:sidebar.brand name="Laravel Starter Kit" {{ $attributes }}>
    <x-slot name="logo" class="size-8">
        <!-- ... -->
    </x-slot>
</flux:sidebar.brand>
```

```blade
<!-- flux/sidebar/brand.bade.php -->
<div class="in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:px-2">
    <!-- ... -->
</div>
```

`w-10` and `px-2` leaves only `w-6` of effective space.

<img width="627" alt="SCR-20260209-moaj" src="https://github.com/user-attachments/assets/8dc17f7d-1dad-44a0-b7ef-870d1b9dab25" />

# The solution

Remove the padding and add `justify-center` to the collapsed brand styles:

```diff
- ->add('in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:px-2')
+ ->add('in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:justify-center')
```

This gives the full `w-10` to the logo and centers it, matching how `sidebar.item` handles collapsed alignment.

<img width="627" height="345" alt="SCR-20260209-mqtk" src="https://github.com/user-attachments/assets/712d4851-0d1b-41d9-8527-4c4dc95551d6" />

Fixes livewire/flux#2339