### PR TITLE
Fix navbar item spacing

### DIFF
--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -25,9 +25,9 @@ $square ??= $slot->isEmpty();
 $iconClasses = Flux::classes($square ? 'size-6' : 'size-5');
 
 $classes = Flux::classes()
-    ->add('h-8 flex items-center rounded-lg')
+    ->add('px-3 h-8 flex items-center rounded-lg')
     ->add('relative') // This is here for the "active" bar at the bottom to be positioned correctly...
-    ->add($square ? 'w-8 justify-center' : 'px-2.5')
+    ->add($square ? 'px-2!' : '')
     ->add('text-zinc-500 dark:text-white/80 ')
     // Styles for when this link is the "current" one...
     ->add('data-current:after:absolute data-current:after:-bottom-3 data-current:after:inset-x-0 data-current:after:h-[2px]')

--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -25,9 +25,9 @@ $square ??= $slot->isEmpty();
 $iconClasses = Flux::classes($square ? 'size-6' : 'size-5');
 
 $classes = Flux::classes()
-    ->add('px-3 h-8 flex items-center rounded-lg')
+    ->add('h-8 flex items-center rounded-lg')
     ->add('relative') // This is here for the "active" bar at the bottom to be positioned correctly...
-    ->add($square ? '' : 'px-2.5!')
+    ->add($square ? 'w-8 justify-center' : 'px-2.5')
     ->add('text-zinc-500 dark:text-white/80 ')
     // Styles for when this link is the "current" one...
     ->add('data-current:after:absolute data-current:after:-bottom-3 data-current:after:inset-x-0 data-current:after:h-[2px]')


### PR DESCRIPTION
# The Scenario

Navbar items in the header layout appear larger and more widely spaced than the original design. The difference is particularly noticeable when hovering over icon-only items.

<img width="520" height="136" alt="CleanShot 2026-07-21 at 13 04 13@2x" src="https://github.com/user-attachments/assets/3dba765d-c32b-4c34-9b70-164a5b60d9dc" />

```blade
<flux:navbar>
    <flux:navbar.item icon="home" href="#" current>Home</flux:navbar.item>
    <flux:navbar.item icon="inbox" badge="12" href="#">Inbox</flux:navbar.item>
</flux:navbar>

<flux:navbar>
    <flux:navbar.item icon="magnifying-glass" href="#" label="Search" />
    <flux:navbar.item icon="cog-6-tooth" href="#" label="Settings" />
</flux:navbar>
```

# The Problem

Navbar items use `px-3` by default, but the padding override is applied to items containing content rather than icon-only items.

This causes an icon-only item with a 24 pixel icon to render 48 pixels wide.

# The Solution

The solution is to restore the proportions used by the original Flux Pro navbar item before the component was moved into the free package.

The original implementation combined a 20 pixel icon with 10 pixels of padding on each side, producing a 40 pixel wide item (it wasn't truly square).

<img width="482" height="154" alt="CleanShot 2026-07-21 at 13 04 17@2x" src="https://github.com/user-attachments/assets/c025726c-5591-4298-bb19-352640460238" />

We tested making icon-only navbar items truly square at 32 by 32 pixels. With the current 24 pixel icon (it was changed to `size-6` at some point), this left only 4 pixels of space on each side and made the items feel too compressed compared with the original design.

<img width="424" height="142" alt="CleanShot 2026-07-21 at 13 04 05@2x" src="https://github.com/user-attachments/assets/a8e98354-583f-4209-963d-2cc820464e35" />

The final approach retains the current 24 pixel icon and applies 8 pixels of padding on each side. This preserves the original 40 pixel width while keeping the updated icon size. Navbar items containing content retain their default `px-3` padding.

<img width="470" height="126" alt="CleanShot 2026-07-21 at 13 04 36@2x" src="https://github.com/user-attachments/assets/827e29ad-ea2d-4c62-b047-a57c2ddc9dc4" />

Fixes #2688