### PR TITLE
Fix modal with Blaze

### DIFF
--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -89,8 +89,8 @@ if ($dismissible === false) {
     <dialog
         wire:ignore.self {{-- This needs to be here because the dialog element adds a "close" attribute that isn't durable... --}}
         {{ $styleAttributes->class($classes) }}
-        @if ($name) data-modal="{{ $name }}" @endif
-        @if ($flyout) data-flux-flyout @endif
+        <?php if ($name): ?> data-modal="{{ $name }}" <?php endif; ?>
+        <?php if ($flyout): ?> data-flux-flyout <?php endif; ?>
         @unblaze(scope: ['name' => $name])
         x-data="fluxModal(@js($scope['name']), @js(isset($__livewire) ? $__livewire->getId() : null))"
         @endunblaze


### PR DESCRIPTION
# The scenario

Using a `<flux:modal>` component with Blaze.

# The problem

Livewire morph markers (`<!--[if BLOCK]-->`) end up inside the `<dialog>` opening tag, producing invalid HTML.

This seems to be caused by the addition of `@unblaze` — the directive likely changes how the template is compiled, causing Livewire to treat the surrounding `@if` blocks as morphable regions.

# The solution

Replace `@if` / `@endif` with `<?php if (): ?>` / `<?php endif; ?>` for the conditional attributes. Raw PHP directives are invisible to Livewire's morph system, so no markers are injected.