### PR TITLE
Fix button group styling when buttons are wrapped in tooltips

### DIFF
--- a/stubs/resources/views/flux/button/group.blade.php
+++ b/stubs/resources/views/flux/button/group.blade.php
@@ -38,6 +38,15 @@ $classes = Flux::classes()
         '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-input]>[data-flux-group-target]]:rounded-none',
         '[&>*:first-child:not(:last-child)>[data-flux-input]>[data-flux-group-target]]:rounded-e-none',
         '[&>*:last-child:not(:first-child)>[data-flux-input]>[data-flux-group-target]]:rounded-s-none',
+
+        // "Weld" borders for sub-children wrapped in tooltips (button inside tooltip inside modal trigger, etc.)...
+        '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-none',
+        '[&>*:first-child:not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-e-none',
+        '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-s-none',
+
+        // Borders for sub-children wrapped in tooltips...
+        '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:not(:first-child):not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
     ])
     ;
 @endphp

--- a/stubs/resources/views/flux/input/group/index.blade.php
+++ b/stubs/resources/views/flux/input/group/index.blade.php
@@ -41,6 +41,15 @@ $classes = Flux::classes()
         '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-input]>[data-flux-group-target]]:rounded-none',
         '[&>*:first-child:not(:last-child)>[data-flux-input]>[data-flux-group-target]]:rounded-e-none',
         '[&>*:last-child:not(:first-child)>[data-flux-input]>[data-flux-group-target]]:rounded-s-none',
+
+        // "Weld" borders for sub-children wrapped in tooltips (button inside tooltip inside modal trigger, etc.)...
+        '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-none',
+        '[&>*:first-child:not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-e-none',
+        '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-s-none',
+
+        // Borders for sub-children wrapped in tooltips...
+        '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:not(:first-child):not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
     ])
     ;
 @endphp


### PR DESCRIPTION
# The Scenario

When a button with a tooltip is placed inside a `<flux:button.group>` (typically via a `<flux:modal.trigger>`), the button visually breaks out of the group — the border radius isn't welded together and the borders don't collapse properly, making it appear as a separate disconnected button.

This happens with both the `tooltip` prop on the button and the `<flux:tooltip>` component wrapper.

<img width="1228" height="1156" alt="Screenshot 2026-02-17 at 01 50 10PM@2x" src="https://github.com/user-attachments/assets/7b6bb7c4-8b33-491c-8811-e5d1d6e75e4b" />

```blade
<flux:button.group>
    <flux:modal.trigger name="modal-left">
        <flux:button icon="bars-3-bottom-left" tooltip="Left align" />
    </flux:modal.trigger>
    <flux:modal.trigger name="modal-center">
        <flux:button icon="bars-3" tooltip="Center align" />
    </flux:modal.trigger>
    <flux:modal.trigger name="modal-right">
        <flux:button icon="bars-3-bottom-right" tooltip="Right align" />
    </flux:modal.trigger>
</flux:button.group>
```

# The Problem

The button group component uses CSS child selectors to weld buttons together by overriding border-radius and collapsing borders. It handles three nesting depths:

1. Direct children: `[&>[data-flux-group-target]:first-child...]` — buttons directly in the group
2. One level nested: `[&>*:first-child>[data-flux-group-target]...]` — button inside one wrapper (e.g., a `<flux:modal.trigger>` with `display: contents`)
3. Two levels nested via input: `[&>*:first-child>[data-flux-input]>[data-flux-group-target]...]` — button inside two wrappers (e.g., combobox)

When a tooltip wraps a button inside a `<flux:modal.trigger>`, the DOM structure becomes:

```
button-group > div.contents (modal trigger) > ui-tooltip > button
```

The `<flux:modal.trigger>` uses `display: contents` so it's invisible to layout, but CSS selectors still see it in the DOM tree. The one-level selectors don't match because the button isn't a direct child of the modal trigger — the `<ui-tooltip>` element sits between them. And the two-level selectors only target `[data-flux-input]` as the intermediate element, not `[data-flux-tooltip]`.

# The Solution

Added targeted `[data-flux-tooltip]` selectors to both `button/group.blade.php` and `input/group/index.blade.php`, mirroring the existing `[data-flux-input]` pattern for two-level nesting:

```
[&>*:first-child:not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-e-none
```

This specifically matches the `wrapper > tooltip > button` pattern using child combinators (`>`) at each level, so it won't affect buttons nested deep inside menus, dropdowns, or popovers within the group — avoiding the issue with the previous approach of using descendant selectors.

<img width="1228" height="1156" alt="Screenshot 2026-02-17 at 01 49 28PM@2x" src="https://github.com/user-attachments/assets/0530d31b-676d-4643-b8cc-fa78c47fd17a" />

Fixes #2021