### PR TITLE
Revert "Encapsulate version checking for view namespace hash"

### DIFF
--- a/src/FluxManager.php
+++ b/src/FluxManager.php
@@ -176,12 +176,11 @@ class FluxManager
 
     public function componentExists($name)
     {
-        return app('view')->exists($this->getFluxViewNamespaceHash() . '::' . $name);
-    }
-
-    public function getFluxViewNamespaceHash()
-    {
         // Laravel 12+ uses xxh128 hashing for views https://github.com/laravel/framework/pull/52301...
-        return app()->version() >= 12 ? hash('xxh128', 'flux') : md5('flux');
+        if (app()->version() >= 12) {
+            return app('view')->exists(hash('xxh128', 'flux') . '::' . $name);
+        }
+
+        return app('view')->exists(md5('flux') . '::' . $name);
     }
 }

--- a/src/FluxTagCompiler.php
+++ b/src/FluxTagCompiler.php
@@ -14,11 +14,9 @@ class FluxTagCompiler extends ComponentTagCompiler
 
             $class = \Illuminate\View\AnonymousComponent::class;
 
-            $fluxHash = Flux::getFluxViewNamespaceHash();
-
             // Laravel 12+ uses xxh128 hashing for views https://github.com/laravel/framework/pull/52301...
             return "<?php if (!Flux::componentExists(\$name = {$component})) throw new \Exception(\"Flux component [{\$name}] does not exist.\"); ?>##BEGIN-COMPONENT-CLASS##@component('{$class}', 'flux::' . {$component}, [
-    'view' => {$fluxHash} . '::' . {$component},
+    'view' => (app()->version() >= 12 ? hash('xxh128', 'flux') : md5('flux')) . '::' . {$component},
     'data' => \$__env->getCurrentComponentData(),
 ])
 <?php \$component->withAttributes(\$attributes->getAttributes()); ?>";


### PR DESCRIPTION
Reverts livewire/flux#2551

This PR caused errors, so need to revert it.

<img width="2594" height="2556" alt="Screenshot 2026-04-09 at 08 12 09AM@2x" src="https://github.com/user-attachments/assets/d3fbabc0-6bf7-43d7-a715-2648e0375c41" />
