### PR TITLE
Update pagination wording to use trans_choice for optional pluralisat…

### DIFF
--- a/stubs/resources/views/flux/pagination.blade.php
+++ b/stubs/resources/views/flux/pagination.blade.php
@@ -72,7 +72,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== null && $scrollTo !== false)
     <div {{ $attributes->class('@container pt-3 border-t border-zinc-100 dark:border-zinc-700 flex justify-between items-center gap-3') }} data-flux-pagination>
         @if ($paginator->total() > 0)
             <div class="text-zinc-500 dark:text-zinc-400 text-xs font-medium whitespace-nowrap">
-                {!! __('Showing') !!} {{ $paginator->firstItem() }} {!! __('to') !!} {{ $paginator->lastItem() }} {!! __('of') !!} {{ $paginator->total() }} {!! __('results') !!}
+                {!! __('Showing') !!} {{ $paginator->firstItem() }} {!! __('to') !!} {{ $paginator->lastItem() }} {!! __('of') !!} {{ $paginator->total() }} {!! trans_choice('result|results', $paginator->total()) !!}
             </div>
         @else
             <div></div>


### PR DESCRIPTION
…ion of the word result

# The scenario

This is really picky but something I noticed when working with the table component when paginating and there is only one result in the paginated collection.

# The problem

When using pagination with a table like so:

` <flux:table :paginate="$this->submissions">...</flux:table>`

When the resultset size is 1, the pagination text shows as "Showing 1 to 1 of 1 results", when it should be "Showing 1 to 1 of 1 result".

# The solution

This PR fixes the issue by using the trans_choice helper to choose "result" or "results" correctly.