### PR TITLE
Fix aware in select option

### DIFF
--- a/stubs/resources/views/flux/select/option/index.blade.php
+++ b/stubs/resources/views/flux/select/option/index.blade.php
@@ -1,6 +1,6 @@
 @blaze(fold: true, safe: ['value'])
 
-@aware([ 'variant' ])
+@aware([ 'variant', 'indicator' ])
 
 @props([
     'variant' => 'default',


### PR DESCRIPTION
# The scenario

Using `indicator="checkbox"` on a `<flux:select>` listbox doesn't have any effect with Blaze:

```blade
<flux:select variant="listbox" indicator="checkbox" multiple>
    <flux:select.option value="1">Option 1</flux:select.option>
    <flux:select.option value="2">Option 2</flux:select.option>
</flux:select>
```

# The problem

The `@aware` directive in `select/option/index.blade.php` didn't include `indicator`, so Blaze didn't propagate it through the delegate component:

```
flux:select (indicator="checkbox")
  └ flux:select.option — @aware(['variant']) ← indicator not included
      └ flux:delegate-component
          └ flux:select.option.variants.custom — @aware(['indicator'])
```

# The solution

Add `indicator` to the `@aware` directive in `select/option/index.blade.php`

```php
@aware([ 'variant', 'indicator' ])
```

Fixes livewire/blaze#115