### PR TITLE
Support `flux:navmenu.item` with badge

### DIFF
--- a/stubs/resources/views/flux/navmenu/badge.blade.php
+++ b/stubs/resources/views/flux/navmenu/badge.blade.php
@@ -1,0 +1,56 @@
+@blaze(fold: true)
+
+@props([
+    'variant' => null,
+    'color' => null,
+])
+
+@php
+$class = Flux::classes()
+    ->add('text-xs font-medium rounded-sm px-1 py-0.5 min-w-5 text-center')
+    /**
+     * We can't compile classes for each color because of variants color to color and Tailwind's JIT compiler.
+     * We instead need to write out each one by hand. Sorry...
+     */
+    ->add($variant === 'solid' ? match ($color) {
+        default => 'text-white dark:text-white bg-zinc-600 dark:bg-zinc-600',
+        'red' => 'text-white dark:text-white bg-red-500 dark:bg-red-600',
+        'orange' => 'text-white dark:text-white bg-orange-500 dark:bg-orange-600',
+        'amber' => 'text-white dark:text-zinc-950 bg-amber-500 dark:bg-amber-500',
+        'yellow' => 'text-white dark:text-zinc-950 bg-yellow-500 dark:bg-yellow-400',
+        'lime' => 'text-white dark:text-white bg-lime-500 dark:bg-lime-600',
+        'green' => 'text-white dark:text-white bg-green-500 dark:bg-green-600',
+        'emerald' => 'text-white dark:text-white bg-emerald-500 dark:bg-emerald-600',
+        'teal' => 'text-white dark:text-white bg-teal-500 dark:bg-teal-600',
+        'cyan' => 'text-white dark:text-white bg-cyan-500 dark:bg-cyan-600',
+        'sky' => 'text-white dark:text-white bg-sky-500 dark:bg-sky-600',
+        'blue' => 'text-white dark:text-white bg-blue-500 dark:bg-blue-600',
+        'indigo' => 'text-white dark:text-white bg-indigo-500 dark:bg-indigo-600',
+        'violet' => 'text-white dark:text-white bg-violet-500 dark:bg-violet-600',
+        'purple' => 'text-white dark:text-white bg-purple-500 dark:bg-purple-600',
+        'fuchsia' => 'text-white dark:text-white bg-fuchsia-500 dark:bg-fuchsia-600',
+        'pink' => 'text-white dark:text-white bg-pink-500 dark:bg-pink-600',
+        'rose' => 'text-white dark:text-white bg-rose-500 dark:bg-rose-600',
+    } :  match ($color) {
+        default => 'text-zinc-700 dark:text-zinc-200 bg-zinc-400/15 dark:bg-zinc-400/40',
+        'red' => 'text-red-700 dark:text-red-200 bg-red-400/20 dark:bg-red-400/40',
+        'orange' => 'text-orange-700 dark:text-orange-200 bg-orange-400/20 dark:bg-orange-400/40',
+        'amber' => 'text-amber-700 dark:text-amber-200 bg-amber-400/25 dark:bg-amber-400/40',
+        'yellow' => 'text-yellow-800 dark:text-yellow-200 bg-yellow-400/25 dark:bg-yellow-400/40',
+        'lime' => 'text-lime-800 dark:text-lime-200 bg-lime-400/25 dark:bg-lime-400/40',
+        'green' => 'text-green-800 dark:text-green-200 bg-green-400/20 dark:bg-green-400/40',
+        'emerald' => 'text-emerald-800 dark:text-emerald-200 bg-emerald-400/20 dark:bg-emerald-400/40',
+        'teal' => 'text-teal-800 dark:text-teal-200 bg-teal-400/20 dark:bg-teal-400/40',
+        'cyan' => 'text-cyan-800 dark:text-cyan-200 bg-cyan-400/20 dark:bg-cyan-400/40',
+        'sky' => 'text-sky-800 dark:text-sky-200 bg-sky-400/20 dark:bg-sky-400/40',
+        'blue' => 'text-blue-800 dark:text-blue-200 bg-blue-400/20 dark:bg-blue-400/40',
+        'indigo' => 'text-indigo-700 dark:text-indigo-200 bg-indigo-400/20 dark:bg-indigo-400/40',
+        'violet' => 'text-violet-700 dark:text-violet-200 bg-violet-400/20 dark:bg-violet-400/40',
+        'purple' => 'text-purple-700 dark:text-purple-200 bg-purple-400/20 dark:bg-purple-400/40',
+        'fuchsia' => 'text-fuchsia-700 dark:text-fuchsia-200 bg-fuchsia-400/20 dark:bg-fuchsia-400/40',
+        'pink' => 'text-pink-700 dark:text-pink-200 bg-pink-400/20 dark:bg-pink-400/40',
+        'rose' => 'text-rose-700 dark:text-rose-200 bg-rose-400/20 dark:bg-rose-400/40',
+    });
+@endphp
+
+<span {{ $attributes->class($class) }} data-flux-navlist-badge>{{ $slot }}</span>

