### PR TITLE
Fix timeline line width break when `size="lg"` is set on individual item

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -313,11 +313,14 @@ Timeline
         --flux-timeline-content-gap: calc(var(--spacing) * 2);
     }
 
-    :where([data-flux-timeline-size="lg"]) {
+    :where([data-flux-timeline][data-flux-timeline-size="lg"]) {
         --flux-timeline-item-gap: calc(var(--spacing) * 8);
         --flux-timeline-content-gap: calc(var(--spacing) * 4);
         --flux-timeline-line-gap: 0px;
         --flux-timeline-line-width: 2px;
+    }
+
+    :where([data-flux-timeline-size="lg"]) {
         --flux-timeline-indicator-size: calc(var(--spacing) * 12);
     }
 


### PR DESCRIPTION
# The Scenario

When using `size="lg"` on an individual `flux:timeline.item`, the timeline line becomes thicker (2px) at that item while surrounding items remain at 1px, creating a visible break in the line.

<img width="2840" height="1686" alt="Screenshot 2026-03-10 at 01 13 42PM@2x" src="https://github.com/user-attachments/assets/2e848752-315d-4f25-a359-b85948c1da9d" />

```blade
<flux:timeline>
    <flux:timeline.item>
        <flux:timeline.indicator>
            <flux:icon.tag variant="micro" />
        </flux:timeline.indicator>
        <flux:timeline.content>
            <flux:heading>Default item</flux:heading>
        </flux:timeline.content>
    </flux:timeline.item>

    <flux:timeline.item size="lg">
        <flux:timeline.indicator>
            <flux:icon.star variant="micro" />
        </flux:timeline.indicator>
        <flux:timeline.content>
            <flux:heading>Large item</flux:heading>
        </flux:timeline.content>
    </flux:timeline.item>
</flux:timeline>
```

# The Problem

The CSS rule `:where([data-flux-timeline-size="lg"])` sets `--flux-timeline-line-width: 2px` and `--flux-timeline-line-gap: 0px`. This selector matches any element with the attribute, including individual `<li>` items. When only one item has `size="lg"`, its line segments inherit the thicker width while surrounding items stay at 1px.

# The Solution

Split the CSS rule into two parts:

- Line-related variables (`--flux-timeline-line-width`, `--flux-timeline-line-gap`) and timeline-level spacing (`--flux-timeline-item-gap`, `--flux-timeline-content-gap`) now use the more specific selector `:where([data-flux-timeline][data-flux-timeline-size="lg"])`, which only matches the `<ol>` wrapper.
- The indicator size (`--flux-timeline-indicator-size`) remains on the broader `:where([data-flux-timeline-size="lg"])` selector so it can still scale per-item.

<img width="2828" height="1544" alt="Screenshot 2026-03-10 at 01 14 31PM@2x" src="https://github.com/user-attachments/assets/a144b253-2cf7-4ede-bcc6-82bd6b187c41" />

**Note:** You will see in the fixed screenshot above the different line colours, that will be fixed in a Flux Pro PR https://github.com/livewire/flux-pro/pull/473.

Fixes #2473