### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "livewire/flux",
-    "version": "2.12.1",
     "description": "The official UI component library for Livewire.",
     "keywords": ["flux", "laravel", "livewire", "components", "ui"],
     "license": "proprietary",


### PR DESCRIPTION
# The Scenario

Laravel 13 is releasing next month and Flux doesn't yet declare compatibility with it.

# The Solution

Updated `composer.json` dependency constraints to support Laravel 13. Laravel 13 requires PHP `^8.3` and Symfony `^7.4|^8.0`, so the `illuminate/*` and `symfony/console` constraints have been updated accordingly.