### PR TITLE
Fix Blaze folding `flux:error` as static hidden HTML in inline field templates

### DIFF
--- a/stubs/resources/views/flux/with-inline-field.blade.php
+++ b/stubs/resources/views/flux/with-inline-field.blade.php
@@ -28,7 +28,9 @@ extract(Flux::forwardedattributes($attributes, [
             <flux:description>{{ $description }}</flux:description>
         <?php endif; ?>
 
-        <flux:error :$name />
+        @unblaze(scope: ['name' => $name])
+        <flux:error :name="$scope['name']" />
+        @endunblaze
     </flux:field>
 <?php else: ?>
     {{ $slot }}

--- a/stubs/resources/views/flux/with-inline-field.blade.php
+++ b/stubs/resources/views/flux/with-inline-field.blade.php
@@ -29,7 +29,7 @@ extract(Flux::forwardedattributes($attributes, [
         <?php endif; ?>
 
         @unblaze(scope: ['name' => $name])
-        <flux:error :name="$scope['name']" />
+            <flux:error :name="$scope['name']" />
         @endunblaze
     </flux:field>
 <?php else: ?>

--- a/stubs/resources/views/flux/with-reversed-inline-field.blade.php
+++ b/stubs/resources/views/flux/with-reversed-inline-field.blade.php
@@ -29,7 +29,9 @@ extract(Flux::forwardedattributes($attributes, [
 
         {{ $slot }}
 
-        <flux:error :$name />
+        @unblaze(scope: ['name' => $name])
+        <flux:error :name="$scope['name']" />
+        @endunblaze
     </flux:field>
 <?php else: ?>
     {{ $slot }}

--- a/stubs/resources/views/flux/with-reversed-inline-field.blade.php
+++ b/stubs/resources/views/flux/with-reversed-inline-field.blade.php
@@ -30,7 +30,7 @@ extract(Flux::forwardedattributes($attributes, [
         {{ $slot }}
 
         @unblaze(scope: ['name' => $name])
-        <flux:error :name="$scope['name']" />
+            <flux:error :name="$scope['name']" />
         @endunblaze
     </flux:field>
 <?php else: ?>


### PR DESCRIPTION
# The Scenario

When Blaze is installed, validation errors on `flux:checkbox`, `flux:radio`, and `flux:switch` never render. The error `div` is folded as static hidden HTML at compile time and never re-evaluated at runtime.

```php
<?php

use Livewire\Attributes\Validate;
use Livewire\Component;

new class extends Component {
    #[Validate('accepted')]
    public bool $terms = false;

    public function save()
    {
        $this->validate();
    }
}; ?>

<form wire:submit="save">
    <flux:checkbox label="Accept terms" wire:model="terms" />
    <flux:button type="submit">Submit</flux:button>
</form>
```

# The Problem

`with-inline-field.blade.php` and `with-reversed-inline-field.blade.php` render `flux:error` directly inside a `@blaze(fold: true)` block without wrapping it in `@unblaze`. `with-field.blade.php` already handles this correctly.

# The Solution

Wrap `flux:error` in `@unblaze` in both `with-inline-field.blade.php` and `with-reversed-inline-field.blade.php`, matching the existing pattern in `with-field.blade.php`.

Fixes #2560