### PR TITLE
Fix inconsistent sidebar item and group spacing

### DIFF
--- a/stubs/resources/views/flux/sidebar/group.blade.php
+++ b/stubs/resources/views/flux/sidebar/group.blade.php
@@ -15,7 +15,7 @@
 <?php if ($expandable && $heading): ?>
     <?php if ($icon): ?>
         <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} @if ($expanded === true) open @endif data-flux-sidebar-group>
-            <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button mb-[2px] rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
+            <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button my-px rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
                 <div class="px-3">
                     <?php if (is_string($icon) && $icon !== ''): ?>
                         <flux:icon :icon="$icon" :variant="$iconVariant" class="size-4" />
@@ -32,15 +32,17 @@
                 </div>
             </button>
 
-            <div class="relative hidden data-open:block space-y-[2px] ps-7" @if ($expanded === true) data-open @endif>
+            <div class="relative hidden data-open:block ps-7" @if ($expanded === true) data-open @endif>
                 <div class="absolute inset-y-[3px] w-px bg-zinc-200 dark:bg-white/30 start-0 ms-5"></div>
 
-                {{ $slot }}
+                <div class="flex flex-col">
+                    {{ $slot }}
+                </div>
             </div>
         </ui-disclosure>
 
         <flux:dropdown hover class="in-data-flux-sidebar-on-mobile:hidden not-in-data-flux-sidebar-collapsed-desktop:hidden" position="right" align="start" data-flux-sidebar-group-dropdown>
-            <button type="button" class="border-1 border-transparent w-full px-3 in-data-flux-menu:px-2 h-8 flex gap-3 items-center group/disclosure-button mb-[2px] rounded-lg in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-menu:w-10 in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-menu:justify-center hover:bg-zinc-800/5 dark:hover:bg-white/[7%] in-data-flux-menu:hover:bg-zinc-50 dark:in-data-flux-menu:hover:bg-zinc-600 text-zinc-500 in-data-flux-menu:text-zinc-800 hover:text-zinc-800 dark:text-white/80 in-data-flux-menu:dark:text-white dark:hover:text-white">
+            <button type="button" class="border-1 border-transparent w-full px-3 in-data-flux-menu:px-2 h-8 flex gap-3 items-center group/disclosure-button my-px rounded-lg in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-menu:w-10 in-data-flux-sidebar-collapsed-desktop:not-in-data-flux-menu:justify-center hover:bg-zinc-800/5 dark:hover:bg-white/[7%] in-data-flux-menu:hover:bg-zinc-50 dark:in-data-flux-menu:hover:bg-zinc-600 text-zinc-500 in-data-flux-menu:text-zinc-800 hover:text-zinc-800 dark:text-white/80 in-data-flux-menu:dark:text-white dark:hover:text-white">
                 <?php if ($icon): ?>
                     <div class="relative">
                         <?php if (is_string($icon) && $icon !== ''): ?>
@@ -67,7 +69,7 @@
         </flux:dropdown>
     <?php else: ?>
         <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} @if ($expanded === true) open @endif data-flux-sidebar-group>
-            <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button mb-[2px] rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
+            <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button my-px rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
                 <div class="ps-3.5 pe-3.5">
                     <flux:icon.chevron-down class="size-3! hidden group-data-open/disclosure-button:block" />
                     <flux:icon.chevron-right class="size-3! block group-data-open/disclosure-button:hidden rtl:rotate-180" />
@@ -76,26 +78,28 @@
                 <span class="text-sm font-medium leading-none">{{ $heading }}</span>
             </button>
 
-            <div class="relative hidden data-open:block space-y-[2px] ps-7" @if ($expanded === true) data-open @endif>
+            <div class="relative hidden data-open:block ps-7" @if ($expanded === true) data-open @endif>
                 <div class="absolute inset-y-[3px] w-px bg-zinc-200 dark:bg-white/30 start-0 ms-5"></div>
 
-                {{ $slot }}
+                <div class="flex flex-col">
+                    {{ $slot }}
+                </div>
             </div>
         </ui-disclosure>
     <?php endif; ?>
 
 <?php elseif ($heading): ?>
-    <div {{ $attributes->class('block space-y-[2px] in-data-flux-sidebar-collapsed-desktop:hidden') }} data-flux-sidebar-group>
+    <div {{ $attributes->class('flex flex-col in-data-flux-sidebar-collapsed-desktop:hidden') }} data-flux-sidebar-group>
         <div class="px-3 py-2">
             <div class="text-sm text-zinc-400 font-medium leading-none">{{ $heading }}</div>
         </div>
 
-        <div>
+        <div class="flex flex-col">
             {{ $slot }}
         </div>
     </div>
 <?php else: ?>
-    <div {{ $attributes->class('block space-y-[2px] in-data-flux-sidebar-collapsed-desktop:hidden') }} data-flux-sidebar-group>
+    <div {{ $attributes->class('flex flex-col in-data-flux-sidebar-collapsed-desktop:hidden') }} data-flux-sidebar-group>
         {{ $slot }}
     </div>
 <?php endif; ?>


### PR DESCRIPTION
# The scenario

Sidebar items and sidebar groups have inconsistent vertical spacing.

<img src="https://res.cloudinary.com/dwn42wfda/image/upload/v1774195753/sessions/25/wfg6qkexzlcgalzmxilx.png" alt="Before/After" width="620" />

# The problem

## Problem 1

* Sidebar items use `my-px`
* Group heading buttons use `mb-[2px]`

The group heading buttons are missing top margin, so the gap above them is only 1px.

```html
<!-- sidebar item: symmetric margin → consistent 2px gaps -->
<a class="... my-px ...">

<!-- sidebar group button: bottom-only → 1px gap above -->
<button class="... mb-[2px] ...">
```

## Problem 2

* At top-level, the container uses `flex flex-col`
* Inside expanded groups, the container is a plain block-level div

Inside expended groups the `<ui-tooltip>` custom elements default to `display: inline`, which silently ignores vertical margins on child elements.

```html
<!-- top-level nav - margins work ✓ -->
<nav class="flex flex-col">
    <ui-tooltip>         <!-- behaves as block (flex item) -->
        <a class="... my-px ...">

<!-- inside group - margins ignored ✗ -->
<div class="block">
    <ui-tooltip>         <!-- stays inline (custom element default) -->
        <a class="... my-px ...">
```

# The solution

Match group buttons to sidebar items:

```diff
- <button class="... mb-[2px] ...">
+ <button class="... my-px ...">
```

Wrap group slot content in `flex flex-col` so tooltip wrappers render as block, and remove the now-unnecessary `space-y-[2px]` that was partially compensating:

```diff
- <div class="... space-y-[2px] ...">
-     {{ $slot }}
+ <div class="...">
+     <div class="flex flex-col">
+         {{ $slot }}
+     </div>
```

Fixes livewire/flux#2477