### PR TITLE
Replace `flux:textarea` inline style with tailwindcss class

### DIFF
--- a/stubs/resources/views/flux/textarea.blade.php
+++ b/stubs/resources/views/flux/textarea.blade.php
@@ -18,25 +18,24 @@ $classes = Flux::classes()
     ->add('block p-3 w-full')
     ->add('shadow-xs disabled:shadow-none border rounded-lg')
     ->add('bg-white dark:bg-white/10 dark:disabled:bg-white/[7%]')
-    ->add($resize ? 'resize-y' : 'resize-none')
+    ->add($rows === 'auto' ? 'field-sizing-content' : '')
+    ->add($resize ? match ($resize) {
+        default => 'resize' // to prevent unhandled match type when user only provide the attribute without value
+        'none' => 'resize-none',
+        'both' => 'resize',
+        'horizontal' => 'resize-x',
+        'vertical' => 'resize-y',
+    } : 'resize-none')
     ->add('text-base sm:text-sm text-zinc-700 disabled:text-zinc-500 placeholder-zinc-400 disabled:placeholder-zinc-400/70 dark:text-zinc-300 dark:disabled:text-zinc-400 dark:placeholder-zinc-400 dark:disabled:placeholder-zinc-500')
     ->add('border-zinc-200 border-b-zinc-300/80 dark:border-white/10')
     ->add('data-invalid:shadow-none data-invalid:border-red-500 dark:data-invalid:border-red-500')
     ;
-
-$resizeStyle = match ($resize) {
-    'none' => 'resize: none',
-    'both' => 'resize: both',
-    'horizontal' => 'resize: horizontal',
-    'vertical' => 'resize: vertical',
-};
 @endphp
 
 <flux:with-field :$attributes>
     <textarea
         {{ $attributes->class($classes) }}
         rows="{{ $rows }}"
-        style="{{ $resizeStyle }}; {{ $rows === 'auto' ? 'field-sizing: content' : '' }}"
         @isset ($name) name="{{ $name }}" @endisset
         @unblaze(scope: ['name' => $name ?? null, 'invalid' => $invalid ?? false])
         <?php if ($scope['invalid'] || ($scope['name'] && $errors->has($scope['name']))): ?>

--- a/stubs/resources/views/flux/textarea.blade.php
+++ b/stubs/resources/views/flux/textarea.blade.php
@@ -20,7 +20,7 @@ $classes = Flux::classes()
     ->add('bg-white dark:bg-white/10 dark:disabled:bg-white/[7%]')
     ->add($rows === 'auto' ? 'field-sizing-content' : '')
     ->add($resize ? match ($resize) {
-        default => 'resize' // to prevent unhandled match type when user only provide the attribute without value
+        default => 'resize', // to prevent unhandled match type when user only provide the attribute without value
         'none' => 'resize-none',
         'both' => 'resize',
         'horizontal' => 'resize-x',

--- a/stubs/resources/views/flux/textarea.blade.php
+++ b/stubs/resources/views/flux/textarea.blade.php
@@ -18,14 +18,14 @@ $classes = Flux::classes()
     ->add('block p-3 w-full')
     ->add('shadow-xs disabled:shadow-none border rounded-lg')
     ->add('bg-white dark:bg-white/10 dark:disabled:bg-white/[7%]')
-    ->add($rows === 'auto' ? 'field-sizing-content' : '')
     ->add($resize ? match ($resize) {
-        default => 'resize', // to prevent unhandled match type when user only provide the attribute without value
         'none' => 'resize-none',
         'both' => 'resize',
         'horizontal' => 'resize-x',
         'vertical' => 'resize-y',
+        default => 'resize-y',
     } : 'resize-none')
+    ->add($rows === 'auto' ? 'field-sizing-content' : '')
     ->add('text-base sm:text-sm text-zinc-700 disabled:text-zinc-500 placeholder-zinc-400 disabled:placeholder-zinc-400/70 dark:text-zinc-300 dark:disabled:text-zinc-400 dark:placeholder-zinc-400 dark:disabled:placeholder-zinc-500')
     ->add('border-zinc-200 border-b-zinc-300/80 dark:border-white/10')
     ->add('data-invalid:shadow-none data-invalid:border-red-500 dark:data-invalid:border-red-500')


### PR DESCRIPTION
# The scenario

Although I can't seem to reproduce this issue https://github.com/livewire/flux/issues/2627, I think this might be better to use tailwind class on `flux:textarea` since this style not exposed to Alpine like `flux:progress` in https://github.com/livewire/flux/pull/2512.

We can revert it if this style need to be set dynamically using Alpine. I just never see the need of it, at least for me.

# The problem

`flux:textarea` current template using inline style for resize type and field-sizing.

```blade
<textarea
    ...
    style="{{ $resizeStyle }}; {{ $rows === 'auto' ? 'field-sizing: content' : '' }}"
    ... 
    >{{ $slot }}</textarea>
```

# The solution

Change inline style with tailwindcss class which can cover it all.

```php
$classes = Flux::classes()
    ...
    ->add($rows === 'auto' ? 'field-sizing-content' : '')
    ->add($resize ? match ($resize) {
        default => 'resize', // to prevent unhandled match type when user only provide the attribute without value
        'none' => 'resize-none',
        'both' => 'resize',
        'horizontal' => 'resize-x',
        'vertical' => 'resize-y',
    } : 'resize-none')
    ...
```

# File Changes
- `stubs/resources/views/flux/textarea.blade.php`