### PR TITLE
Wrap hardcoded `aria-label` strings with `__()` for i18n support

### DIFF
--- a/stubs/resources/views/flux/input/clearable.blade.php
+++ b/stubs/resources/views/flux/input/clearable.blade.php
@@ -15,7 +15,7 @@ $attributes = $attributes->merge([
     x-data="fluxInputClearable"
     x-on:click="clear()"
     tabindex="-1"
-    aria-label="Clear input"
+    aria-label="{{ __('Clear input') }}"
     data-flux-clear-button
 >
     <flux:icon.x-mark variant="micro" />

--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -128,7 +128,7 @@ if (! $overflow) {
                     <?php if ($closable): ?>
                         <div class="absolute top-0 end-0 mt-4 me-4">
                             <flux:modal.close>
-                                <flux:button variant="ghost" icon="x-mark" size="sm" aria-label="Close modal" class="text-zinc-400! hover:text-zinc-800! dark:text-zinc-500! dark:hover:text-white!"></flux:button>
+                                <flux:button variant="ghost" icon="x-mark" size="sm" aria-label="{{ __('Close modal') }}" class="text-zinc-400! hover:text-zinc-800! dark:text-zinc-500! dark:hover:text-white!"></flux:button>
                             </flux:modal.close>
                         </div>
                     <?php endif; ?>
@@ -140,7 +140,7 @@ if (! $overflow) {
             <?php if ($closable): ?>
                 <div class="absolute top-0 end-0 mt-4 me-4">
                     <flux:modal.close>
-                        <flux:button variant="ghost" icon="x-mark" size="sm" aria-label="Close modal" class="text-zinc-400! hover:text-zinc-800! dark:text-zinc-500! dark:hover:text-white!"></flux:button>
+                        <flux:button variant="ghost" icon="x-mark" size="sm" aria-label="{{ __('Close modal') }}" class="text-zinc-400! hover:text-zinc-800! dark:text-zinc-500! dark:hover:text-white!"></flux:button>
                     </flux:modal.close>
                 </div>
             <?php endif; ?>


### PR DESCRIPTION
# The Scenario

Components with interactive elements like the modal close button and clearable input have hardcoded English `aria-label` attributes. Screen reader users in non-English locales hear English labels regardless of their application's language, making these components inaccessible to international users.

```blade
{{-- modal/index.blade.php --}}
<flux:button aria-label="Close modal">...</flux:button>

{{-- input/clearable.blade.php --}}
<flux:button aria-label="Clear input">...</flux:button>
```

# The Problem

Several components use raw English strings in `aria-label` attributes instead of wrapping them with Laravel's `__()` translation helper. Other components in Flux already follow the correct pattern (e.g., `sidebar/toggle.blade.php` uses `aria-label="{{ __('Toggle sidebar') }}"`), so this is an inconsistency rather than a deliberate design decision.

# The Solution

Wrap all hardcoded `aria-label` strings with `__()` so they can be translated via Laravel's JSON translation files:

```blade
{{-- Before --}}
aria-label="Close modal"

{{-- After --}}
aria-label="{{ __('Close modal') }}"
```

Strings added to the translatable set:
- `"Clear input"`
- `"Close modal"`

A corresponding PR for Flux Pro covers the remaining hardcoded strings there.

Fixes https://github.com/livewire/flux/discussions/2294