### PR TITLE
Fix collapsed sidebar group keyboard navigation

### DIFF
--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -25,7 +25,8 @@ $tooltip ??= $slot->isNotEmpty() ? (string) $slot : null;
 // Size-up icons in square/icon-only buttons...
 $iconClasses = Flux::classes('size-4')
     ->add('in-data-flux-sidebar-group-dropdown:text-zinc-400! dark:in-data-flux-sidebar-group-dropdown:text-white/80!')
-    ->add('[[data-flux-sidebar-item]:hover_&]:text-current!');
+    ->add('[[data-flux-sidebar-item]:hover_&]:text-current!')
+    ->add('[[data-flux-sidebar-item][data-active]_&]:text-current!');
 
 $classes = Flux::classes()
     ->add('h-8 in-data-flux-sidebar-on-mobile:h-10 relative flex items-center gap-3 rounded-lg')
@@ -47,8 +48,10 @@ $classes = Flux::classes()
     })
     // Override the default styles to match dropdowns for when the item is inside a collapsed group dropdown...
     ->add('in-data-flux-sidebar-group-dropdown:w-auto! in-data-flux-sidebar-group-dropdown:px-2!')
+    ->add('in-data-flux-sidebar-group-dropdown:focus:outline-hidden!')
     ->add('in-data-flux-sidebar-group-dropdown:text-zinc-800! in-data-flux-sidebar-group-dropdown:bg-white! in-data-flux-sidebar-group-dropdown:hover:bg-zinc-50!')
-    ->add('dark:in-data-flux-sidebar-group-dropdown:text-white! dark:in-data-flux-sidebar-group-dropdown:bg-transparent! dark:in-data-flux-sidebar-group-dropdown:hover:bg-zinc-600!')
+    ->add('in-data-flux-sidebar-group-dropdown:data-active:bg-zinc-50!')
+    ->add('dark:in-data-flux-sidebar-group-dropdown:text-white! dark:in-data-flux-sidebar-group-dropdown:bg-transparent! dark:in-data-flux-sidebar-group-dropdown:hover:bg-zinc-600! dark:in-data-flux-sidebar-group-dropdown:data-active:bg-zinc-600!')
     ;
 @endphp
 


### PR DESCRIPTION
This has a corresponding Flux Pro PR https://github.com/livewire/flux-pro/pull/506

# The Scenario

Currently, if you have a collapsed sidebar that contains an expanded sidebar group, you cannot focus the group trigger, open the dropdown, and then reliably navigate inside the dropdown using the keyboard.

Pressing Space or Enter opens the dropdown, but focus does not move to the first item. That leaves keyboard users without a working path into the dropdown links. When focus does land on an item, it can also show a focus ring instead of matching the active background treatment used by standard Flux dropdown menu items.

<img width="800" height="399" alt="CleanShot 2026-06-09 at 19 37 47" src="https://github.com/user-attachments/assets/fe164a86-5597-4609-8206-bc11d7c879e7" />

```blade
<flux:sidebar collapsible>
    <flux:sidebar.nav>
        <flux:sidebar.group expandable expanded icon="star" heading="Favorites">
            <flux:sidebar.item href="#marketing-site">Marketing site</flux:sidebar.item>
            <flux:sidebar.item href="#android-app">Android app</flux:sidebar.item>
            <flux:sidebar.item href="#brand-guidelines">Brand guidelines</flux:sidebar.item>
        </flux:sidebar.group>
    </flux:sidebar.nav>
</flux:sidebar>
```

# The Problem

Collapsed sidebar group dropdowns render sidebar items inside a menu. `ui-menu` already focuses the first item when opened with ArrowDown, but collapsed sidebar group dropdowns also need that first-item focus when opened with Space or Enter.

The sidebar item styles also handled hover state in this dropdown context, but did not style `data-active` or suppress the item focus outline. That made keyboard-focused dropdown items visually differ from standard Flux menu items.

# The Solution

Keep the existing ArrowDown menu behaviour unchanged, and add a scoped Space/Enter path only when the dropdown has `data-flux-sidebar-group-dropdown`. When that scoped path opens the menu, the first menu item receives focus so arrow-key navigation works from inside the dropdown.

Also style `data-active` for sidebar items inside collapsed group dropdowns and hide the per-item focus outline in that dropdown context, matching normal menu active-state styling.

(dropdown menu items do have a background colour, just not shown in the compressed gif)
<img width="800" height="399" alt="CleanShot 2026-06-09 at 19 34 02" src="https://github.com/user-attachments/assets/a5d39639-b981-4bce-81dd-75ace944c791" />

Fixes livewire/flux#2643
