### PR TITLE
Fix `invalid` prop not applying error styling on input and textarea

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -147,8 +147,8 @@ $classes = Flux::classes()
                 <?php if (isset($name)): ?> name="{{ $name }}" <?php endif; ?>
                 <?php if ($maskDynamic): ?> x-mask:dynamic="{{ $maskDynamic }}" @elseif ($mask) x-mask="{{ $mask }}" <?php endif; ?>
                 <?php if (is_numeric($size)): ?> size="{{ $size }}" <?php endif; ?>
-                @unblaze(scope: ['name' => $name ?? null])
-                <?php if ($invalid || ($scope['name'] && $errors->has($scope['name']))): ?>
+                @unblaze(scope: ['name' => $name ?? null, 'invalid' => $invalid ?? false])
+                <?php if ($scope['invalid'] || ($scope['name'] && $errors->has($scope['name']))): ?>
                 aria-invalid="true" data-invalid
                 <?php endif; ?>
                 @endunblaze

--- a/stubs/resources/views/flux/textarea.blade.php
+++ b/stubs/resources/views/flux/textarea.blade.php
@@ -32,8 +32,8 @@ $resizeStyle = match ($resize) {
         rows="{{ $rows }}"
         style="{{ $resizeStyle }}; {{ $rows === 'auto' ? 'field-sizing: content' : '' }}"
         @isset ($name) name="{{ $name }}" @endisset
-        @unblaze(scope: ['name' => $name ?? null])
-        <?php if ($invalid || ($scope['name'] && $errors->has($scope['name']))): ?>
+        @unblaze(scope: ['name' => $name ?? null, 'invalid' => $invalid ?? false])
+        <?php if ($scope['invalid'] || ($scope['name'] && $errors->has($scope['name']))): ?>
         aria-invalid="true" data-invalid
         <?php endif; ?>
         @endunblaze


### PR DESCRIPTION
# The Scenario

When using the `invalid` prop as documented on `flux:input` or `flux:textarea`, the error styling (red border) is not applied.

<img width="1356" height="2598" alt="Screenshot 2026-03-02 at 02 51 21PM@2x" src="https://github.com/user-attachments/assets/87e24317-3ca1-4e26-876a-b44ae3be4a17" />

```blade
<flux:field>
    <flux:label>Password</flux:label>
    <flux:input invalid wire:model="password" /> {{-- No red border --}}
</flux:field>
```

# The Problem

Both the input and textarea components declare `invalid` in their `@props` block, but never reference the `$invalid` variable in the template. Because `@props` extracts the prop from the `$attributes` bag, it gets consumed and silently discarded.

The error styling is only applied automatically when there are server-side validation errors via `$errors->has()`. The explicit `invalid` prop is never checked.

Other components like `flux:select`, `flux:date-picker`, and `flux:time-picker` correctly use the `$invalid` prop.

# The Solution

Add `$invalid` to the existing error-checking condition on both the input and textarea components, so either the explicit prop or automatic error detection triggers the invalid styling.

<img width="1356" height="2598" alt="Screenshot 2026-03-02 at 02 51 30PM@2x" src="https://github.com/user-attachments/assets/970cd8e6-2e2b-458f-b479-4850e5e72d27" />

Fixes #2448