### PR TITLE
Forward `icon:variant` to input action sub-components

### DIFF
--- a/stubs/resources/views/flux/input/clearable.blade.php
+++ b/stubs/resources/views/flux/input/clearable.blade.php
@@ -18,5 +18,5 @@ $attributes = $attributes->merge([
     aria-label="Clear input"
     data-flux-clear-button
 >
-    <flux:icon.x-mark variant="micro" />
+    <flux:icon.x-mark :variant="$iconVariant" />
 </flux:button>

--- a/stubs/resources/views/flux/input/copyable.blade.php
+++ b/stubs/resources/views/flux/input/copyable.blade.php
@@ -17,6 +17,6 @@ $attributes = $attributes->merge([
     x-bind:data-copyable-copied="copied"
     aria-label="{{ __('Copy to clipboard') }}"
 >
-    <flux:icon.clipboard-document-check variant="mini" class="hidden [[data-copyable-copied]>&]:block" />
-    <flux:icon.clipboard-document variant="mini" class="block [[data-copyable-copied]>&]:hidden" />
+    <flux:icon.clipboard-document-check :variant="$iconVariant" class="hidden [[data-copyable-copied]>&]:block" />
+    <flux:icon.clipboard-document :variant="$iconVariant" class="block [[data-copyable-copied]>&]:hidden" />
 </flux:button>

--- a/stubs/resources/views/flux/input/expandable.blade.php
+++ b/stubs/resources/views/flux/input/expandable.blade.php
@@ -13,5 +13,5 @@ $attributes = $attributes->merge([
     :$attributes
     :size="$size === 'sm' || $size === 'xs' ? 'xs' : 'sm'"
 >
-    <flux:icon.chevron-down variant="micro" />
+    <flux:icon.chevron-down :variant="$iconVariant" />
 </flux:button>

--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -174,7 +174,7 @@ $classes = Flux::classes()
                     <?php endif; ?>
 
                     <?php if ($clearable): ?>
-                        <flux:input.clearable inset="left right" :$size />
+                        <flux:input.clearable inset="left right" :$size :$iconVariant />
                     <?php endif; ?>
 
                     <?php if ($kbd): ?>
@@ -182,15 +182,15 @@ $classes = Flux::classes()
                     <?php endif; ?>
 
                     <?php if ($expandable): ?>
-                        <flux:input.expandable inset="left right" :$size />
+                        <flux:input.expandable inset="left right" :$size :$iconVariant />
                     <?php endif; ?>
 
                     <?php if ($copyable): ?>
-                        <flux:input.copyable inset="left right" :$size />
+                        <flux:input.copyable inset="left right" :$size :$iconVariant />
                     <?php endif; ?>
 
                     <?php if ($viewable): ?>
-                        <flux:input.viewable inset="left right" :$size />
+                        <flux:input.viewable inset="left right" :$size :$iconVariant />
                     <?php endif; ?>
 
                     <?php if (is_string($iconTrailing)): ?>

--- a/stubs/resources/views/flux/input/viewable.blade.php
+++ b/stubs/resources/views/flux/input/viewable.blade.php
@@ -17,6 +17,6 @@ $attributes = $attributes->merge([
     x-bind:data-viewable-open="open"
     aria-label="{{ __('Toggle password visibility') }}"
 >
-    <flux:icon.eye-slash variant="micro" class="hidden [[data-viewable-open]>&]:block" />
-    <flux:icon.eye variant="micro" class="block [[data-viewable-open]>&]:hidden" />
+    <flux:icon.eye-slash :variant="$iconVariant" class="hidden [[data-viewable-open]>&]:block" />
+    <flux:icon.eye :variant="$iconVariant" class="block [[data-viewable-open]>&]:hidden" />
 </flux:button>


### PR DESCRIPTION
# The Scenario

When using `viewable`, `clearable`, `copyable`, or `expandable` on a `<flux:input>`, the action icons use hard-coded variants with no way to customise them. The `icon:variant` prop on the input only affects leading/trailing icons, not the action sub-components.

```blade
{{-- icon:variant="outline" only affects leading/trailing icons, not the viewable eye icon --}}
<flux:input type="password" viewable icon:variant="outline" icon="lock-closed" />
```

# The Problem

Each action sub-component hard-coded its own icon variant rather than inheriting from the parent input's `$iconVariant` prop:

- `viewable.blade.php`: `variant="micro"`
- `clearable.blade.php`: `variant="micro"`
- `expandable.blade.php`: `variant="micro"`
- `copyable.blade.php`: `variant="mini"`

The parent `input/index.blade.php` already accepted `icon:variant` (defaulting to `mini`) but never forwarded it to these sub-components.

# The Solution

Forward `$iconVariant` from the parent input component to all four action sub-components (`viewable`, `clearable`, `copyable`, `expandable`), replacing the hard-coded variants. This allows users to customise the icon variant via `icon:variant`:

```blade
<flux:input type="password" viewable icon:variant="outline" />
<flux:input clearable icon:variant="micro" />
```

All sub-components now default to `mini` (the input's default), which also fixes the inconsistency where `copyable` used `mini` but the other three used `micro`.

<img width="780" height="1308" alt="Screenshot 2026-04-16 at 12 18 08PM@2x" src="https://github.com/user-attachments/assets/a3df83bd-b941-4fed-83b5-ad96c084da78" />

Fixes #2335