### PR TITLE
Add CSP nonce support to editor script and style tags

### DIFF
--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -71,7 +71,7 @@ class AssetManager
         return $this->pretendResponseIsFile(__DIR__.'/../../flux-pro/dist/editor.min.js', 'text/javascript');
     }
 
-    public static function scripts($options = [])
+    public static function scripts()
     {
         $manifest = Flux::pro()
             ? json_decode(file_get_contents(__DIR__.'/../../flux-pro/dist/manifest.json'), true)
@@ -79,7 +79,8 @@ class AssetManager
 
         $versionHash = $manifest['/flux.js'];
 
-        $nonce = isset($options) && isset($options['nonce']) ? ' nonce="' . $options['nonce'] . '"' : '';
+        $nonce = app('flux')->nonce();
+        $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
 
         if (config('app.debug')) {
             return '<script src="'. url('/flux/flux.js?id='. $versionHash) . '" data-navigate-once' . $nonce . '></script>';
@@ -88,9 +89,10 @@ class AssetManager
         }
     }
 
-    public static function fluxAppearance($options = [])
+    public static function fluxAppearance()
     {
-        $nonce = isset($options) && isset($options['nonce']) ? ' nonce="' . $options['nonce'] . '"' : '';
+        $nonce = app('flux')->nonce();
+        $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
 
         // Make scrollbars dark in dark mode...
         return <<<HTML
@@ -134,10 +136,13 @@ HTML;
 
         $versionHash = $manifest['/editor.js'];
 
+        $nonce = app('flux')->nonce();
+        $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
+
         if (config('app.debug')) {
-            return '<script src="'. url('/flux/editor.js?id='. $versionHash) . '" defer></script>';
+            return '<script src="'. url('/flux/editor.js?id='. $versionHash) . '" defer' . $nonce . '></script>';
         } else {
-            return '<script src="'. url('/flux/editor.min.js?id='. $versionHash) . '" defer></script>';
+            return '<script src="'. url('/flux/editor.min.js?id='. $versionHash) . '" defer' . $nonce . '></script>';
         }
     }
 
@@ -147,7 +152,10 @@ HTML;
 
         $versionHash = $manifest['/editor.css'];
 
-        return '<link rel="stylesheet" href="'. url('/flux/editor.css?id='. $versionHash) . '">';
+        $nonce = app('flux')->nonce();
+        $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
+
+        return '<link rel="stylesheet" href="'. url('/flux/editor.css?id='. $versionHash) . '"' . $nonce . '>';
     }
 
     public function pretendResponseIsFile($file, $contentType = 'application/javascript; charset=utf-8')

--- a/src/FluxManager.php
+++ b/src/FluxManager.php
@@ -4,6 +4,7 @@ namespace Flux;
 
 use Flux\Concerns\InteractsWithComponents;
 use Composer\InstalledVersions;
+use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\Str;
 use Flux\ClassBuilder;
 
@@ -15,10 +16,13 @@ class FluxManager
 
     public $hasRenderedAssets = false;
 
+    public $nonce = null;
+
     public function boot()
     {
         on('flush-state', function () {
             $this->hasRenderedAssets = false;
+            $this->nonce = null;
         });
 
         $this->bootComponents();
@@ -45,14 +49,27 @@ class FluxManager
     {
         $this->markAssetsRendered();
 
-        return AssetManager::scripts($options);
+        if (isset($options['nonce'])) {
+            $this->nonce = $options['nonce'];
+        }
+
+        return AssetManager::scripts();
     }
 
     public function fluxAppearance($options = [])
     {
         $this->markAssetsRendered();
 
-        return AssetManager::fluxAppearance($options);
+        if (isset($options['nonce'])) {
+            $this->nonce = $options['nonce'];
+        }
+
+        return AssetManager::fluxAppearance();
+    }
+
+    public function nonce()
+    {
+        return $this->nonce ?? Vite::cspNonce();
     }
 
     public function editorStyles()


### PR DESCRIPTION
# The scenario
The editor component's `<script>` and `<link>` tags don't include a `nonce` attribute when the app uses CSP, causing blocked resources.

# The problem
The editor component loads its assets via `@assets` in the component template:

```blade
@assets
<flux:editor.scripts />
<flux:editor.styles />
@endassets
```

These components call into `AssetManager`:

```php
{{-- editor/scripts.blade.php --}}
{!! app('flux')->editorScripts() !!}

{{-- editor/styles.blade.php --}}
{!! app('flux')->editorStyles() !!}
```

These methods hard-code their tags without any nonce support, and the nonce passed to `@fluxScripts` was never propagated to them.

# The solution
We store the nonce on the FluxManager singleton when `scripts()` or `fluxAppearance()` is called, and expose a `nonce()` method that falls back to `Vite::cspNonce()`, following Livewire's own approach for resolving CSP nonces. All asset methods now resolve the nonce through it.

```php
// FluxManager.php
public function nonce()
{
    return $this->nonce ?? Vite::cspNonce();
}

// AssetManager.php — same pattern in all four asset methods
$nonce = app('flux')->nonce();
$nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
```

This is not a breaking change — passing a nonce via `@fluxScripts` or `@fluxAppearance` still works and takes precedence. Apps that don't use CSP nonces are unaffected.

Fixes livewire/flux#2500