### PR TITLE
Fix custom components without Blaze

### DIFF
--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -39,6 +39,10 @@ class FluxServiceProvider extends ServiceProvider
     {
         if (file_exists(resource_path('views/flux'))) {
             Blade::anonymousComponentPath(resource_path('views/flux'), 'flux');
+
+            if (class_exists(\Livewire\Blaze\Blaze::class)) {
+                \Livewire\Blaze\Blaze::optimize()->in(resource_path('views/flux'));
+            }
         }
 
         Blade::anonymousComponentPath(__DIR__.'/../stubs/resources/views/flux', 'flux');


### PR DESCRIPTION
# The scenario

A user has Blaze installed and uses a custom Flux icon or variant:

```blade
<flux:icon name="custom" />
```

Where "custom" is a Blade view in `resources/views/flux/icon/custom.blade.php` without a `@blaze` directive.

# The problem

The icon component uses `flux::delegate-component` and  Blaze assumes all delegate targets are optimized.

But the custom icon template doesn't have `@blaze`, therefore it's not compiled into a function.

Resulting in an exception:

```
Call to undefined function _eab27ebdf4ee954a9a05ceed5425e512()
```

# The solution

Call `Blaze::optimize()->in()` on the custom Flux component path (`resources/views/flux`), so all templates in that directory are automatically optimized — no `@blaze` directive needed.

```php
if (class_exists(\Livewire\Blaze\Blaze::class)) {
    \Livewire\Blaze\Blaze::optimize()->in(resource_path('views/flux'));
}
```