### PR TITLE
Refactor flux-main component to use semantic <main> element

### DIFF
--- a/stubs/resources/views/flux/main.blade.php
+++ b/stubs/resources/views/flux/main.blade.php
@@ -12,6 +12,6 @@ $classes = Flux::classes('[grid-area:main]')
     ;
 @endphp
 
-<div {{ $attributes->class($classes) }} data-flux-main>
+<main {{ $attributes->class($classes) }} data-flux-main>
     {{ $slot }}
-</div>
+</main>


### PR DESCRIPTION
# The scenario

<!-- Describe as succinctly as possible what the bug/problem is. Be sure to include the steps to reproduce the bug, screenshots of the issue, and a self-contained Volt class component, which includes all Blade variable definitions, to reproduce the issue. -->

While reviewing the `flux-main` component’s markup, I identified an opportunity to enhance semantic HTML structure and accessibility by replacing the generic `<div>` wrapper with a semantic `<main>` element. This change aligns with modern web standards and improves screen reader interpretation.

# The problem

<!-- Describe here in detail what you found is wrong with the current code in this package. Add snippets of code here so the maintainers don't need to search the codebase for the issue. -->

The current implementation uses a `<div>` to wrap the main content of the `flux-main` component. While functional, this lacks semantic meaning, which can hinder accessibility and SEO. The component’s structure doesn’t clearly communicate its role as the primary content area of the page.

# The solution

<!-- Describe here what you did to fix the problem, whether there were other possible solutions, and why you chose this one. Be sure to include snippets of the code changes you have made and screenshots of the problem fixed after your changes. -->

I refactored the component to use `<main>` instead of `<div>`, preserving all existing attributes and slot content. This change maintains full functionality while improving semantic clarity and accessibility. 

To ensure compatibility, I tested the change in a fresh Laravel project. I confirmed that the styling remains unaffected because the `data-flux-main` attribute is used for targeting in CSS, not the element tag. The relevant style rule in `dist/flux.css` — `*:has(>[data-flux-main])` — relies on attribute presence, not tag name, so the layout remains consistent. No visual or structural breaks were observed.

The diff shows a direct, low-risk replacement with no behavioral side effects.

This addresses the request/discussion in: https://github.com/livewire/flux/discussions/640