### PR TITLE
[codex] Fix table cell icon alignment

### DIFF
--- a/stubs/resources/views/flux/table/cell.blade.php
+++ b/stubs/resources/views/flux/table/cell.blade.php
@@ -10,8 +10,10 @@
 $classes = Flux::classes()
     ->add('py-3 px-3 first:ps-0 last:pe-0 text-sm')
     ->add(match($align) {
-        'center' => 'text-center',
-        'end' => 'text-end',
+        'center' => 'text-center [&>*]:mx-auto',
+        'end' => 'text-end [&>*]:ms-auto',
+        // Right is @deprecated but needed for backwards compatibility...
+        'right' => 'text-end [&>*]:ms-auto',
         default => '',
     })
     ->add(match ($variant) {


### PR DESCRIPTION
Fixes livewire/flux#2644.

## What changed

`flux:table.cell` now applies direct-child auto margins when a cell is horizontally aligned:

- `align="center"` keeps `text-center` and also centers direct child elements with `mx-auto`
- `align="end"` and the deprecated `align="right"` keep end text alignment and also push direct child elements with `ms-auto`

That keeps plain text behavior unchanged while allowing block-level Flux icons, like `flux:icon.check`, to honor the same cell alignment.

## Root cause

The table cell component relied on `text-center` / `text-end` only. That works for text, but Flux icons render as SVG elements with their own box, so icon-only cells were still laid out at the start edge of the cell instead of being centered.

## Before

![Before: icon-only cells are left aligned despite align center](https://raw.githubusercontent.com/livewire/flux/refs/heads/codex/flux-2644-screenshots/.github/pr-images/2644/before.png)

## After

![After: icon-only cells are centered with align center](https://raw.githubusercontent.com/livewire/flux/refs/heads/codex/flux-2644-screenshots/.github/pr-images/2644/after.png)

## Validation

- Reproduced the issue in a fresh Laravel playground at `~/Code/playgrounds/jun04-flux-2644`
- Captured before/after Playwright screenshots
- Measured normal icon-only cell offsets changing from about `-40px` left of center to `0px`
- Ran `php -l stubs/resources/views/flux/table/cell.blade.php`
- Ran `npm run build` in the playground app after adding Flux vendor views to Tailwind sources

Note: Flux does not appear to ship a local PHP test suite in this package checkout, so this is covered with focused visual verification instead.
