### PR TITLE
Fix inset and padding on buttons with icons

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -62,7 +62,7 @@ if ($loading && $type !== 'submit' && ! $isJsMethod) {
 }
 
 $classes = Flux::classes()
-    ->add('relative items-center font-medium justify-center gap-2 whitespace-nowrap')
+    ->add('relative items-center font-medium justify-center whitespace-nowrap')
     ->add('disabled:opacity-75 dark:disabled:opacity-75 disabled:cursor-default disabled:pointer-events-none')
     ->add(match ($align) {
         'start' => 'justify-start',
@@ -70,18 +70,18 @@ $classes = Flux::classes()
         'end' => 'justify-end',
     })
     ->add(match ($size) { // Size...
-        'base' => 'h-10 text-sm rounded-lg' . ' ' . (
+        'base' => 'h-10 text-sm rounded-lg gap-2' . ' ' . (
             $square
                 ? 'w-10'
                 // If we have an icon, we want to reduce the padding on the side that has the icon...
                 : ($iconLeading && $iconLeading !== '' ? 'ps-3' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3' : 'pe-4')
         ),
-        'sm' => 'h-8 text-sm rounded-md' . ' ' . (
+        'sm' => 'h-8 text-sm rounded-md gap-2' . ' ' . (
             $square
                 ? 'w-8'
                 : ($iconLeading && $iconLeading !== '' ? 'ps-2' : 'ps-3') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-2' : 'pe-3')
         ),
-        'xs' => 'h-6 text-xs rounded-md' . ' ' . (
+        'xs' => 'h-6 text-xs rounded-md gap-1' . ' ' . (
             $square
                 ? 'w-6'
                 : ($iconLeading && $iconLeading !== '' ? 'ps-1' : 'ps-2') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-1' : 'pe-2')

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -94,10 +94,10 @@ $classes = Flux::classes()
             : Flux::applyInset($inset, top: '-mt-2.5', right: ($iconTrailing && $iconTrailing !== '' ? '-me-3' : '-me-4'), bottom: '-mb-3', left: ($iconLeading && $iconLeading !== '' ? '-ms-3' : '-ms-4')),
         'sm' => $square
             ? Flux::applyInset($inset, top: '-mt-1.5', right: '-me-1.5', bottom: '-mb-1.5', left: '-ms-1.5')
-            : Flux::applyInset($inset, top: '-mt-1.5', right: '-me-3', bottom: '-mb-1.5', left: '-ms-3'),
+            : Flux::applyInset($inset, top: '-mt-1.5', right: ($iconTrailing && $iconTrailing !== '' ? '-me-2' : '-me-3'), bottom: '-mb-1.5', left: ($iconLeading && $iconLeading !== '' ? '-ms-2' : '-ms-3')),
         'xs' => $square
             ? Flux::applyInset($inset, top: '-mt-1', right: '-me-1', bottom: '-mb-1', left: '-ms-1')
-            : Flux::applyInset($inset, top: '-mt-1', right: '-me-2', bottom: '-mb-1', left: '-ms-2'),
+            : Flux::applyInset($inset, top: '-mt-1', right: ($iconTrailing && $iconTrailing !== '' ? '-me-1' : '-me-2'), bottom: '-mb-1', left: ($iconLeading && $iconLeading !== '' ? '-ms-1' : '-ms-2')),
     } : '')
     ->add(match ($variant) { // Background color...
         'primary' => 'bg-[var(--color-accent)] hover:bg-[color-mix(in_oklab,_var(--color-accent),_transparent_10%)]',

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -76,8 +76,16 @@ $classes = Flux::classes()
                 // If we have an icon, we want to reduce the padding on the side that has the icon...
                 : ($iconLeading && $iconLeading !== '' ? 'ps-3' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3' : 'pe-4')
         ),
-        'sm' => 'h-8 text-sm rounded-md' . ' ' . ($square ? 'w-8' : 'px-3'),
-        'xs' => 'h-6 text-xs rounded-md' . ' ' . ($square ? 'w-6' : 'px-2'),
+        'sm' => 'h-8 text-sm rounded-md' . ' ' . (
+            $square
+                ? 'w-8'
+                : ($iconLeading && $iconLeading !== '' ? 'ps-2.5' : 'ps-3') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-2.5' : 'pe-3')
+        ),
+        'xs' => 'h-6 text-xs rounded-md' . ' ' . (
+            $square
+                ? 'w-6'
+                : ($iconLeading && $iconLeading !== '' ? 'ps-1.5' : 'ps-2') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-1.5' : 'pe-2')
+        ),
     })
     ->add('inline-flex') // Buttons are inline by default but links are blocks, so inline-flex is needed here to ensure link-buttons are displayed the same as buttons...
     ->add($inset ? match ($size) { // Inset...

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -74,17 +74,17 @@ $classes = Flux::classes()
             $square
                 ? 'w-10'
                 // If we have an icon, we want to reduce the padding on the side that has the icon...
-                : ($iconLeading && $iconLeading !== '' ? 'ps-3.5' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3.5' : 'pe-4')
+                : ($iconLeading && $iconLeading !== '' ? 'ps-3' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3' : 'pe-4')
         ),
         'sm' => 'h-8 text-sm rounded-md' . ' ' . (
             $square
                 ? 'w-8'
-                : ($iconLeading && $iconLeading !== '' ? 'ps-2.5' : 'ps-3') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-2.5' : 'pe-3')
+                : ($iconLeading && $iconLeading !== '' ? 'ps-2' : 'ps-3') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-2' : 'pe-3')
         ),
         'xs' => 'h-6 text-xs rounded-md' . ' ' . (
             $square
                 ? 'w-6'
-                : ($iconLeading && $iconLeading !== '' ? 'ps-1.5' : 'ps-2') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-1.5' : 'pe-2')
+                : ($iconLeading && $iconLeading !== '' ? 'ps-1' : 'ps-2') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-1' : 'pe-2')
         ),
     })
     ->add('inline-flex') // Buttons are inline by default but links are blocks, so inline-flex is needed here to ensure link-buttons are displayed the same as buttons...

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -74,7 +74,7 @@ $classes = Flux::classes()
             $square
                 ? 'w-10'
                 // If we have an icon, we want to reduce the padding on the side that has the icon...
-                : ($iconLeading && $iconLeading !== '' ? 'ps-3.5' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3' : 'pe-4')
+                : ($iconLeading && $iconLeading !== '' ? 'ps-3.5' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3.5' : 'pe-4')
         ),
         'sm' => 'h-8 text-sm rounded-md' . ' ' . (
             $square

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -91,7 +91,7 @@ $classes = Flux::classes()
     ->add($inset ? match ($size) { // Inset...
         'base' => $square
             ? Flux::applyInset($inset, top: '-mt-2.5', right: '-me-2.5', bottom: '-mb-2.5', left: '-ms-2.5')
-            : Flux::applyInset($inset, top: '-mt-2.5', right: '-me-4', bottom: '-mb-3', left: '-ms-4'),
+            : Flux::applyInset($inset, top: '-mt-2.5', right: ($iconTrailing && $iconTrailing !== '' ? '-me-3' : '-me-4'), bottom: '-mb-3', left: ($iconLeading && $iconLeading !== '' ? '-ms-3' : '-ms-4')),
         'sm' => $square
             ? Flux::applyInset($inset, top: '-mt-1.5', right: '-me-1.5', bottom: '-mb-1.5', left: '-ms-1.5')
             : Flux::applyInset($inset, top: '-mt-1.5', right: '-me-3', bottom: '-mb-1.5', left: '-ms-3'),

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -74,7 +74,7 @@ $classes = Flux::classes()
             $square
                 ? 'w-10'
                 // If we have an icon, we want to reduce the padding on the side that has the icon...
-                : ($iconLeading && $iconLeading !== '' ? 'ps-3' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3' : 'pe-4')
+                : ($iconLeading && $iconLeading !== '' ? 'ps-3.5' : 'ps-4') . ' ' . ($iconTrailing && $iconTrailing !== '' ? 'pe-3' : 'pe-4')
         ),
         'sm' => 'h-8 text-sm rounded-md' . ' ' . (
             $square


### PR DESCRIPTION
<details>
<summary>
Original PR
</summary>

# The scenario

When using a button with an icon, the padding is unbalanced

_The lines represent the default padding without an icon_

<img width="972" height="511" alt="SCR-20260721-nwyy" src="https://github.com/user-attachments/assets/37625742-2a01-4767-8e43-34de525b9110" />

# The problem

At this size, Heroicons come with inner padding of ~1px, pushing the icon ~2px from the edge (see 2nd and 3rd row)

We compensate for this on the default size, changing `ps-4/pe-4` (16px) to `ps-3/pe-3` (12px) when an icon is present (see 1st row)

The problem is that this is inconsistent:

1. We overcompensate by 2px on the default size 
2. We do not compensate for this on the smaller sizes

# The solution

1. Pull back the adjustment by 2px on the default size
2. Add the adjustment to the smaller sizes

<img width="976" height="512" alt="SCR-20260721-nxfy" src="https://github.com/user-attachments/assets/e3f36f75-7e63-4add-90a2-9948db335bf7" />

<img width="1604" height="555" alt="SCR-20260721-nnva" src="https://github.com/user-attachments/assets/dca74bba-0efd-4b46-9190-37529f33e79f" />

---

UPDATE:

I realized the original padding may have been adjusted for chevron which seems to have double the inner padding than the rest of the icons. With the above adjustments, the chevron is now pushed inside from the edges.

<img width="742" height="491" alt="SCR-20260721-scjp-2" src="https://github.com/user-attachments/assets/16309184-442c-452e-af27-ab3e9ed1f560" />
</details>

Revision:

# The scenario

Horizontal inset on a default size button doesn't correctly negate padding when an icon is present.

<img width="2388" height="1456" alt="Frame@2x (9)" src="https://github.com/user-attachments/assets/b991859e-c994-4f31-894d-8c567520ef7a" />

# The problem

When an icon is present, we intentionally reduce the padding on the side with the icon. This is to compensate for the padding inside the heroicon svg. Without this adjustment, the padding on the side with the icon would look bigger than on the side without it.

```php
($iconLeading ? 'ps-3' : 'ps-4') . ' ' . ($iconTrailing ? 'pe-3' : 'pe-4')
```

The problem is that inset doesn't account for this.

Additionally, the smaller sizes do not have this adjustment, which is why this bug only appears on the default size:

<img width="2600" height="1400" alt="guidelines" src="https://github.com/user-attachments/assets/d8f6fc15-24f5-4504-ba99-53f701b13028" />

# The solution

1. Add icon adjustment to smaller sizes
2. Make inset icon-aware on all sizes

<img width="2600" height="1400" alt="guidelines-2" src="https://github.com/user-attachments/assets/235fbc99-6726-4a53-bf2b-dcd2a086b113" />

<img width="2388" height="1456" alt="Frame@2x (10)" src="https://github.com/user-attachments/assets/e69ad1df-1ecd-4dd4-9768-9b68b99b5e3b" />

## Update

3. Reduce the gap on the `xs` size from `gap-2` to `gap-1`

<img width="834" height="353" alt="SCR-20260724-okfv" src="https://github.com/user-attachments/assets/a4b048f8-370a-46b2-a6d4-95ac93b92b88" />