--- a/stubs/resources/views/flux/navmenu/item.blade.php
+++ b/stubs/resources/views/flux/navmenu/item.blade.php
@@ -6,11 +6,13 @@
 @props([
     'iconVariant' => 'mini',
     'iconTrailing' => null,
+    'badgeColor' => null,
     'variant' => 'default',
     'disabled' => false,
     'indent' => false,
     'suffix' => null,
     'value' => null,
+    'badge' => null,
     'icon' => null,
     'kbd' => null,
 ])
@@ -59,7 +61,9 @@ $classes = Flux::classes()
         {{ $icon }}
     <?php endif; ?>
 
-    {{ $slot }}
+    <?php if ($slot->isNotEmpty()): ?>
+        <div class="flex-1 text-sm font-medium leading-none whitespace-nowrap [[data-nav-footer]_&]:hidden [[data-nav-sidebar]_[data-nav-footer]_&]:block" data-content>{{ $slot }}</div>
+    <?php endif; ?>
 
     <?php if ($suffix): ?>
         <?php if (is_string($suffix)): ?>
@@ -75,5 +79,10 @@ $classes = Flux::classes()
         <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$trailingIconClasses" />
     <?php elseif ($iconTrailing): ?>
         {{ $iconTrailing }}
+    <?php endif; ?>
+
+    <?php if (isset($badge) && $badge !== ''): ?>
+        <?php $badgeAttributes = Flux::attributesAfter('badge:', $attributes, ['color' => $badgeColor]); ?>
+        <flux:navmenu.badge :attributes="$badgeAttributes">{{ $badge }}</flux:navmenu.badge>
     <?php endif; ?>
 </flux:button-or-link>


### PR DESCRIPTION
# The scenario

`flux:navmenu` can be used as [user dropdown](https://fluxui.dev/components/dropdown#navigation-menus) (See image below). However, current template doesnt support badge (yet). I have been searching for user dropdown design on https://dribbble.com/ and there are quite a lot of design that use badge on it.

| Dark | Light |
| - | - |
| <img width="214" height="261" alt="image" src="https://github.com/user-attachments/assets/4ceaad5b-365f-4b6a-88fc-bafd7d165108" /> | <img width="215" height="271" alt="image" src="https://github.com/user-attachments/assets/c0b3ed3a-13a9-4271-9ea2-04a3f55f4f54" /> |
| <img width="223" height="266" alt="image" src="https://github.com/user-attachments/assets/9a92f027-1b3b-4613-9a3e-1fefd0615719" /> | <img width="214" height="268" alt="image" src="https://github.com/user-attachments/assets/0e7e1d7e-1278-4db8-91fb-c13b26e86aab" /> |

# The problem

While `flux:navlist.item` and `flux:navbar.item` already support this, I dont see the issue for `flux:navmenu.item` also support this. 

# The solution

Added new component `flux:navmenu.badge` as complement after trailing icon just exactly like `flux:navbar.item` and `flux:navlist.item`. 

A dedicated component keeps styling scoped and consistent with existing navlist/navbar patterns. This brings consistency across all navigation item components

- Modify `flux:navmenu.item` slot to use wrapper following `flux:navlist.item` and `flux:navbar.item` wrapper

### Example
```blade
<flux:dropdown position="bottom" align="end">
    <flux:profile avatar="/img/demo/user.png" name="John Doe" />

    <flux:navmenu>
        <flux:navmenu.item href="#" icon="adjustments-horizontal">Account</flux:navmenu.item>

        <flux:navmenu.item href="#" icon="wallet">Wallet</flux:navmenu.item>

        <flux:navmenu.item href="#" icon="credit-card" badge="Pro" badge:color="orange" badge:variant="solid">
            Upgrade Plan
        </flux:navmenu.item>

        <flux:navmenu.item href="#" icon="gift" badge="New" badge:color="indigo" badge:variant="solid">
            Referrals
        </flux:navmenu.item>

        <flux:navmenu.separator />

        <flux:navmenu.item href="#" icon="arrow-right-start-on-rectangle">Logout</flux:navmenu.item>
    </flux:navmenu>
</flux:dropdown>
```

### New File
- `stubs/resources/views/flux/navmenu/badge.blade.php`

### File Changed
- `stubs/resources/views/flux/navmenu/item.blade.php`