### PR TITLE
Add configurable card indicator positions

### DIFF
--- a/stubs/resources/views/flux/checkbox/group/variants/cards.blade.php
+++ b/stubs/resources/views/flux/checkbox/group/variants/cards.blade.php
@@ -11,6 +11,7 @@
     'variant' => null,
     'size' => null,
     'name' => null,
+    'indicator' => true,
 ])
 
 @php

--- a/stubs/resources/views/flux/checkbox/variants/cards.blade.php
+++ b/stubs/resources/views/flux/checkbox/variants/cards.blade.php
@@ -14,6 +14,12 @@
 ])
 
 @php
+// Normalize the "indicator" prop into the same position semantics as radio cards...
+$indicatorPosition = $indicator ? 'end' : false;
+
+if ($indicator === 'start' || $indicator === 'left') {
+    $indicatorPosition = 'start';
+}
 
 $iconClasses = Flux::classes()
     ->add('inline-block mt-0.5 text-zinc-400 [ui-checkbox[data-checked]_&]:text-zinc-800 dark:[ui-checkbox[data-checked]_&]:text-white')
@@ -22,7 +28,8 @@ $iconClasses = Flux::classes()
     ;
 
 $classes = Flux::classes()
-    ->add('relative flex justify-between gap-3 flex-1 p-4')
+    ->add('relative flex gap-3 flex-1 p-4')
+    ->add($indicatorPosition === 'start' ? 'justify-start' : 'justify-between')
     ->add('rounded-lg shadow-xs')
     ->add('bg-white dark:bg-white/10 dark:hover:bg-white/15 dark:data-checked:bg-white/15')
     ->add('after:absolute after:-inset-px after:rounded-lg')
@@ -55,6 +62,10 @@ $classes = Flux::classes()
 {{-- We have to put "data-flux-field" so that a single box can be disabled without "disabling" the group field label... --}}
 <ui-checkbox {{ $attributes->class($classes) }} data-flux-control data-flux-checkbox-cards tabindex="-1" data-flux-field>
     <?php if ($label): ?>
+        <?php if ($indicatorPosition === 'start'): ?>
+            <flux:checkbox.indicator class="mt-px" />
+        <?php endif; ?>
+
         <div class="flex-1 flex gap-2">
             <?php if (is_string($icon) && $icon !== ''): ?>
                 <flux:icon :icon="$icon" :variant="$iconVariant" :class="$iconClasses" />
@@ -71,7 +82,9 @@ $classes = Flux::classes()
             </div>
         </div>
 
-        <flux:checkbox.indicator class="mt-px" />
+        <?php if ($indicatorPosition === 'end'): ?>
+            <flux:checkbox.indicator class="mt-px" />
+        <?php endif; ?>
     <?php else: ?>
         {{ $slot }}
     <?php endif; ?>

--- a/stubs/resources/views/flux/checkbox/variants/cards.blade.php
+++ b/stubs/resources/views/flux/checkbox/variants/cards.blade.php
@@ -71,7 +71,7 @@ $classes = Flux::classes()
             </div>
         </div>
 
-        <flux:checkbox.indicator />
+        <flux:checkbox.indicator class="mt-px" />
     <?php else: ?>
         {{ $slot }}
     <?php endif; ?>

--- a/stubs/resources/views/flux/radio/group/variants/cards.blade.php
+++ b/stubs/resources/views/flux/radio/group/variants/cards.blade.php
@@ -11,6 +11,7 @@
     'variant' => null,
     'size' => null,
     'name' => null,
+    'indicator' => true,
 ])
 
 @php

--- a/stubs/resources/views/flux/radio/variants/cards.blade.php
+++ b/stubs/resources/views/flux/radio/variants/cards.blade.php
@@ -14,6 +14,15 @@
 ])
 
 @php
+// Normalize the "indicator" prop into a position. `true` keeps the historical
+// right-aligned indicator, `false` hides it, and `start`/`end` (with `left`/`right`
+// aliases) control which side of the card the indicator sits on...
+$indicatorPosition = match ($indicator) {
+    'start', 'left' => 'start',
+    'end', 'right', true => 'end',
+    default => false,
+};
+
 $iconClasses = Flux::classes()
     ->add('inline-block mt-0.5 text-zinc-400 [ui-radio[data-checked]_&]:text-zinc-800 dark:[ui-radio[data-checked]_&]:text-white')
     // When using the outline icon variant, we need to size it down to match the default icon sizes...
@@ -21,7 +30,8 @@ $iconClasses = Flux::classes()
     ;
 
 $classes = Flux::classes()
-    ->add('relative flex justify-between gap-3 flex-1 p-4')
+    ->add('relative flex gap-3 flex-1 p-4')
+    ->add($indicatorPosition === 'start' ? 'justify-start' : 'justify-between')
     ->add('rounded-lg shadow-xs')
     ->add('bg-white dark:bg-white/10 dark:hover:bg-white/15 dark:data-checked:bg-white/15')
     ->add('after:absolute after:-inset-px after:rounded-lg')
