### PR TITLE
Support `wire:model` on expandable `flux:sidebar.group` and `flux:navlist.group`

### DIFF
--- a/stubs/resources/views/flux/navlist/group.blade.php
+++ b/stubs/resources/views/flux/navlist/group.blade.php
@@ -6,8 +6,24 @@
     'heading' => null,
 ])
 
+@php
+$wireModel = $attributes->wire('model');
+
+// Support adding the .self modifier to the wire:model directive...
+if ($expandable && $wireModel && $wireModel->directive && ! $wireModel->hasModifier('self')) {
+    unset($attributes[$wireModel->directive]);
+
+    $wireModel->directive .= '.self';
+
+    $attributes = $attributes->merge([$wireModel->directive => $wireModel->value]);
+}
+
+// Support binding the state to a Livewire property
+$state = $wireModel?->value ? '$wire.' . $wireModel->value : ($expanded ? 'true' : 'false');
+@endphp
+
 <?php if ($expandable && $heading): ?>
-    <ui-disclosure {{ $attributes->class('group/disclosure') }} @if ($expanded === true) open @endif data-flux-navlist-group>
+    <ui-disclosure {{ $attributes->class('group/disclosure') }} x-data="{ open: {{ $state }} }" x-model.self="open" @if ($expanded === true) open @endif data-flux-navlist-group>
         <button type="button" class="w-full h-10 lg:h-8 flex items-center group/disclosure-button mb-[2px] rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
             <div class="ps-3 pe-4">
                 <flux:icon.chevron-down class="size-3! hidden group-data-open/disclosure-button:block" />

--- a/stubs/resources/views/flux/sidebar/group.blade.php
+++ b/stubs/resources/views/flux/sidebar/group.blade.php
@@ -12,9 +12,25 @@
     'icon' => null,
 ])
 
+@php
+// Support adding the .self modifier to the wire:model directive...
+if ($expandable && ($wireModel = $attributes->wire('model')) && $wireModel->directive && ! $wireModel->hasModifier('self')) {
+    unset($attributes[$wireModel->directive]);
+
+    $wireModel->directive .= '.self';
+
+    $attributes = $attributes->merge([$wireModel->directive => $wireModel->value]);
+}
+
+// Support binding the state to a Livewire property
+$state = ($expandable && ($wireModel ?? null)?->value)
+    ? '$wire.' . $wireModel->value
+    : ($expanded ? 'true' : 'false');
+@endphp
+
 <?php if ($expandable && $heading): ?>
     <?php if ($icon): ?>
-        <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} @if ($expanded === true) open @endif data-flux-sidebar-group>
+        <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} x-data="{ open: {{ $state }} }" x-model.self="open" @if ($expanded === true) open @endif data-flux-sidebar-group>
             <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button my-px rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
                 <div class="px-3">
                     <?php if (is_string($icon) && $icon !== ''): ?>
@@ -68,7 +84,7 @@
             </flux:menu>
         </flux:dropdown>
     <?php else: ?>
-        <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} @if ($expanded === true) open @endif data-flux-sidebar-group>
+        <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} x-data="{ open: {{ $state }} }" x-model.self="open" @if ($expanded === true) open @endif data-flux-sidebar-group>
             <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button my-px rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
                 <div class="ps-3.5 pe-3.5">
                     <flux:icon.chevron-down class="size-3! hidden group-data-open/disclosure-button:block" />

--- a/stubs/resources/views/flux/sidebar/group.blade.php
+++ b/stubs/resources/views/flux/sidebar/group.blade.php
@@ -13,8 +13,10 @@
 ])
 
 @php
+$wireModel = $attributes->wire('model');
+
 // Support adding the .self modifier to the wire:model directive...
-if ($expandable && ($wireModel = $attributes->wire('model')) && $wireModel->directive && ! $wireModel->hasModifier('self')) {
+if ($expandable && $wireModel && $wireModel->directive && ! $wireModel->hasModifier('self')) {
     unset($attributes[$wireModel->directive]);
 
     $wireModel->directive .= '.self';
@@ -23,9 +25,7 @@ if ($expandable && ($wireModel = $attributes->wire('model')) && $wireModel->dire
 }
 
 // Support binding the state to a Livewire property
-$state = ($expandable && ($wireModel ?? null)?->value)
-    ? '$wire.' . $wireModel->value
-    : ($expanded ? 'true' : 'false');
+$state = $wireModel?->value ? '$wire.' . $wireModel->value : ($expanded ? 'true' : 'false');
 @endphp
 
 <?php if ($expandable && $heading): ?>


### PR DESCRIPTION
# The Scenario

A developer wants to persist whether an expandable `flux:sidebar.group` or `flux:navlist.group` is open by binding it to a Livewire property. Adding `wire:click` to the group header doesn't work cleanly: clicks on child items bubble up to the wrapper and re-trigger the toggle, and `.self` doesn't help because the actual click target is an inner `<button>`, not the wrapper.

```php
<?php

use Livewire\Component;
use Livewire\Attributes\Session;

new class extends Component
{
    #[Session]
    public bool $expanded = true;
}; ?>

<flux:sidebar.group :expanded="\$expanded"
                    expandable
                    heading="My Items"
                    wire:click="\$toggle('expanded')">
    <flux:sidebar.item href="/home">Home</flux:sidebar.item>
    <flux:sidebar.item href="/settings">Settings</flux:sidebar.item>
</flux:sidebar.group>
```

# The Problem

Both `stubs/resources/views/flux/sidebar/group.blade.php` and `stubs/resources/views/flux/navlist/group.blade.php` spread `\$attributes` directly onto the outer `<ui-disclosure>` wrapper. `wire:model` would therefore land on `<ui-disclosure>`, but without the `.self` modifier it would also pick up bubbled `input`/`change` events from nested form controls inside the group.

The sibling component `flux:accordion.item` already handles this exact case by auto-applying the `.self` modifier to `wire:model` and setting up Alpine `x-data` / `x-model.self` for clean two-way binding with the disclosure's `value`. `flux:sidebar.group` and `flux:navlist.group` were missing this.

# The Solution

Apply the same pattern from `flux:accordion.item` to both `flux:sidebar.group` and `flux:navlist.group` when `expandable`:

- Auto-add `.self` to any `wire:model` directive so it only listens to events fired directly on `<ui-disclosure>`.
- Initialise Alpine `x-data="{ open: \$wire.<prop> }"` and bind via `x-model.self="open"` so the disclosure value stays in sync with the Livewire property in both directions.

After this change, the original use case becomes:

```blade
<flux:sidebar.group expandable heading="My Items" wire:model.live="expanded">
    <flux:sidebar.item href="/home">Home</flux:sidebar.item>
    <flux:sidebar.item href="/settings">Settings</flux:sidebar.item>
</flux:sidebar.group>
```

Fixes #2580