### PR TITLE
Preserve inherited text styles in sortable table column

### DIFF
--- a/stubs/resources/views/flux/table/sortable.blade.php
+++ b/stubs/resources/views/flux/table/sortable.blade.php
@@ -7,7 +7,8 @@
 
 @php
 $classes = Flux::classes()
-    ->add('flex items-center gap-1 -my-1 -ms-2 -me-2 px-2 py-1 [text-transform:inherit]')
+    ->add('flex items-center gap-1 -my-1 -ms-2 -me-2 px-2 py-1')
+    ->add('[text-align:inherit] [text-indent:inherit] [text-shadow:inherit] [text-transform:inherit] [word-spacing:inherit]')
     ->add('in-[.group\/end-align]:flex-row-reverse in-[.group\/end-align]:-me-2 in-[.group\/end-align]:-ms-8')
     ;
 @endphp

--- a/stubs/resources/views/flux/table/sortable.blade.php
+++ b/stubs/resources/views/flux/table/sortable.blade.php
@@ -7,7 +7,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('flex items-center gap-1 -my-1 -ms-2 -me-2 px-2 py-1 ')
+    ->add('flex items-center gap-1 -my-1 -ms-2 -me-2 px-2 py-1 [text-transform:inherit]')
     ->add('in-[.group\/end-align]:flex-row-reverse in-[.group\/end-align]:-me-2 in-[.group\/end-align]:-ms-8')
     ;
 @endphp


### PR DESCRIPTION
# The scenario

Applying a Tailwind CSS `text-transform` utility such as `uppercase`, `lowercase`, or `capitalize` to a `flux:table.column` works for regular columns, but stops working when the column is made sortable.

Minimal reproduction:

```blade
<?php

use Livewire\Component;

new class extends Component
{
    public string $sortBy = 'date';

    public string $sortDirection = 'asc';

    public function sort(string $column): void
    {
        if ($this->sortBy === $column) {
            $this->sortDirection = $this->sortDirection === 'asc'
                ? 'desc'
                : 'asc';

            return;
        }

        $this->sortBy = $column;
        $this->sortDirection = 'asc';
    }
};
?>

<div class="p-6">
    <flux:table>
        <flux:table.columns>
            <flux:table.column class="uppercase">
                Non-sortable
            </flux:table.column>

            <flux:table.column
                sortable
                class="uppercase"
                :sorted="$sortBy === 'date'"
                :direction="$sortDirection"
                wire:click="sort('date')"
            >
                Sortable
            </flux:table.column>
        </flux:table.columns>

        <flux:table.rows>
            <flux:table.row>
                <flux:table.cell>Example</flux:table.cell>
                <flux:table.cell>2026-07-10</flux:table.cell>
            </flux:table.row>
        </flux:table.rows>
    </flux:table>
</div>
```

# The problem

Sortable table headings render their label inside the `flux:table.sortable` button:

```blade
<button
    type="button"
    {{ $attributes->class($classes) }}
    data-flux-table-sortable
>
    {{ $slot }}

    <!-- Sort icon -->
</button>
```

Although the `text-transform` utility is correctly applied to the parent `<th>`, the sortable button does not consistently inherit that value.

This causes sortable and non-sortable table columns to respond differently to typography utilities applied to `flux:table.column`.

# The solution

This change explicitly makes the sortable button inherit the computed `text-transform` value from its parent column:

```diff
$classes = Flux::classes()
-    ->add('flex items-center gap-1 -my-1 -ms-2 -me-2 px-2 py-1')
+    ->add('flex items-center gap-1 -my-1 -ms-2 -me-2 px-2 py-1 [text-transform:inherit]')
    ->add('in-[.group\/end-align]:flex-row-reverse in-[.group\/end-align]:-me-2 in-[.group\/end-align]:-ms-8')
    ;
```

Using `inherit` instead of adding a specific utility such as `uppercase` preserves the styling chosen by the consumer and supports all text-transform values, including:

* `uppercase`
* `lowercase`
* `capitalize`
* `normal-case`

After this change, sortable and non-sortable table columns consistently respect text-transform utilities applied to `flux:table.column`.

Fixes livewire/flux#2683
