### PR TITLE
Fix `flux:switch` indicator position with custom base font-size

### DIFF
--- a/stubs/resources/views/flux/switch.blade.php
+++ b/stubs/resources/views/flux/switch.blade.php
@@ -29,13 +29,13 @@ $classes = Flux::classes()
 $indicatorClasses = Flux::classes()
     ->add('size-3.5')
     ->add('rounded-full')
-    ->add('transition translate-x-[3px] dark:translate-x-[2px] rtl:-translate-x-[3px] dark:rtl:-translate-x-[2px]')
+    ->add('transition translate-x-[0.1875rem] dark:translate-x-[0.125rem] rtl:-translate-x-[0.1875rem] dark:rtl:-translate-x-[0.125rem]')
     ->add('bg-white')
     ->add([
-        'group-data-checked:translate-x-[15px] rtl:group-data-checked:-translate-x-[15px]',
-        // We have to add the dark variant of the `translate-x-[15px]` to ensure that if `.dark` is added to an element mid way 
-        // down the DOM instead of on the root HTML element, that the above `dark:translate-x-[2px]` doesn't over ride it...
-        'dark:group-data-checked:translate-x-[15px] dark:rtl:group-data-checked:-translate-x-[15px]',
+        'group-data-checked:translate-x-[0.9375rem] rtl:group-data-checked:-translate-x-[0.9375rem]',
+        // We have to add the dark variant of the `translate-x-[0.9375rem]` to ensure that if `.dark` is added to an element mid way
+        // down the DOM instead of on the root HTML element, that the above `dark:translate-x-[0.125rem]` doesn't over ride it...
+        'dark:group-data-checked:translate-x-[0.9375rem] dark:rtl:group-data-checked:-translate-x-[0.9375rem]',
         'group-data-checked:bg-(--color-accent-foreground)',
     ]);
 @endphp


### PR DESCRIPTION
# The Scenario

When the base `font-size` is changed from the default `16px`, the `flux:switch` indicator circle doesn't position correctly. It either overshoots or undershoots its target position depending on whether the font-size is larger or smaller than `16px`.

![Screenshot 2026-03-02 at 02 38 29PM](https://github.com/user-attachments/assets/38e61e2b-d86d-4c45-b355-118919f00ec0)

```blade
<html style="font-size: 20px">

<flux:switch />

</html>
```

# The Problem

The switch container and indicator use rem-based sizing (`w-8` = 2rem, `h-5` = 1.25rem, `size-3.5` = 0.875rem), but the translate values that position the indicator use fixed pixel values (`translate-x-[3px]`, `translate-x-[2px]`, `translate-x-[15px]`).

When the base font-size changes, the container and indicator scale proportionally (since they use rem), but the translate offsets stay fixed (since they use px), causing a mismatch.

# The Solution

Convert the pixel-based translate values to their rem equivalents so they scale proportionally with the rest of the component:

- `3px` → `0.1875rem`
- `2px` → `0.125rem`
- `15px` → `0.9375rem`

![Screenshot 2026-03-02 at 02 35 12PM](https://github.com/user-attachments/assets/71004b43-e4d0-4da4-b441-b38795d0352e)


Fixes #2443