### PR TITLE
Fix date picker crashing when used with `clearable`

### DIFF
--- a/stubs/resources/views/flux/input/clearable.blade.php
+++ b/stubs/resources/views/flux/input/clearable.blade.php
@@ -1,5 +1,10 @@
 @blaze(fold: true, memo: true)
 
+@props([
+    'iconVariant' => 'mini',
+    'size' => null,
+])
+
 @php
 $attributes = $attributes->merge([
     'variant' => 'subtle',

--- a/stubs/resources/views/flux/input/copyable.blade.php
+++ b/stubs/resources/views/flux/input/copyable.blade.php
@@ -1,5 +1,10 @@
 @blaze(fold: true, memo: true)
 
+@props([
+    'iconVariant' => 'mini',
+    'size' => null,
+])
+
 @php
 $attributes = $attributes->merge([
     'variant' => 'subtle',

--- a/stubs/resources/views/flux/input/expandable.blade.php
+++ b/stubs/resources/views/flux/input/expandable.blade.php
@@ -1,5 +1,10 @@
 @blaze(fold: true, memo: true)
 
+@props([
+    'iconVariant' => 'mini',
+    'size' => null,
+])
+
 @php
 $attributes = $attributes->merge([
     'variant' => 'subtle',

--- a/stubs/resources/views/flux/input/viewable.blade.php
+++ b/stubs/resources/views/flux/input/viewable.blade.php
@@ -1,5 +1,10 @@
 @blaze(fold: true, memo: true)
 
+@props([
+    'iconVariant' => 'mini',
+    'size' => null,
+])
+
 @php
 $attributes = $attributes->merge([
     'variant' => 'subtle',


### PR DESCRIPTION
# The Scenario

Rendering a `flux:date-picker` with a clearable trigger throws:

```
ErrorException
Undefined variable $iconVariant

packages/flux/stubs/resources/views/flux/input/clearable.blade.php:22
```

```blade
<flux:date-picker wire:model="agreement_date" label="Agreement date">
    <x-slot name="trigger">
        <flux:date-picker.input clearable />
    </x-slot>
</flux:date-picker>
```

Any code that renders `flux:input.clearable`, `flux:input.viewable`, `flux:input.copyable`, or `flux:input.expandable` directly (rather than via a `flux:input`) hits the same error.

# The Problem

#2566 switched the four input action sub-components from hard-coded icon variants (`variant="micro"` / `variant="mini"`) to `:variant="$iconVariant"`, and updated `flux:input` to forward `:$iconVariant` into each one.

Because `flux:input` always passes `iconVariant` down, the sub-components receive it as a variable and render fine in that path. But the sub-components themselves never declared `iconVariant` in `@props` — so they only work when a parent explicitly passes it.

`flux:date-picker.input`'s native variant renders the clear button via:

```blade
{{-- packages/flux-pro/stubs/resources/views/flux/date-picker/input/variants/native.blade.php --}}
<flux:input.clearable :$size as="div" />
```

`iconVariant` isn't passed, isn't declared, isn't defined, and rendering blows up.

# The Solution

Declare `iconVariant` (and `size`, for the same reason) as props with sensible defaults on each of the four sub-components:

```blade
@props([
    'iconVariant' => 'mini',
    'size' => null,
])
```

`mini` matches the default on `flux:input`, so behaviour is unchanged when the sub-components are used via `flux:input`. Anywhere they're used standalone — `flux:date-picker.input` internally, or user code calling them directly — now falls through to the default and renders cleanly.

`size` had to be declared alongside `iconVariant` because once `@props` is present, Blade stops auto-exposing undeclared attributes as variables, which broke the existing `$size === 'sm'` checks.

Fixes #2590