### PR TITLE
Use @blaze(fold: true) in Lucide icon stubs

### DIFF
--- a/src/Console/IconCommand.php
+++ b/src/Console/IconCommand.php
@@ -95,7 +95,7 @@ class IconCommand extends Command
             SVG)->toString();
 
         $stub = <<<'HTML'
-        @blaze
+        @blaze(fold: true)
 
         {{-- Credit: Lucide (https://lucide.dev) --}}
 


### PR DESCRIPTION
## Summary

The `flux:icon` command generates Blade stubs for imported Lucide icons using a bare `@blaze` directive. All Heroicons stubs (e.g. `stubs/resources/views/flux/icon/h3.blade.php`) use `@blaze(fold: true)` to collapse the icon in the Blade component tree. This PR brings the generated Lucide stubs in line with that convention.

- **Before:** `@blaze`
- **After:** `@blaze(fold: true)`

## Changed file

- `src/Console/IconCommand.php` — one-line change to the stub string in `generateIconBlade()`