### PR TITLE
Forward `icon:variant` to navbar item trailing icon

### DIFF
--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -22,7 +22,7 @@
 $square ??= $slot->isEmpty();
 
 // Size-up icons in square/icon-only buttons...
-$iconClasses = Flux::classes($square ? 'size-6' : 'size-5');
+$iconClasses = Flux::classes($square ? 'size-6!' : 'size-5!');
 
 $classes = Flux::classes()
     ->add('px-3 h-8 flex items-center rounded-lg')
@@ -72,7 +72,7 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
-        <flux:icon :icon="$iconTrailing" :variant="$iconVariant" class="size-4! ms-1" />
+        <flux:icon :icon="$iconTrailing" :variant="$iconVariant" class="size-5! ms-1" />
     <?php elseif ($iconTrailing): ?>
         {{ $iconTrailing }}
     <?php endif; ?>

--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -72,7 +72,7 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
-        <flux:icon :$icon :variant="$iconVariant" class="{!! $iconClasses !!}" />
+        <flux:icon :icon="$iconTrailing" :variant="$iconVariant" class="{!! $iconClasses !!}" />
     <?php elseif ($iconTrailing): ?>
         {{ $iconTrailing }}
     <?php endif; ?>

--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -22,7 +22,7 @@
 $square ??= $slot->isEmpty();
 
 // Size-up icons in square/icon-only buttons...
-$iconClasses = Flux::classes($square ? 'size-6!' : 'size-5!');
+$iconClasses = Flux::classes($square ? 'size-6' : 'size-5');
 
 $classes = Flux::classes()
     ->add('px-3 h-8 flex items-center rounded-lg')
@@ -72,7 +72,7 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
-        <flux:icon :icon="$iconTrailing" :variant="$iconVariant" class="size-5! ms-1" />
+        <flux:icon :$icon :variant="$iconVariant" class="{!! $iconClasses !!}" />
     <?php elseif ($iconTrailing): ?>
         {{ $iconTrailing }}
     <?php endif; ?>

--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -72,7 +72,7 @@ $classes = Flux::classes()
     <?php endif; ?>
 
     <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
-        <flux:icon :icon="$iconTrailing" variant="micro" class="size-4 ms-1" />
+        <flux:icon :icon="$iconTrailing" :variant="$iconVariant" class="size-4! ms-1" />
     <?php elseif ($iconTrailing): ?>
         {{ $iconTrailing }}
     <?php endif; ?>


### PR DESCRIPTION
This PR modify `flux:navbar.item` and forward `icon:variant` to its trailing icon which should be consistence with
- `flux:navlist.item`
- `flux:navmenu.item`

As comparison
### `flux:navbar.item`
```blade
<?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
    <flux:icon :icon="$iconTrailing" variant="micro" class="size-4 ms-1" />
    {{-- Update: <flux:icon :icon="$iconTrailing" :variant="$iconVariant" class="{!! $iconClasses !}}" /> --}}
<?php elseif ($iconTrailing): ?>
    {{ $iconTrailing }}
<?php endif; ?>
```
### `flux:navlist.item`
```blade
@php
    ...
    // Size-up icons in square/icon-only buttons...
    $iconClasses = Flux::classes($square ? 'size-5!' : 'size-4!');
    ...
@endphp

<?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
    <flux:icon :icon="$iconTrailing" :variant="$iconVariant" class="size-4!" />
<?php elseif ($iconTrailing): ?>
    {{ $iconTrailing }}
<?php endif; ?>
```
### `flux:navmenu.item`
```blade
@php
    ...
    $iconClasses = Flux::classes()
        ->add('me-2')
        // When using the outline icon variant, we need to size it down to match the default icon sizes...
        ->add($iconVariant === 'outline' ? 'size-5' : null)
        ;

    $trailingIconClasses = Flux::classes()
        ->add('ms-auto')
        // When using the outline icon variant, we need to size it down to match the default icon sizes...
        ->add($iconVariant === 'outline' ? 'size-5' : null)
        ;
    ...
@endphp

<?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
    <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$trailingIconClasses" />
<?php elseif ($iconTrailing): ?>
    {{ $iconTrailing }}
<?php endif; ?>
```

```blade
// icon:variant not forwarded
<flux:navbar.item icon:variant="outline" icon:trailing="bell-alert">Notifications</flux:navbar.item>
```

| Before | After |
| - | - |
| <img width="128" height="43" alt="image" src="https://github.com/user-attachments/assets/a8ed75f1-1bf7-4af4-bf64-8e479638ea66" /> | <img width="130" height="42" alt="image" src="https://github.com/user-attachments/assets/893e7c19-44ec-4adb-8b42-6ad05d33ca5e" /> |
