### PR TITLE
Add toggle prop to OTP for private mode visibility

### DIFF
--- a/stubs/resources/views/flux/otp/index.blade.php
+++ b/stubs/resources/views/flux/otp/index.blade.php
@@ -3,6 +3,7 @@
 @props([
     'length' => null,
     'private' => false,
+    'toggle' => false,
 ])
 
 @php
@@ -18,6 +19,10 @@
         data-flux-control
         role="group"
         data-flux-input-aria-label="{{ __('Character {current} of {total}') }}"
+        <?php if($toggle && $private): ?>
+            x-data="{ __private: true }"
+            x-effect="$el.querySelectorAll('input[data-flux-control]').forEach(i => i.type = __private ? 'password' : 'text')"
+        <?php endif; ?>
     >
         <?php if($slot->isEmpty() && $length): ?>
             <?php for($i = 0; $i < $length; $i++): ?>
@@ -25,6 +30,13 @@
             <?php endfor; ?>
         <?php else: ?>
             {{ $slot }}
+        <?php endif; ?>
+
+        <?php if($toggle && $private): ?>
+            <button type="button" x-on:click="__private = !__private" class="flex items-center justify-center size-8 rounded-md text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors" aria-label="{{ __('Toggle visibility') }}">
+                <flux:icon x-show="__private" name="eye" variant="micro" />
+                <flux:icon x-show="!__private" name="eye-slash" variant="micro" x-cloak />
+            </button>
         <?php endif; ?>
     </ui-otp>
 </flux:with-field>


### PR DESCRIPTION
## Summary

- Adds a `toggle` prop to `flux:otp` that renders an eye/eye-slash button to toggle input visibility when used alongside `private`
- Uses Alpine's `x-effect` to reactively switch input types between `password` and `text`
- Only renders the toggle button when both `private` and `toggle` are set

## Usage

```blade
<flux:otp wire:model="pin" length="6" private toggle />
```

Also works with custom slot markup:

```blade
<flux:otp wire:model="pin" private toggle>
    <flux:otp.group>
        <flux:otp.input />
        <flux:otp.input />
        <flux:otp.input />
        <flux:otp.input />
        <flux:otp.input />
        <flux:otp.input />
    </flux:otp.group>
</flux:otp>
```

## Motivation

PIN and OTP inputs often need a visibility toggle for accessibility and usability. Currently, achieving this requires custom Alpine code outside the component. This prop provides a native, zero-config solution.