### PR TITLE
Mark unsafe forwarded props

### DIFF
--- a/stubs/resources/views/flux/checkbox/group/index.blade.php
+++ b/stubs/resources/views/flux/checkbox/group/index.blade.php
@@ -1,4 +1,12 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // variant props
+    'size', 'name',
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
 
 @props([
     'variant' => 'default',

--- a/stubs/resources/views/flux/checkbox/group/variants/buttons.blade.php
+++ b/stubs/resources/views/flux/checkbox/group/variants/buttons.blade.php
@@ -1,4 +1,11 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
+
 
 @props([
     'variant' => null,

--- a/stubs/resources/views/flux/checkbox/group/variants/cards.blade.php
+++ b/stubs/resources/views/flux/checkbox/group/variants/cards.blade.php
@@ -1,4 +1,11 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
+
 
 @props([
     'variant' => null,

--- a/stubs/resources/views/flux/checkbox/group/variants/default.blade.php
+++ b/stubs/resources/views/flux/checkbox/group/variants/default.blade.php
@@ -1,4 +1,11 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
+
 
 @php
 $classes = Flux::classes()

--- a/stubs/resources/views/flux/checkbox/group/variants/pills.blade.php
+++ b/stubs/resources/views/flux/checkbox/group/variants/pills.blade.php
@@ -1,4 +1,11 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
+
 
 @props([
     'variant' => null,

--- a/stubs/resources/views/flux/checkbox/index.blade.php
+++ b/stubs/resources/views/flux/checkbox/index.blade.php
@@ -1,4 +1,8 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // variant props
+    'name', 'accent', 'size', 'label', 'icon', 'description', 'indicator',
+    'icon:variant',
+])
 
 @aware([ 'variant' ])
 

--- a/stubs/resources/views/flux/input/group/index.blade.php
+++ b/stubs/resources/views/flux/input/group/index.blade.php
@@ -1,4 +1,10 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
 
 @props([
     'name' => $attributes->whereStartsWith('wire:model')->first(),

--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -1,4 +1,12 @@
-@blaze(fold: true, unsafe: ['icon:trailing', 'icon:leading', 'icon:variant', 'mask:dynamic'])
+@blaze(fold: true, unsafe: [
+    // attributes
+    'icon:trailing', 'icon:leading', 'icon:variant', 'mask:dynamic',
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
 
 @php $iconTrailing ??= $attributes->pluck('icon:trailing'); @endphp
 @php $iconLeading ??= $attributes->pluck('icon:leading'); @endphp

--- a/stubs/resources/views/flux/otp/index.blade.php
+++ b/stubs/resources/views/flux/otp/index.blade.php
@@ -1,4 +1,10 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
 
 @props([
     'length' => null,

--- a/stubs/resources/views/flux/radio/group/index.blade.php
+++ b/stubs/resources/views/flux/radio/group/index.blade.php
@@ -1,4 +1,12 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // variant props
+    'size', 'name',
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
 
 @props([
     'variant' => 'default',

--- a/stubs/resources/views/flux/radio/group/variants/buttons.blade.php
+++ b/stubs/resources/views/flux/radio/group/variants/buttons.blade.php
@@ -1,4 +1,11 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
+
 
 @props([
     'variant' => null,

--- a/stubs/resources/views/flux/radio/group/variants/cards.blade.php
+++ b/stubs/resources/views/flux/radio/group/variants/cards.blade.php
@@ -1,4 +1,11 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
+
 
 @props([
     'variant' => null,

--- a/stubs/resources/views/flux/radio/group/variants/default.blade.php
+++ b/stubs/resources/views/flux/radio/group/variants/default.blade.php
@@ -1,4 +1,11 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
+
 
 @props([
     'name' => null,

--- a/stubs/resources/views/flux/radio/group/variants/pills.blade.php
+++ b/stubs/resources/views/flux/radio/group/variants/pills.blade.php
@@ -1,4 +1,11 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
+
 
 @props([
     'variant' => null,

--- a/stubs/resources/views/flux/radio/group/variants/segmented.blade.php
+++ b/stubs/resources/views/flux/radio/group/variants/segmented.blade.php
@@ -1,4 +1,11 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
+
 
 @props([
     'name' => null,

--- a/stubs/resources/views/flux/radio/index.blade.php
+++ b/stubs/resources/views/flux/radio/index.blade.php
@@ -1,4 +1,12 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // variant props
+    'size',
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
 
 @aware([ 'variant', 'size', 'indicator' ])
 

--- a/stubs/resources/views/flux/select/index.blade.php
+++ b/stubs/resources/views/flux/select/index.blade.php
@@ -1,4 +1,13 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // variant props
+    'name', 'placeholder', 'invalid', 'size', 'clear', 'close',
+    'selectedSuffix', 'searchable', 'clearable', 'button', 'input', 'trigger', 'search', 'empty', 'multiple',
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
 
 @props([
     'variant' => 'default',

--- a/stubs/resources/views/flux/select/option/index.blade.php
+++ b/stubs/resources/views/flux/select/option/index.blade.php
@@ -1,4 +1,6 @@
-@blaze(fold: true, safe: ['value'])
+@blaze(fold: true, safe: [
+    'filterable', 'indicator', 'loading',
+])
 
 @aware([ 'variant', 'indicator' ])
 

--- a/stubs/resources/views/flux/switch.blade.php
+++ b/stubs/resources/views/flux/switch.blade.php
@@ -1,4 +1,7 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-inline-field props
+    'name', 'label', 'description',
+])
 
 @props([
     'name' => null,

--- a/stubs/resources/views/flux/textarea.blade.php
+++ b/stubs/resources/views/flux/textarea.blade.php
@@ -1,4 +1,10 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-field props
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
 
 @props([
     'name' => $attributes->whereStartsWith('wire:model')->first(),

--- a/stubs/resources/views/flux/with-field.blade.php
+++ b/stubs/resources/views/flux/with-field.blade.php
@@ -1,4 +1,9 @@
-@blaze(fold: true, unsafe: ['description:trailing'])
+@blaze(fold: true, unsafe: [
+    'name', 'label', 'badge',
+    'description', 'description:trailing',
+    'label:badge', 'label:aside', 'label:trailing',
+    'error:name', 'error:bag', 'error:message', 'error:icon', 'error:nested', 'error:deep',
+])
 
 @php
 extract(Flux::forwardedAttributes($attributes, [

--- a/stubs/resources/views/flux/with-inline-field.blade.php
+++ b/stubs/resources/views/flux/with-inline-field.blade.php
@@ -1,4 +1,6 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    'name', 'label', 'description',
+])
 
 @php
 extract(flux::forwardedattributes($attributes, [

--- a/stubs/resources/views/flux/with-reversed-inline-field.blade.php
+++ b/stubs/resources/views/flux/with-reversed-inline-field.blade.php
@@ -1,4 +1,7 @@
-@blaze(fold: true)
+@blaze(fold: true, unsafe: [
+    // flux:with-inline-field props
+    'name', 'label', 'description',
+])
 
 @php
 extract(flux::forwardedattributes($attributes, [


### PR DESCRIPTION
# The scenario

When using Blaze, attributes forwarded through `<flux:with-field>` or `<flux:delegate-component>` don't work correctly when passed as dynamic PHP variables:

```blade
@php($label = null)

<flux:select :label="$label" />
```

The above always renders `ui-label` despite `$label` being `null`.

# The problem

Blaze treats props as "safe" (foldable at compile time) when they're not declared in the component's own `@props`. Forwarded props like `label`, `description`, `error:name`, etc. are defined in a different file (`with-field.blade.php`), so Blaze can't see them and folds them as static values.

# The solution

Manually declare all forwarded props as `unsafe` in the `@blaze` directive of each affected component.

Fixes livewire/flux#2458