### PR TITLE
Fix bottom flyout width in Firefox

### DIFF
--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -25,12 +25,14 @@ if ($flyout) {
     $classes = Flux::classes()
         ->add(match ($variant) {
             default => match($position) {
-                'bottom' => 'fixed m-0 p-8 min-w-[100vw] overflow-y-auto mt-auto [--flux-flyout-translate:translateY(50px)] border-t',
+                // For bottom flyout we intentionally use 100% instead of 100vw because Firefox includes scrollbar gutter in vw...
+                'bottom' => 'fixed m-0 p-8 min-w-[100%] overflow-y-auto mt-auto [--flux-flyout-translate:translateY(50px)] border-t',
                 'left' => 'fixed m-0 p-8 max-h-dvh min-h-dvh md:[:where(&)]:min-w-[25rem] overflow-y-auto mr-auto [--flux-flyout-translate:translateX(-50px)] border-e rtl:mr-0 rtl:ml-auto rtl:[--flux-flyout-translate:translateX(50px)]',
                 default => 'fixed m-0 p-8 max-h-dvh min-h-dvh md:[:where(&)]:min-w-[25rem] overflow-y-auto ml-auto [--flux-flyout-translate:translateX(50px)] border-s rtl:ml-0 rtl:mr-auto rtl:[--flux-flyout-translate:translateX(-50px)]',
             },
             'floating' => match($position) {
-                'bottom' => 'fixed m-2 p-8 min-w-[calc(100vw-1rem)] overflow-y-auto mt-auto [--flux-flyout-translate:translateY(50px)]',
+                // For bottom flyout we intentionally use 100% instead of 100vw because Firefox includes scrollbar gutter in vw...
+                'bottom' => 'fixed m-2 p-8 min-w-[calc(100%-1rem)] overflow-y-auto mt-auto [--flux-flyout-translate:translateY(50px)]',
                 'left' => 'fixed m-2 p-8 max-h-[calc(100dvh-1rem)] min-h-[calc(100dvh-1rem)] md:[:where(&)]:min-w-[25rem] overflow-y-auto mr-auto [--flux-flyout-translate:translateX(-50px)] rtl:mr-0 rtl:ml-auto rtl:[--flux-flyout-translate:translateX(50px)]',
                 default => 'fixed m-2 p-8 max-h-[calc(100dvh-1rem)] min-h-[calc(100dvh-1rem)] md:[:where(&)]:min-w-[25rem] overflow-y-auto ml-auto [--flux-flyout-translate:translateX(50px)] rtl:ml-0 rtl:mr-auto rtl:[--flux-flyout-translate:translateX(-50px)]',
             },


### PR DESCRIPTION
# The scenario

In Firefox, bottom flyout overflows the screen width and renders behind scrollbar gutter:

<img width="1048" height="745" alt="SCR-20260323-lrhk-2" src="https://github.com/user-attachments/assets/33a7f2a2-3897-4a86-827b-a3eb677273cf" />

```html
<flux:modal flyout position="bottom" class="p-0!">
    ...
</flux:modal>

<div class="h-[calc(100vh+10rem)]"></div> <!-- Force scroll -->
```

# The problem

In Firefox the `100vw` measurement includes the scrollbar gutter. 

```
'bottom' => 'fixed m-0 p-8 min-w-[100vw] ...',
```

# The solution

Use `100%` instead. Because the modal is rendered in the top layer, `100% === 100vw`.



Fixes livewire/flux#2482