### PR TITLE
Fix sidebar brand not truncating

### DIFF
--- a/stubs/resources/views/flux/sidebar/brand.blade.php
+++ b/stubs/resources/views/flux/sidebar/brand.blade.php
@@ -12,13 +12,13 @@
 
 @php
 $classes = Flux::classes()
-    ->add('h-10 flex items-center px-2 in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:px-0 in-data-flux-sidebar-collapsed-desktop:justify-center')
+    ->add('h-10 min-w-0 flex items-center px-2 in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:px-0 in-data-flux-sidebar-collapsed-desktop:justify-center')
     ->add('in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:absolute')
     ->add('in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:opacity-0')
     ;
 
 $textClasses = Flux::classes()
-    ->add('text-sm font-medium truncate [:where(&)]:text-zinc-800 dark:[:where(&)]:text-zinc-100')
+    ->add('min-w-0 text-sm font-medium truncate [:where(&)]:text-zinc-800 dark:[:where(&)]:text-zinc-100')
     ;
 @endphp
 

--- a/stubs/resources/views/flux/sidebar/collapse.blade.php
+++ b/stubs/resources/views/flux/sidebar/collapse.blade.php
@@ -13,7 +13,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('w-10 h-8 flex items-center justify-center')
+    ->add('w-10 h-8 shrink-0 flex items-center justify-center')
     ->add('in-data-flux-sidebar-collapsed-desktop:opacity-0')
     ->add('in-data-flux-sidebar-collapsed-desktop:absolute')
     ->add('in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:opacity-100')


### PR DESCRIPTION
# The Scenario

When `flux:sidebar.brand` is given a long `name`, the brand link overflows the sidebar's width and pushes the `flux:sidebar.collapse` toggle button completely outside the sidebar. The `truncate` class on the brand's name never engages, so the text does not get cut off with an ellipsis.

<img width="606" height="250" alt="Screenshot 2026-05-18 at 10 54 12AM@2x" src="https://github.com/user-attachments/assets/1e314c7a-153f-4d72-9ed2-8b69af359cc3" />

```blade
<flux:sidebar collapsible sticky>
    <flux:sidebar.header>
        <flux:sidebar.brand
            href="#"
            logo="https://fluxui.dev/img/demo/logo.png"
            name="This is a very long company name here"
        />
        <flux:sidebar.collapse />
    </flux:sidebar.header>

    <flux:sidebar.nav>
        <flux:sidebar.item href="#" icon="home">Home</flux:sidebar.item>
    </flux:sidebar.nav>
</flux:sidebar>
```

# The Problem

The brand link sits inside the sidebar header as a flex item, with its name in a child `<div>` that has `truncate`. By default, flex items refuse to shrink below their content's natural width, so the brand keeps growing to fit the full name, pushing the collapse toggle out of bounds. The `truncate` on the name never has a constrained width to clip against.

# The Solution

Add `min-w-0` to the brand link and its inner text `<div>` so they can shrink inside their respective flex parents, which lets `truncate` engage on the name. Add `shrink-0` to `flux:sidebar.collapse` so the toggle keeps its fixed width when the brand wants to grow.

<img width="604" height="238" alt="Screenshot 2026-05-18 at 10 55 07AM@2x" src="https://github.com/user-attachments/assets/9a64c9f0-ee6d-4c10-a0f1-52ce1899f4d8" />

Fixes #2612
