### PR TITLE
Make table cell padding overridable

### DIFF
--- a/stubs/resources/views/flux/table/cell.blade.php
+++ b/stubs/resources/views/flux/table/cell.blade.php
@@ -8,7 +8,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('py-3 px-3 first:ps-0 last:pe-0 text-sm')
+    ->add('[:where(&)]:py-3 [:where(&)]:px-3 first:ps-0 last:pe-0 text-sm')
     ->add(match($align) {
         'center' => 'text-center',
         'end' => 'text-end',


### PR DESCRIPTION
# The scenario

When using the table example from the docs, the dropdown button is misaligned.

<img width="2000" height="1058" alt="SCR-20260603-lntp-2" src="https://github.com/user-attachments/assets/009b40a9-64ec-407a-995b-085914b1ca3d" />

<img width="960" height="573" alt="SCR-20260603-lqdn" src="https://github.com/user-attachments/assets/082ebd58-87bc-4955-b9dc-7feb85e11b21" />

# The problem

This is caused by `inset="top bottom"` that's there to optically reduce padding.

The problem is that the negative margin on bottom can't be applied because there is no space below the button to reduce, the cell is already at its minimum height. However the negative margin on top is applied in full.


https://github.com/user-attachments/assets/9eb3576f-b3d0-44af-8af0-9cdb6ccc65cf

# The solution

Stop using inset for vertical alignment inside table cells.

A more reliable approach is to remove the padding on those cells and let the table vertically align them based on the height of other cells:

```diff
- <flux:table.cell>
+ <flux:table.cell class="py-0">

-     <flux:button size="sm" icon="ellipsis-horizontal" inset="top bottom"></flux:button>
+     <flux:button size="sm" icon="ellipsis-horizontal"></flux:button>

  </flux:table.cell>
```

<img width="1401" height="680" alt="SCR-20260603-mooj-2" src="https://github.com/user-attachments/assets/9f8f2100-2c2e-42f3-893d-16ecc71152e7" />

This PR only makes the padding overridable with `[:where(&)]:`

The main change lives in the docs repo: https://github.com/livewire/flux-docs/pull/175