### PR TITLE
Move custom element display rules from JS to CSS to prevent CLS

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -106,10 +106,38 @@ select[data-flux-select-native]:hover:not(:disabled) {
 }
 
 /**
-Button styles...
+Custom element display rules...
 */
-ui-button {
-    display: block;
+@layer base {
+    ui-button { display: block; }
+    ui-label { display: inline-block; cursor: default; }
+    ui-description { display: block; }
+    ui-legend { display: block; }
+    ui-select { display: block; }
+    ui-selected-option { display: contents; }
+    ui-options:not([popover]), ui-option { display: block; cursor: default; }
+    ui-option-create { display: block; cursor: default; }
+    ui-option-empty { display: block; cursor: default; }
+    ui-empty { display: block; cursor: default; }
+    ui-pillbox { display: block; }
+    ui-checkbox-group { display: block; }
+    ui-checkbox { display: inline-block; user-select: none; }
+    ui-switch { display: inline-block; user-select: none; }
+    ui-radio-group { display: block; }
+    ui-radio { display: inline-block; user-select: none; }
+    ui-date-picker { display: block; }
+    ui-time-picker { display: block; }
+    ui-calendar { display: block; }
+    ui-calendar-preset, ui-calendar-previous, ui-calendar-next, ui-calender-next { display: block; user-select: none; }
+    ui-menu[popover]:popover-open { display: block; }
+    ui-menu[popover].\:popover-open { display: block; }
+    ui-menu-checkbox, ui-menu-radio { cursor: default; display: contents; }
+    ui-disclosure { display: block; }
+    ui-tab-group, ui-tabs { display: block; cursor: default; }
+    ui-resizable { display: block; }
+    ui-composer { display: block; }
+    ui-editor { display: block; }
+    ui-editor-content { display: block; }
 }
 
 /**


### PR DESCRIPTION
# The Scenario

When using Flux custom elements like `<flux:description>`, `<flux:label>`, `<flux:checkbox>`, or `<flux:switch>`, there is a visible layout shift (CLS) on first paint. Elements briefly render as `display: inline` (the browser default for unknown elements), then snap to their correct display value once JavaScript executes.

This is most noticeable on elements visible at first paint — particularly `ui-description` with longer text that wraps differently at `inline` vs `block`:

```blade
<flux:field>
    <flux:label>Email</flux:label>
    <flux:input name="email" />
    <flux:description>Enter your email address. But this is more noticeable if you have a really long helper text that wraps a couple times.</flux:description>
</flux:field>
```

# The Problem

Display values for ~30 custom elements are set exclusively at runtime via JavaScript `inject()` calls — one per component file (e.g. `js/field.js`, `js/select.js`, `js/checkbox.js`). The `inject()` function uses `document.adoptedStyleSheets` to create CSS rules dynamically:

```js
inject(({ css }) => css`ui-description { display: block; }`)
inject(({ css }) => css`ui-checkbox { display: inline-block; user-select: none; }`)
inject(({ css }) => css`ui-switch { display: inline-block; user-select: none; }`)
// ~25 more...
```

Until JS executes, browsers render these unknown elements as `display: inline`, causing the layout shift. Only `ui-button` had a pre-existing CSS rule in `flux.css`.

# The Solution

Move all custom element display rules into `flux.css` inside an `@layer base` block, so they apply from first paint while still allowing Tailwind utility classes to override them.

This PR adds the CSS rules. The corresponding `inject()` calls are removed from the JS source files in a companion PR (livewire/flux-pro#446).

Fixes #2394