### PR TITLE
Fix with-field.blade.php ComponentAttributeBag::all() for Laravel 10 compatibility

### DIFF
--- a/stubs/resources/views/flux/with-field.blade.php
+++ b/stubs/resources/views/flux/with-field.blade.php
@@ -39,6 +39,7 @@ extract(Flux::forwardedAttributes($attributes, [
 
         {{ $slot }}
 
+        {{-- We're using ->getAttributes() here because ->all() is only available since Laravel 11... --}}
         @unblaze(scope: ['attributes' => $errorAttributes->getAttributes()])
         <flux:error :attributes="new \Illuminate\View\ComponentAttributeBag($scope['attributes'])" />
         @endunblaze


### PR DESCRIPTION
# The scenario

When using Flux v2.13.0 with Laravel 10, any component that renders with a `label` or `description` attribute (inputs, selects, textareas, etc.) throws:

```
Method Illuminate\View\ComponentAttributeBag::all does not exist.
```

# The problem

In `stubs/resources/views/flux/with-field.blade.php` line 42, `$errorAttributes->all()` is called on a `ComponentAttributeBag` instance:

```blade
@unblaze(scope: ['attributes' => $errorAttributes->all()])
```

The `all()` method was added to `ComponentAttributeBag` in Laravel 11. It does not exist in Laravel 10, causing the error above.

This is the same issue that was fixed in `FluxManager.php` via #1386, but `with-field.blade.php` was missed.

# The solution

Replaced `$errorAttributes->all()` with `$errorAttributes->getAttributes()`, which is available in both Laravel 10 and 11. In Laravel 11, `all()` is defined as `return $this->getAttributes()` — they are equivalent.

```diff
-        @unblaze(scope: ['attributes' => $errorAttributes->all()])
+        @unblaze(scope: ['attributes' => $errorAttributes->getAttributes()])
```

Fixes livewire/flux#1385