### PR TITLE
Add info variant to toast component

### DIFF
--- a/stubs/resources/views/flux/toast/index.blade.php
+++ b/stubs/resources/views/flux/toast/index.blade.php
@@ -22,9 +22,9 @@
 
                         {{-- Info icon --}}
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="hidden [[data-flux-toast-dialog][data-variant=info]_&]:block shrink-0 mt-0.5 size-4 text-cyan-500 dark:text-cyan-400">
-                            <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM8 4a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd" />
+                            <path fill-rule="evenodd" d="M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0ZM9 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM6.75 8a.75.75 0 0 0 0 1.5h.75v1.75a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8.25 8h-1.5Z" clip-rule="evenodd" />
                         </svg>
-
+                        
                         {{-- Danger icon --}}
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="hidden [[data-flux-toast-dialog][data-variant=danger]_&]:block shrink-0 mt-0.5 size-4 text-rose-500 dark:text-rose-400">
                             <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM8 4a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd" />


### PR DESCRIPTION
Currently, there are 3 variants for toast (success, warning, and danger) but there is no info variant for case like updating resources.

This PR adds new info variant icon to toast component

### Dark mode
<img width="417" height="105" alt="image" src="https://github.com/user-attachments/assets/f1b623b3-d7a2-42ac-9dd5-be1b1b407470" />

### Light mode
<img width="416" height="107" alt="image" src="https://github.com/user-attachments/assets/f29ceca4-7505-448b-b083-78eac64656ae" />

The icon is from https://heroicons.com/micro and adjusted like danger variant with coloring `text-cyan-500 dark:text-cyan-400`