### PR TITLE
Fix cursor pagination crash on empty page

### DIFF
--- a/stubs/resources/views/flux/pagination.blade.php
+++ b/stubs/resources/views/flux/pagination.blade.php
@@ -35,7 +35,8 @@ $scrollIntoViewJsSnippet = ($scrollTo !== null && $scrollTo !== false)
                     </div>
                 @else
                     @if(method_exists($paginator,'getCursorName'))
-                        <button type="button" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->previousCursor()->encode() }}" wire:click="setPage('{{$paginator->previousCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" class="flex justify-center items-center size-8 sm:size-6 rounded-[6px] text-zinc-400 dark:text-white hover:bg-zinc-100 dark:hover:bg-white/20 hover:text-zinc-800 dark:hover:text-white">
+                        @php($previousCursor = $paginator->previousCursor() ?? $paginator->cursor())
+                        <button type="button" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $previousCursor?->encode() }}" wire:click="setPage('{{ $previousCursor?->encode() }}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" class="flex justify-center items-center size-8 sm:size-6 rounded-[6px] text-zinc-400 dark:text-white hover:bg-zinc-100 dark:hover:bg-white/20 hover:text-zinc-800 dark:hover:text-white">
                             <flux:icon.chevron-left variant="micro" class="rtl:hidden" />
                             <flux:icon.chevron-right variant="micro" class="hidden rtl:inline" />
                         </button>
@@ -49,7 +50,8 @@ $scrollIntoViewJsSnippet = ($scrollTo !== null && $scrollTo !== false)
 
                 @if ($paginator->hasMorePages())
                     @if(method_exists($paginator,'getCursorName'))
-                        <button type="button" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->nextCursor()->encode() }}" wire:click="setPage('{{$paginator->nextCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" class="flex justify-center items-center size-8 sm:size-6 rounded-[6px] text-zinc-400 dark:text-white hover:bg-zinc-100 dark:hover:bg-white/20 hover:text-zinc-800 dark:hover:text-white">
+                        @php($nextCursor = $paginator->nextCursor() ?? $paginator->cursor())
+                        <button type="button" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $nextCursor?->encode() }}" wire:click="setPage('{{ $nextCursor?->encode() }}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" class="flex justify-center items-center size-8 sm:size-6 rounded-[6px] text-zinc-400 dark:text-white hover:bg-zinc-100 dark:hover:bg-white/20 hover:text-zinc-800 dark:hover:text-white">
                             <flux:icon.chevron-right variant="micro" class="rtl:hidden" />
                             <flux:icon.chevron-left variant="micro" class="hidden rtl:inline" />
                         </button>

--- a/stubs/resources/views/flux/pagination.blade.php
+++ b/stubs/resources/views/flux/pagination.blade.php
@@ -35,6 +35,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== null && $scrollTo !== false)
                     </div>
                 @else
                     @if(method_exists($paginator,'getCursorName'))
+                        {{-- On an empty page the previous cursor is null, so fall back to the current cursor (reloads the same page, mirroring Laravel's null page URL) --}}
                         @php($previousCursor = $paginator->previousCursor() ?? $paginator->cursor())
                         <button type="button" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $previousCursor?->encode() }}" wire:click="setPage('{{ $previousCursor?->encode() }}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" class="flex justify-center items-center size-8 sm:size-6 rounded-[6px] text-zinc-400 dark:text-white hover:bg-zinc-100 dark:hover:bg-white/20 hover:text-zinc-800 dark:hover:text-white">
                             <flux:icon.chevron-left variant="micro" class="rtl:hidden" />
@@ -50,6 +51,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== null && $scrollTo !== false)
 
                 @if ($paginator->hasMorePages())
                     @if(method_exists($paginator,'getCursorName'))
+                        {{-- On an empty page the next cursor is null, so fall back to the current cursor (reloads the same page, mirroring Laravel's null page URL) --}}
                         @php($nextCursor = $paginator->nextCursor() ?? $paginator->cursor())
                         <button type="button" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $nextCursor?->encode() }}" wire:click="setPage('{{ $nextCursor?->encode() }}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" class="flex justify-center items-center size-8 sm:size-6 rounded-[6px] text-zinc-400 dark:text-white hover:bg-zinc-100 dark:hover:bg-white/20 hover:text-zinc-800 dark:hover:text-white">
                             <flux:icon.chevron-right variant="micro" class="rtl:hidden" />


### PR DESCRIPTION
# The Scenario

When a Flux pagination component renders cursor pagination on an empty page, Flux can throw an error instead of rendering the pagination controls.

This can happen when a stale cursor URL is opened, records are deleted, or filtering leaves the current cursor page empty.

```blade
<flux:pagination :paginator="$users" />
```

# The Problem

Flux's simple pagination view calls `->encode()` directly on the previous and next cursor values:

```blade
$paginator->previousCursor()->encode()
$paginator->nextCursor()->encode()
```

Laravel's cursor paginator returns `null` from `previousCursor()` and `nextCursor()` when the current page has no items. The pagination buttons can still render in that state because they are controlled by `onFirstPage()` and `hasMorePages()`.

That means Flux can call `encode()` on `null` while rendering the previous or next button.

# The Solution

Use the same approach that was merged in Livewire in livewire/livewire#10302.

Capture the previous and next cursors before rendering the buttons, then fall back to the current cursor when Laravel returns `null`.

The `wire:key` and `setPage` calls now use null-safe encoding, so an empty cursor page reloads the current cursor instead of throwing while the view renders.

Related to livewire/livewire#10302