### PR TITLE
Fix closed modals remaining interactive when display is `flex`

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -50,6 +50,10 @@ Transition dialogs with fade a slight scale effect...
     transition: all 0.075s allow-discrete;
 }
 
+[data-flux-modal] > dialog:not([open]) {
+    display: none;
+}
+
 [data-flux-modal] > dialog { transform: scale(0.95); }
 
 [data-flux-modal] > dialog[data-flux-flyout] { transform: scale(1) var(--flux-flyout-translate, var(--fx-flyout-translate, translateX(50px))); }


### PR DESCRIPTION
# The Scenario

When a flyout modal uses `flex flex-col` to arrange a header, scrollable content, and footer, closing the modal makes it disappear visually but its contents remain interactive. Links within the closed modal can still receive pointer events.

<img width="800" height="779" alt="CleanShot 2026-07-27 at 16 42 22" src="https://github.com/user-attachments/assets/07ce2ed6-1baa-4b86-bb4b-05d9f4297962" />

```blade
<flux:modal
    flyout
    variant="floating"
    name="mini-cart"
    class="flex flex-col"
>
    <!-- Flyout content... -->
</flux:modal>
```

# The Problem

Closing the native dialog correctly removes its `open` attribute. Flux previously relied on the browser’s user-agent stylesheet to apply `display: none` to the closed dialog.

An author-level display utility such as `flex` overrides that user-agent rule. The closed dialog therefore remains rendered with `opacity: 0` and continues receiving pointer events.

# The Solution

Explicitly hide non-open Flux dialogs with a scoped author-level CSS rule. This overrides display utilities while the dialog is closed and allows them to apply normally when it is open.

<img width="800" height="787" alt="CleanShot 2026-07-27 at 17 55 07" src="https://github.com/user-attachments/assets/ebe49841-9052-4893-9f36-0976c265581f" />


Fixes #2699
