### PR TITLE
Fix `description:trailing` not showing without label or description

### DIFF
--- a/stubs/resources/views/flux/with-field.blade.php
+++ b/stubs/resources/views/flux/with-field.blade.php
@@ -25,7 +25,7 @@ extract(Flux::forwardedAttributes($attributes, [
     'badge' => null,
 ])
 
-<?php if (isset($label) || isset($description)): ?>
+<?php if (isset($label) || isset($description) || isset($descriptionTrailing)): ?>
     <?php
 
         $fieldAttributes = Flux::attributesAfter('field:', $attributes, []);


### PR DESCRIPTION
# The scenario

When user want to show description below `<textarea>` wrapped inside `<flux:field>` using `description:trailing` attribute, its not showing at all.

```blade
<div class="min-w-[300px]">
    <flux:field>
        <flux:label badge="Required" badge:class="ms-2">Message</flux:label>
        <flux:textarea description:trailing="Max 3,000 characters" wire:model="message" />
        <flux:error name="message" />
    </flux:field>
</div>
```

# The problem

There are only check against label and description itself but not for trailing description in **`<flux:with-field>`** component
```blade
<?php if (isset($label) || isset($description)): ?>
```
Eventhough description trailing should be rendered inside this check.

<img width="332" height="175" alt="image" src="https://github.com/user-attachments/assets/2cf2c5c5-c777-4d45-9077-65f79bb06475" />

# The solution

Add optional check for trailing description
```blade
<?php if (isset($label) || isset($description) || isset($descriptionTrailing)): ?>
```
<img width="332" height="185" alt="image" src="https://github.com/user-attachments/assets/ee1484c1-d1a3-465f-b7fe-0e5e0350be84" />

# File Changes
- `stubs/resources/views/flux/with-field.blade.php`

Fixes https://github.com/livewire/flux/issues/2623