### PR TITLE
Add Carousel to pro components publish list

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -169,6 +169,7 @@ Custom element display rules...
     ui-editor { display: block; }
     ui-editor-content { display: block; }
     ui-progress { display: block; }
+    ui-carousel, ui-carousel-track, ui-carousel-slide { display: block; }
 }
 
 /**

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -56,6 +56,7 @@ class PublishCommand extends Command
             'Accordion' => ['accordion'],
             'Autocomplete' => ['autocomplete'],
             'Calendar' => ['calendar'],
+            'Carousel' => ['carousel'],
             'Chart' => ['chart'],
             'Checkbox' => ['checkbox'],
             'Color picker' => ['color-picker'],


### PR DESCRIPTION
## Summary
- Adds `'Carousel' => ['carousel']` to the pro components list in `PublishCommand.php` so users can publish the carousel component stubs via `php artisan flux:publish`

## Context
Companion PR to livewire/flux-pro#503 which adds the carousel component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)