### PR TITLE
Refactor suffix rendering logic in `flux:menu.item` component

### DIFF
--- a/stubs/resources/views/flux/menu/item.blade.php
+++ b/stubs/resources/views/flux/menu/item.blade.php
@@ -61,14 +61,12 @@ $suffixClasses = Flux::classes()
 
     {{ $slot }}
 
-    <?php if ($suffix): ?>
-        <?php if (is_string($suffix)): ?>
-            <div class="{{ $suffixClasses }}">
-                {{ $suffix }}
-            </div>
-        <?php else: ?>
+    <?php if (is_string($suffix) && $suffix !== ''): ?>
+        <div class="{{ $suffixClasses }}">
             {{ $suffix }}
-        <?php endif; ?>
+        </div>
+    <?php elseif ($suffix): ?>
+        {{ $suffix }}
     <?php endif; ?>
 
     <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>


### PR DESCRIPTION
Just a tiny refactor for `flux:menu.item`

## Before

<img width="743" height="191" alt="image" src="https://github.com/user-attachments/assets/52420d47-ee07-466f-af0f-60ea6a9493ba" />

## After

<img width="744" height="153" alt="image" src="https://github.com/user-attachments/assets/0884121b-90b1-48d9-a7fd-243c5016f6c4" />

## File Changed
- `stubs/resources/views/flux/menu/item.blade.php`