@@ -54,6 +64,10 @@ $classes = Flux::classes()
 {{-- We have to put "data-flux-field" so that a single box can be disabled without "disabling" the group field label... --}}
 <ui-radio {{ $attributes->class($classes) }} data-flux-control data-flux-radio-cards tabindex="-1" data-flux-field>
     <?php if ($label): ?>
+        <?php if ($indicatorPosition === 'start'): ?>
+            <flux:radio.indicator />
+        <?php endif; ?>
+
         <div class="flex-1 flex gap-2">
             <?php if (is_string($icon) && $icon !== ''): ?>
                 <flux:icon :icon="$icon" :variant="$iconVariant" :class="$iconClasses" />
@@ -70,7 +84,7 @@ $classes = Flux::classes()
             </div>
         </div>
 
-        <?php if ($indicator): ?>
+        <?php if ($indicatorPosition === 'end'): ?>
             <flux:radio.indicator />
         <?php endif; ?>
     <?php else: ?>

--- a/stubs/resources/views/flux/radio/variants/cards.blade.php
+++ b/stubs/resources/views/flux/radio/variants/cards.blade.php
@@ -63,7 +63,7 @@ $classes = Flux::classes()
 <ui-radio {{ $attributes->class($classes) }} data-flux-control data-flux-radio-cards tabindex="-1" data-flux-field>
     <?php if ($label): ?>
         <?php if ($indicatorPosition === 'start'): ?>
-            <flux:radio.indicator />
+            <flux:radio.indicator class="mt-px" />
         <?php endif; ?>
 
         <div class="flex-1 flex gap-2">
@@ -83,7 +83,7 @@ $classes = Flux::classes()
         </div>
 
         <?php if ($indicatorPosition === 'end'): ?>
-            <flux:radio.indicator />
+            <flux:radio.indicator class="mt-px" />
         <?php endif; ?>
     <?php else: ?>
         {{ $slot }}

--- a/stubs/resources/views/flux/radio/variants/cards.blade.php
+++ b/stubs/resources/views/flux/radio/variants/cards.blade.php
@@ -14,14 +14,12 @@
 ])
 
 @php
-// Normalize the "indicator" prop into a position. `true` keeps the historical
-// right-aligned indicator, `false` hides it, and `start`/`end` (with `left`/`right`
-// aliases) control which side of the card the indicator sits on...
-$indicatorPosition = match ($indicator) {
-    'start', 'left' => 'start',
-    'end', 'right', true => 'end',
-    default => false,
-};
+// Normalize the "indicator" prop into a position while preserving the previous truthy/falsy behaviour...
+$indicatorPosition = $indicator ? 'end' : false;
+
+if ($indicator === 'start' || $indicator === 'left') {
+    $indicatorPosition = 'start';
+}
 
 $iconClasses = Flux::classes()
     ->add('inline-block mt-0.5 text-zinc-400 [ui-radio[data-checked]_&]:text-zinc-800 dark:[ui-radio[data-checked]_&]:text-white')

--- a/stubs/resources/views/flux/radio/variants/cards.blade.php
+++ b/stubs/resources/views/flux/radio/variants/cards.blade.php
@@ -14,7 +14,7 @@
 ])
 
 @php
-// Normalize the "indicator" prop into a position while preserving the previous truthy/falsy behaviour...
+// Normalize the "indicator" prop into a position while preserving the previous truthy/falsy behavior...
 $indicatorPosition = $indicator ? 'end' : false;
 
 if ($indicator === 'start' || $indicator === 'left') {


### PR DESCRIPTION
# The scenario

Card-style radio and checkbox controls often place their indicator before the label. Both components should expose the same positioning API so an interface can use one convention consistently.

# The problem

Radio cards could only render their indicator at the end. Checkbox cards also fixed the indicator at the end, despite already accepting an `indicator` prop, so neither per-card nor group-level positioning was available consistently.

The 18px indicators were also top-aligned inside a 20px heading line box, placing their visual center 1px above the label.

# The solution

Both `radio` and `checkbox` card variants now use the same `indicator` semantics:

- `start` or `left` renders at logical start.
- `end`, `right`, `true`, or another truthy value renders at logical end.
- `false` hides the indicator.
- The position can be set on an individual card or inherited from its group.

`left` and `right` are compatibility aliases for logical `start` and `end`, so the layout follows RTL direction correctly. The existing default remains end-aligned.

Both indicators also receive a 1px top offset, aligning their center exactly with the label's line box.

# Validation

- Exercised radio and checkbox start/end positions in a real browser.
- Covered group inheritance and per-card overrides.
- Covered `left`, `right`, arbitrary truthy values, and `false`.
- Covered checked and unchecked interactions.
- Covered RTL logical direction.
- Measured indicator-to-heading center delta at `0px` for both controls.
- Browser console remained clean.

[Before/after screenshots and measurement details](https://github.com/livewire/flux/pull/2657#issuecomment-5292984089)

<img width="670" height="742" alt="Radio card indicator positions" src="https://github.com/user-attachments/assets/b5039392-8be9-48b4-b073-5053d6c91846" />

Fixes livewire/flux#2654.
