### PR TITLE
Fix Blaze safe list in select option

### DIFF
--- a/stubs/resources/views/flux/select/option/index.blade.php
+++ b/stubs/resources/views/flux/select/option/index.blade.php
@@ -1,4 +1,5 @@
-@blaze(fold: true, safe: [
+@blaze(fold: true, unsafe: [
+    // variant props
     'filterable', 'indicator', 'loading',
 ])
 


### PR DESCRIPTION
# The scenario

When `indicator` is passed in as a dynamic property, the select always renders the default indicator.

```blade
<flux:select
    variant="listbox"
    :indicator="$multiple ? 'checkbox' : null"
>
    ...
</flux:select>
```

<img width="734" height="293" alt="SCR-20260520-tslb" src="https://github.com/user-attachments/assets/63b6fad2-63a0-4d70-a645-9dee4447dddd" />

# The problem

The problem is that in the above example, the select folds because `indicator` is currently marked as `safe`. However `indicator` is not a pass-through prop, it changes which indicator component is rendered inside the option.

This was introduced by an oversight in #2496, where we marked props of `flux::delegate-component` targets as `unsafe` in their parent component (because Blaze cannot "see through" the delegate component).

What makes it even clearer that this was an oversight, is that [this was the only component in the entire diff](https://github.com/livewire/flux/commit/d0202a2f05953b9b3d404bcbadadf050e426b381#diff-b6a765c7e42ee17d4efe2d1b7fb2e12436d0e57d0b97641ef8fdc6d36f7a3c1a) that added `safe` props. In all the other components we marked props as `unsafe`, which was the main point of the PR.

# The solution

Change `safe` to `unsafe` + add comment for consistency with other components.

Fixes livewire/flux#2613