### PR TITLE
Fix field spacing when only using description

### DIFF
--- a/stubs/resources/views/flux/field.blade.php
+++ b/stubs/resources/views/flux/field.blade.php
@@ -33,6 +33,7 @@ $classes = Flux::classes()
         default => [ // Adjust spacing around description...
             '[&>[data-flux-label]+[data-flux-description]]:mt-0',
             '[&>[data-flux-label]+[data-flux-description]]:mb-3',
+            '[&>[data-flux-description]:first-child:has(+*)]:mb-3',
             '[&>*:not([data-flux-label])+[data-flux-description]]:mt-3',
         ],
         'bare' => '',


### PR DESCRIPTION
# The Scenario

When rendering Flux input fields, a description without a label sits directly against the input. The spacing is correct for a label-only field, and also for a field that has both a label and description.

<img width="1060" height="1064" alt="CleanShot 2026-06-25 at 09 47 34@2x" src="https://github.com/user-attachments/assets/2071f488-81ef-432f-b8ad-4db0864ef048" />

```blade
<div class="space-y-8">
    <div>
        <flux:heading size="lg" level="2" class="mb-4">Label</flux:heading>

        <flux:input label="Input label" placeholder="Input value" />
    </div>

    <div>
        <flux:heading size="lg" level="2" class="mb-4">Label + description</flux:heading>

        <flux:input label="Input label" description="Input description" placeholder="Input value" />
    </div>

    <div>
        <flux:heading size="lg" level="2" class="mb-4">Description</flux:heading>

        <flux:input description="Input description" placeholder="Input value" />
    </div>
</div>
```

# The Problem

The field spacing selector handles `label+description` but not description on it's down. As such the description has no bottom margin when there is no label.

# The Solution

Add a field spacing selector for descriptions that are the first child and have following content. This gives description-only fields the same `mb-3` gap used between label descriptions and controls.

```php
'[&>[data-flux-description]:first-child:has(+*)]:mb-3',
```

The selector is scoped to that leading-description case, so existing label + description spacing remains unchanged.

<img width="1046" height="1080" alt="CleanShot 2026-06-25 at 09 50 30@2x" src="https://github.com/user-attachments/assets/3657b25a-b767-47c6-bd26-a5b34b5ecdc9" />

Fixes #2664
