### PR TITLE
Add minimum width to navlist and navbar badges

### DIFF
--- a/stubs/resources/views/flux/navbar/badge.blade.php
+++ b/stubs/resources/views/flux/navbar/badge.blade.php
@@ -7,7 +7,7 @@
 
 @php
 $class = Flux::classes()
-    ->add('text-xs font-medium rounded-sm px-1 py-0.5')
+    ->add('text-xs font-medium rounded-sm px-1 py-0.5 min-w-5 text-center')
     /**
      * We can't compile classes for each color because of variants color to color and Tailwind's JIT compiler.
      * We instead need to write out each one by hand. Sorry...

--- a/stubs/resources/views/flux/navlist/badge.blade.php
+++ b/stubs/resources/views/flux/navlist/badge.blade.php
@@ -7,7 +7,7 @@
 
 @php
 $class = Flux::classes()
-    ->add('text-xs font-medium rounded-sm px-1 py-0.5')
+    ->add('text-xs font-medium rounded-sm px-1 py-0.5 min-w-5 text-center')
     /**
      * We can't compile classes for each color because of variants color to color and Tailwind's JIT compiler.
      * We instead need to write out each one by hand. Sorry...


### PR DESCRIPTION
## The scenario

Navlist and navbar badges with single-character content (e.g. "5") render too narrow compared to two-character badges.

<img src="https://res.cloudinary.com/dwn42wfda/image/upload/v1774111935/sessions/19/nuejgtvtsjtc7ppqtkie.png" width="360" />

## The problem

The badge has no minimum width — its width is determined entirely by the text content plus `px-1` horizontal padding.

## The solution

Add `min-w-5 text-center` to both `navlist/badge` and `navbar/badge`. The `min-w-5` (20px) matches the badge height, making single-character badges square and visually consistent with two-character badges.

<img src="https://res.cloudinary.com/dwn42wfda/image/upload/v1774111936/sessions/19/hy08erghjcb63lecqp4g.png" width="360" />

Fixes livewire/flux#2478