### PR TITLE
Add `input:` attribute prefix for targeting the input element

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -28,6 +28,8 @@
 
 @php
 
+$inputAttributes = Flux::attributesAfter('input:', $attributes, []);
+
 // There are a few loading scenarios that this covers:
 // If `:loading="false"` then never show loading.
 // If `:loading="true"` then always show loading.
@@ -141,7 +143,7 @@ $classes = Flux::classes()
             <input
                 type="{{ $type }}"
                 {{-- Leave file inputs unstyled... --}}
-                {{ $attributes->except('class')->class($type === 'file' ? '' : $classes) }}
+                {{ $attributes->except('class')->class($type === 'file' ? '' : $classes)->merge($inputAttributes->getAttributes()) }}
                 <?php if (isset($name)): ?> name="{{ $name }}" <?php endif; ?>
                 <?php if ($maskDynamic): ?> x-mask:dynamic="{{ $maskDynamic }}" @elseif ($mask) x-mask="{{ $mask }}" <?php endif; ?>
                 <?php if (is_numeric($size)): ?> size="{{ $size }}" <?php endif; ?>


### PR DESCRIPTION
# The Scenario

When using `flux:input`, classes and attributes need to be targeted to the inner `<input>` element rather than the wrapper `<div>`. Previously, this was only possible using the `class:input` syntax, which is inconsistent with the `nested:attribute` convention used by other Flux components (e.g., `field:class`, `label:class`, `container:class`).

```blade
<flux:input class="max-w-xs" input:class="text-green-500!" placeholder="Name" />

<flux:input label="Email" input:class="text-green-500!" />
```

# The Problem

The input component only supported the legacy `class:input` syntax for targeting classes to the `<input>` element. Other components use the `nested:attribute` prefix convention (e.g., `field:class`, `label:class`, `container:class`), but the input component didn't support `input:class` or other `input:*` attributes.

# The Solution

Added support for the `input:` attribute prefix using the same `Flux::attributesAfter()` pattern used throughout the codebase. Any `input:*` attributes are extracted and merged onto the `<input>` element. The existing `class:input` syntax continues to work for backwards compatibility.