### PR TITLE
Replace blade directive with php syntax

### DIFF
--- a/stubs/resources/views/flux/breadcrumbs/item.blade.php
+++ b/stubs/resources/views/flux/breadcrumbs/item.blade.php
@@ -56,7 +56,7 @@ $iconClasses = Flux::classes()
         </div>
     <?php endif; ?>
 
-    <?php if ($separator === null): ?>
+    <?php if ($separator == null): ?>
         <flux:icon icon="chevron-right" variant="mini" class="{{ $separatorClasses->add('rtl:hidden') }}" />
         <flux:icon icon="chevron-left" variant="mini" class="{{ $separatorClasses->add('hidden rtl:inline') }}" />
     <?php elseif (! is_string($separator)): ?>

--- a/stubs/resources/views/flux/breadcrumbs/item.blade.php
+++ b/stubs/resources/views/flux/breadcrumbs/item.blade.php
@@ -56,14 +56,14 @@ $iconClasses = Flux::classes()
         </div>
     <?php endif; ?>
 
-    @if ($separator == null)
+    <?php if ($separator === null): ?>
         <flux:icon icon="chevron-right" variant="mini" class="{{ $separatorClasses->add('rtl:hidden') }}" />
         <flux:icon icon="chevron-left" variant="mini" class="{{ $separatorClasses->add('hidden rtl:inline') }}" />
-    @elseif (! is_string($separator))
+    <?php elseif (! is_string($separator)): ?>
         {{ $separator }}
-    @elseif ($separator === 'slash')
+    <?php elseif ($separator === 'slash'): ?>
         <flux:icon icon="slash" variant="mini" class="{{ $separatorClasses->add('rtl:-scale-x-100') }}" />
-    @else
+    <?php else: ?>
         <flux:icon :icon="$separator" variant="mini" class="{{ $separatorClasses }}" />
-    @endif
+    <?php endif; ?>
 </div>

--- a/stubs/resources/views/flux/checkbox/variants/buttons.blade.php
+++ b/stubs/resources/views/flux/checkbox/variants/buttons.blade.php
@@ -61,7 +61,7 @@ $iconAttributes = Flux::attributesAfter('icon:', $attributes, [
         {{ $icon }}
     <?php endif; ?>
 
-    @if ($slot->isNotEmpty() || isset($label))
+    <?php if ($slot->isNotEmpty() || isset($label)): ?>
         <span>{{ $slot->isNotEmpty() ? $slot : $label }}</span>
-    @endif
+    <?php endif; ?>
 </ui-checkbox>

--- a/stubs/resources/views/flux/header.blade.php
+++ b/stubs/resources/views/flux/header.blade.php
@@ -20,11 +20,11 @@ if ($sticky) {
 @endphp
 
 <header {{ $attributes->class($classes) }} data-flux-header>
-    @if ($container)
+    <?php if ($container) : ?>
         <div class="mx-auto w-full h-full [:where(&)]:max-w-7xl px-6 lg:px-8 flex items-center">
             {{ $slot }}
         </div>
-    @else
+    <?php else: ?>
         {{ $slot }}
-    @endif
+    <?php endif; ?>
 </header>

--- a/stubs/resources/views/flux/radio/variants/buttons.blade.php
+++ b/stubs/resources/views/flux/radio/variants/buttons.blade.php
@@ -61,7 +61,7 @@ $iconAttributes = Flux::attributesAfter('icon:', $attributes, [
         {{ $icon }}
     <?php endif; ?>
 
-    @if ($slot->isNotEmpty() || isset($label))
+    <?php if ($slot->isNotEmpty() || isset($label)): ?>
         <span>{{ $slot->isNotEmpty() ? $slot : $label }}</span>
-    @endif
+    <?php endif; ?>
 </ui-radio>

--- a/stubs/resources/views/flux/sidebar/index.blade.php
+++ b/stubs/resources/views/flux/sidebar/index.blade.php
@@ -38,9 +38,9 @@ if ($collapsibleOnMobile) {
 }
 @endphp
 
-@if ($collapsibleOnMobile)
+<?php if ($collapsibleOnMobile): ?>
     <flux:sidebar.backdrop />
-@endif
+<?php endif; ?>
 
 <ui-sidebar
     {{ $attributes->class($classes) }}

--- a/stubs/resources/views/flux/switch.blade.php
+++ b/stubs/resources/views/flux/switch.blade.php
@@ -43,16 +43,16 @@ $indicatorClasses = Flux::classes()
     ]);
 @endphp
 
-@if ($align === 'left' || $align === 'start')
+<?php if ($align === 'left' || $align === 'start'): ?>
     <flux:with-inline-field :$attributes>
         <ui-switch {{ $attributes->class($classes) }} @if($showName) name="{{ $name }}" @endif @if($checked) checked data-checked @endif data-flux-control data-flux-switch>
             <span class="{{ \Illuminate\Support\Arr::toCssClasses($indicatorClasses) }}"></span>
         </ui-switch>
     </flux:with-inline-field>
-@else
+<?php else: ?>
     <flux:with-reversed-inline-field :$attributes>
         <ui-switch {{ $attributes->class($classes) }} @if($showName) name="{{ $name }}" @endif @if($checked) checked data-checked @endif data-flux-control data-flux-switch>
             <span class="{{ \Illuminate\Support\Arr::toCssClasses($indicatorClasses) }}"></span>
         </ui-switch>
     </flux:with-reversed-inline-field>
-@endif
+<?php endif; ?>

--- a/stubs/resources/views/flux/table/sortable.blade.php
+++ b/stubs/resources/views/flux/table/sortable.blade.php
@@ -16,18 +16,18 @@ $classes = Flux::classes()
     {{ $slot }}
 
     <div class="rounded-sm text-zinc-400 group-hover/sortable:text-zinc-800 dark:group-hover/sortable:text-white">
-        @if ($sorted)
-            @if ($direction === 'asc')
+        <?php if ($sorted): ?>
+            <?php if ($direction === 'asc'): ?>
                 <flux:icon.chevron-up variant="micro" />
-            @elseif ($direction === 'desc')
+            <?php elseif ($direction === 'desc'): ?>
                 <flux:icon.chevron-down variant="micro" />
-            @else
+            <?php else: ?>
                 <flux:icon.chevron-down variant="micro" />
-            @endif
-        @else
+            <?php endif; ?>
+        <?php else: ?>
             <div class="opacity-0 group-hover/sortable:opacity-100">
                 <flux:icon.chevron-down variant="micro" />
             </div>
-        @endif
+        <?php endif; ?>
     </div>
 </button>


### PR DESCRIPTION
This PR consists of
- Replace the blade directive used in component html with php syntax mainly for consistency with other components. 
- Inline blade directive remains untouched.
- Pagination component remains untouched (I get overwhelmed by its directives 🤕 )

### File changed
- `stubs/resources/views/flux/breadcrumbs/item.blade.php`
- `stubs/resources/views/flux/checkbox/variants/buttons.blade.php`
- `stubs/resources/views/flux/radio/variants/buttons.blade.php`
- `stubs/resources/views/flux/sidebar/index.blade.php`
- `stubs/resources/views/flux/table/sortable.blade.php`
- `stubs/resources/views/flux/header.blade.php`
- `stubs/resources/views/flux/switch.blade.php`