### PR TITLE
Fix border radiuses on input groups

### DIFF
--- a/stubs/resources/views/flux/input/group/prefix.blade.php
+++ b/stubs/resources/views/flux/input/group/prefix.blade.php
@@ -14,7 +14,7 @@ $classes = Flux::classes([
 ])->add(match ($size) {
     default => 'text-base sm:text-sm rounded-s-lg',
     'sm' => 'text-sm rounded-s-md',
-    'xs' => 'text-xs rounded-s-sm',
+    'xs' => 'text-xs rounded-s-md',
 });
 @endphp
 

--- a/stubs/resources/views/flux/input/group/prefix.blade.php
+++ b/stubs/resources/views/flux/input/group/prefix.blade.php
@@ -1,14 +1,21 @@
 @blaze(fold: true)
 
+@props([
+    'size' => null,
+])
+
 @php
 $classes = Flux::classes([
-    'flex items-center px-4 text-sm whitespace-nowrap',
+    'flex items-center px-4 whitespace-nowrap',
     'text-zinc-800 dark:text-zinc-200',
     'bg-zinc-800/5 dark:bg-white/20',
     'border-zinc-200 dark:border-white/10',
-    'rounded-s-lg',
     'border-s border-t border-b shadow-xs',
-]);
+])->add(match ($size) {
+    default => 'text-base sm:text-sm rounded-s-lg',
+    'sm' => 'text-sm rounded-s-md',
+    'xs' => 'text-xs rounded-s-sm',
+});
 @endphp
 
 <div {{ $attributes->class($classes) }} data-flux-input-group-prefix>

--- a/stubs/resources/views/flux/input/group/suffix.blade.php
+++ b/stubs/resources/views/flux/input/group/suffix.blade.php
@@ -1,5 +1,9 @@
 @blaze(fold: true)
 
+@props([
+    'size' => null,
+])
+
 @php
 $classes = Flux::classes([
     'flex items-center px-4 text-sm whitespace-nowrap',
@@ -8,7 +12,12 @@ $classes = Flux::classes([
     'border-zinc-200 dark:border-white/10',
     'rounded-e-lg',
     'border-e border-t border-b shadow-xs',
-]);
+])->add(match ($size) {
+    default => 'text-base sm:text-sm rounded-e-lg',
+    'sm' => 'text-sm rounded-e-md',
+    'xs' => 'text-xs rounded-e-sm',
+});
+
 @endphp
 
 <div {{ $attributes->class($classes) }} data-flux-input-group-suffix>

--- a/stubs/resources/views/flux/input/group/suffix.blade.php
+++ b/stubs/resources/views/flux/input/group/suffix.blade.php
@@ -6,16 +6,15 @@
 
 @php
 $classes = Flux::classes([
-    'flex items-center px-4 text-sm whitespace-nowrap',
+    'flex items-center px-4 whitespace-nowrap',
     'text-zinc-800 dark:text-zinc-200',
     'bg-zinc-800/5 dark:bg-white/20',
     'border-zinc-200 dark:border-white/10',
-    'rounded-e-lg',
     'border-e border-t border-b shadow-xs',
 ])->add(match ($size) {
     default => 'text-base sm:text-sm rounded-e-lg',
     'sm' => 'text-sm rounded-e-md',
-    'xs' => 'text-xs rounded-e-sm',
+    'xs' => 'text-xs rounded-e-md',
 });
 
 @endphp

--- a/stubs/resources/views/flux/input/group/suffix.blade.php
+++ b/stubs/resources/views/flux/input/group/suffix.blade.php
@@ -16,7 +16,6 @@ $classes = Flux::classes([
     'sm' => 'text-sm rounded-e-md',
     'xs' => 'text-xs rounded-e-md',
 });
-
 @endphp
 
 <div {{ $attributes->class($classes) }} data-flux-input-group-suffix>

--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -90,12 +90,12 @@ $inputLoadingClasses = Flux::classes()
     ;
 
 $classes = Flux::classes()
-    ->add('w-full border rounded-lg block disabled:shadow-none dark:shadow-none')
+    ->add('w-full border block disabled:shadow-none dark:shadow-none')
     ->add('appearance-none') // Without this, input[type="date"] on mobile doesn't respect w-full...
     ->add(match ($size) {
-        default => 'text-base sm:text-sm py-2 h-10 leading-[1.375rem]', // This makes the height of the input 40px (same as buttons and such...)
-        'sm' => 'text-sm py-1.5 h-8 leading-[1.125rem]',
-        'xs' => 'text-xs py-1.5 h-6 leading-[1.125rem]',
+        default => 'text-base sm:text-sm rounded-lg py-2 h-10 leading-[1.375rem]', // This makes the height of the input 40px (same as buttons and such...)
+        'sm' => 'text-sm rounded-md py-1.5 h-8 leading-[1.125rem]',
+        'xs' => 'text-xs rounded-md py-1.5 h-6 leading-[1.125rem]',
     })
     ->add(match ($hasLeadingIcon) {
         true => 'ps-10',


### PR DESCRIPTION
# The scenario

When placing varous small or extra small sized input components inline or within a input group, it shows that their border radius are not consistent. 

# The problem

On `sm` and `xs` sized components we have these two different implementations:

There is a `rounded-lg` on:

- `flux:input`
- `flux:input.group.prefix`
- `flux:input.group.suffix`
- `flux:autocomplete` (pro)
- `flux:colorpicker` (pro)

And a `rounded-md` on:

- `flux:select` (partially pro)
- `flux:datepicker` (pro)
- `flux:pillbox` (pro) --> only for `sm` sized; `xs` sized does not exist

# The solution

This PR makes the border radiuses consistent with `flux:select` and `flux:colorpicker` on the free components `flux:input`,`flux:input.group.prefix` and `flux:input.group.suffix`. To do this, `group.prefix` and `group.suffix` need `size` property support.

Fixes livewire/flux#2672 