### PR TITLE
Fix modal with Blaze

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -142,7 +142,7 @@ $classes = Flux::classes()
                 type="{{ $type }}"
                 {{-- Leave file inputs unstyled... --}}
                 {{ $attributes->except('class')->class($type === 'file' ? '' : $classes) }}
-                <?php if(isset($name)): ?> name="{{ $name }}" <?php endif; ?>
+                <?php if (isset($name)): ?> name="{{ $name }}" <?php endif; ?>
                 <?php if ($maskDynamic): ?> x-mask:dynamic="{{ $maskDynamic }}" @elseif ($mask) x-mask="{{ $mask }}" <?php endif; ?>
                 <?php if (is_numeric($size)): ?> size="{{ $size }}" <?php endif; ?>
                 @unblaze(scope: ['name' => $name ?? null])

--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -91,7 +91,9 @@ if ($dismissible === false) {
         {{ $styleAttributes->class($classes) }}
         @if ($name) data-modal="{{ $name }}" @endif
         @if ($flyout) data-flux-flyout @endif
-        x-data="fluxModal(@js($name), @js(isset($__livewire) ? $__livewire->getId() : null))"
+        @unblaze(scope: ['name' => $name])
+        x-data="fluxModal(@js($scope['name']), @js(isset($__livewire) ? $__livewire->getId() : null))"
+        @endunblaze
         x-on:modal-show.document="handleShow($event)"
         x-on:modal-close.document="handleClose($event)"
     >


### PR DESCRIPTION
# The scenario

Using `<flux:modal>` with Blaze enabled, the modal stops working after the first render.

# The problem

Blaze folds `$name` into a static string in the `x-data` attribute:

```blade
x-data="fluxModal(@js($name), @js(isset($__livewire) ? $__livewire->getId() : null))"
```

After the first render, the modal ID is baked in as a literal and never updates.

# The solution

Wrap the `x-data` attribute with `@unblaze` so `$name` stays dynamic:

```blade
@unblaze(scope: ['name' => $name])
x-data="fluxModal(@js($scope['name']), @js(isset($__livewire) ? $__livewire->getId() : null))"
@endunblaze
```