### PR TITLE
Support `flux:badge` with tooltip

### DIFF
--- a/stubs/resources/views/flux/badge/index.blade.php
+++ b/stubs/resources/views/flux/badge/index.blade.php
@@ -86,22 +86,24 @@ $classes = Flux::classes()
     });
 @endphp
 
-<flux:button-or-div :attributes="$attributes->class($classes)" data-flux-badge>
-    <?php if (is_string($icon) && $icon !== ''): ?>
-        <flux:icon :$icon :variant="$iconVariant" :class="$iconClasses" data-flux-badge-icon />
-    <?php else: ?>
-        {{ $icon }}
-    <?php endif; ?>
+<flux:with-tooltip :$attributes>
+    <flux:button-or-div :attributes="$attributes->class($classes)" data-flux-badge>
+        <?php if (is_string($icon) && $icon !== ''): ?>
+            <flux:icon :$icon :variant="$iconVariant" :class="$iconClasses" data-flux-badge-icon />
+        <?php else: ?>
+            {{ $icon }}
+        <?php endif; ?>
 
-    {{ $slot->isEmpty() ? $label : $slot }}
+        {{ $slot->isEmpty() ? $label : $slot }}
 
-    <?php if ($iconTrailing): ?>
-        <div class="ps-1 flex items-center" data-flux-badge-icon:trailing>
-            <?php if (is_string($iconTrailing)): ?>
-                <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$iconClasses" />
-            <?php else: ?>
-                {{ $iconTrailing }}
-            <?php endif; ?>
-        </div>
-    <?php endif; ?>
-</flux:button-or-div>
+        <?php if ($iconTrailing): ?>
+            <div class="ps-1 flex items-center" data-flux-badge-icon:trailing>
+                <?php if (is_string($iconTrailing)): ?>
+                    <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$iconClasses" />
+                <?php else: ?>
+                    {{ $iconTrailing }}
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+    </flux:button-or-div>
+</flux:with-tooltip>


### PR DESCRIPTION
`flux:badge` can be set as a `<div>` or a `<button>` however it doesnt support tooltip attribute (yet) meanwhile `flux:button` which can be set as a `<div>`, `<a>` or `<button>` already support tooltip attribute.

This PR wrap `flux:badge` with `flux:with-tooltip` and pass the attributes just like `flux:button`

### Before
https://github.com/user-attachments/assets/a3386e56-c5d9-408e-b7ca-b2d03310d2d7

### After
https://github.com/user-attachments/assets/079ea20d-8faf-453d-9713-346416eba50a

File changed
- `flux/badge/index.blade.php`
