### PR TITLE
Fix timeline content overflow with long unbreakable content

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -371,6 +371,7 @@ Timeline
         grid-column: 3;
         grid-row: 2 / 5;
         align-self: center;
+        min-width: 0;
     }
 
     [data-flux-timeline-line-leading] {


### PR DESCRIPTION
# The scenario

`<flux:timeline.content>` overflows its container when it contains long unbreakable content like `<pre>` blocks with URLs.

```html
<flux:timeline.content>
    <pre style="overflow: auto; max-width: 100%;">https://example.com/this-is-a-very-long-url-that-cannot-break...</pre>
</flux:timeline.content>
```

![Before fix - content overflows container](https://res.cloudinary.com/dwn42wfda/image/upload/v1774109337/sessions/15/fdmdtlxe3c1nbut0ztyt.png)

# The problem

`[data-flux-timeline-content]` is a CSS grid item placed in a `1fr` column, but it doesn't override the default `min-width: auto`. For grid items, `min-width: auto` resolves to `min-content` — the item refuses to shrink below its intrinsic content width. The `1fr` track expands from ~420px to ~1500px to accommodate the unbreakable text.

# The solution

Add `min-width: 0` to `[data-flux-timeline-content]`, allowing the `1fr` track to constrain to the remaining available space.

![After fix - content properly contained](https://res.cloudinary.com/dwn42wfda/image/upload/v1774109339/sessions/15/epca9qpds1kpeknw0fs3.png)

Fixes livewire/flux#2508