### PR TITLE
Make pagination scroll-to CSP safe

### DIFF
--- a/stubs/resources/views/flux/pagination.blade.php
+++ b/stubs/resources/views/flux/pagination.blade.php
@@ -18,12 +18,12 @@ $simple = ! $paginator instanceof \Illuminate\Contracts\Pagination\LengthAwarePa
 $scrollToSelector = $scrollTo === true ? 'body' : $scrollTo;
 
 $scrollIntoViewJsSnippet = ($scrollTo !== null && $scrollTo !== false)
-    ? "scrollTo('{$scrollToSelector}')"
+    ? "(\$el.closest('{$scrollToSelector}') || \$el.closest('body').querySelector('{$scrollToSelector}')).scrollIntoView()"
     : '';
 @endphp
 
 @if ($simple)
-    <div {{ $attributes->class('pt-3 border-t border-zinc-100 dark:border-zinc-700 flex justify-between items-center') }} x-data="fluxPagination" data-flux-pagination>
+    <div {{ $attributes->class('pt-3 border-t border-zinc-100 dark:border-zinc-700 flex justify-between items-center') }} data-flux-pagination>
         <div></div>
 
         @if ($paginator->hasPages())
@@ -63,7 +63,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== null && $scrollTo !== false)
         @endif
     </div>
 @else
-    <div {{ $attributes->class('@container pt-3 border-t border-zinc-100 dark:border-zinc-700 flex justify-between items-center gap-3') }} x-data="fluxPagination" data-flux-pagination>
+    <div {{ $attributes->class('@container pt-3 border-t border-zinc-100 dark:border-zinc-700 flex justify-between items-center gap-3') }} data-flux-pagination>
         @if ($paginator->total() > 0)
             <div class="text-zinc-500 dark:text-zinc-400 text-xs font-medium whitespace-nowrap">
                 {!! __('Showing') !!} {{ $paginator->firstItem() }} {!! __('to') !!} {{ $paginator->lastItem() }} {!! __('of') !!} {{ $paginator->total() }} {!! __('results') !!}


### PR DESCRIPTION
# The scenario

Using `<flux:pagination :paginator="$items" scroll-to />` throws a CSP error in environments with `csp_safe = true` and Content Security Policy headers that block `unsafe-eval`.

# The problem

The scroll-to expression is an inline JavaScript string injected directly into `x-on:click`:

```php
$scrollIntoViewJsSnippet = "(\$el.closest('{$scrollToSelector}') || document.querySelector('{$scrollToSelector}')).scrollIntoView()";
```

# The solution

We register a `fluxPagination` Alpine.data component in `store.js` with a `scrollTo` method, following the same pattern we use for other components that require complex JavaScript (e.g. `fluxModal`, `fluxInputClearable`):

```javascript
Alpine.data('fluxPagination', () => ({
    scrollTo(selector) {
        if (! selector) return

        let el = this.$el.closest(selector) || document.querySelector(selector)

        if (el) el.scrollIntoView()
    }
}))
```

The pagination container gets `x-data="fluxPagination"` and the snippet becomes `scrollTo('selector')` — a simple method call that Alpine's CSP evaluator handles.

Related: livewire/flux-pro PR (same branch `filip/csp-pagination`)

Fixes livewire/flux#2499