### PR TITLE
Fix time picker input group styling

### DIFF
--- a/stubs/resources/views/flux/button/group.blade.php
+++ b/stubs/resources/views/flux/button/group.blade.php
@@ -47,6 +47,7 @@ $classes = Flux::classes()
         // Borders for sub-children wrapped in tooltips or time picker triggers...
         '[&>*:last-child:not(:first-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
         '[&>*:not(:first-child):not(:last-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:has(+[data-flux-input-group-suffix])>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-e-0',
     ])
     ;
 @endphp

--- a/stubs/resources/views/flux/button/group.blade.php
+++ b/stubs/resources/views/flux/button/group.blade.php
@@ -39,23 +39,14 @@ $classes = Flux::classes()
         '[&>*:first-child:not(:last-child)>[data-flux-input]>[data-flux-group-target]]:rounded-e-none',
         '[&>*:last-child:not(:first-child)>[data-flux-input]>[data-flux-group-target]]:rounded-s-none',
 
-        // "Weld" borders for sub-children wrapped in tooltips (button inside tooltip inside modal trigger, etc.)...
-        '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-none',
-        '[&>*:first-child:not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-e-none',
-        '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-s-none',
+        // "Weld" borders for sub-children wrapped in tooltips or time picker triggers...
+        '[&>*:not(:first-child):not(:last-child):not(:only-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]]:rounded-none',
+        '[&>*:first-child:not(:last-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]]:rounded-e-none',
+        '[&>*:last-child:not(:first-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]]:rounded-s-none',
 
-        // Borders for sub-children wrapped in tooltips...
-        '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-        '[&>*:not(:first-child):not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-
-        // "Weld" borders for sub-children wrapped in time picker triggers...
-        '[&>*:not(:first-child):not(:last-child):not(:only-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-none',
-        '[&>*:first-child:not(:last-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-e-none',
-        '[&>*:last-child:not(:first-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-s-none',
-
-        // Borders for sub-children wrapped in time picker triggers...
-        '[&>*:last-child:not(:first-child)>ui-time-picker-trigger>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-        '[&>*:not(:first-child):not(:last-child)>ui-time-picker-trigger>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        // Borders for sub-children wrapped in tooltips or time picker triggers...
+        '[&>*:last-child:not(:first-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:not(:first-child):not(:last-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
     ])
     ;
 @endphp

--- a/stubs/resources/views/flux/button/group.blade.php
+++ b/stubs/resources/views/flux/button/group.blade.php
@@ -47,6 +47,15 @@ $classes = Flux::classes()
         // Borders for sub-children wrapped in tooltips...
         '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
         '[&>*:not(:first-child):not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+
+        // "Weld" borders for sub-children wrapped in time picker triggers...
+        '[&>*:not(:first-child):not(:last-child):not(:only-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-none',
+        '[&>*:first-child:not(:last-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-e-none',
+        '[&>*:last-child:not(:first-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-s-none',
+
+        // Borders for sub-children wrapped in time picker triggers...
+        '[&>*:last-child:not(:first-child)>ui-time-picker-trigger>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:not(:first-child):not(:last-child)>ui-time-picker-trigger>[data-flux-group-target]:not([data-invalid])]:border-s-0',
     ])
     ;
 @endphp

--- a/stubs/resources/views/flux/input/group/index.blade.php
+++ b/stubs/resources/views/flux/input/group/index.blade.php
@@ -50,23 +50,14 @@ $classes = Flux::classes()
         '[&>*:first-child:not(:last-child)>[data-flux-input]>[data-flux-group-target]]:rounded-e-none',
         '[&>*:last-child:not(:first-child)>[data-flux-input]>[data-flux-group-target]]:rounded-s-none',
 
-        // "Weld" borders for sub-children wrapped in tooltips (button inside tooltip inside modal trigger, etc.)...
-        '[&>*:not(:first-child):not(:last-child):not(:only-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-none',
-        '[&>*:first-child:not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-e-none',
-        '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]]:rounded-s-none',
+        // "Weld" borders for sub-children wrapped in tooltips or time picker triggers...
+        '[&>*:not(:first-child):not(:last-child):not(:only-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]]:rounded-none',
+        '[&>*:first-child:not(:last-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]]:rounded-e-none',
+        '[&>*:last-child:not(:first-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]]:rounded-s-none',
 
-        // Borders for sub-children wrapped in tooltips...
-        '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-        '[&>*:not(:first-child):not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-
-        // "Weld" borders for sub-children wrapped in time picker triggers...
-        '[&>*:not(:first-child):not(:last-child):not(:only-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-none',
-        '[&>*:first-child:not(:last-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-e-none',
-        '[&>*:last-child:not(:first-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-s-none',
-
-        // Borders for sub-children wrapped in time picker triggers...
-        '[&>*:last-child:not(:first-child)>ui-time-picker-trigger>[data-flux-group-target]:not([data-invalid])]:border-s-0',
-        '[&>*:not(:first-child):not(:last-child)>ui-time-picker-trigger>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        // Borders for sub-children wrapped in tooltips or time picker triggers...
+        '[&>*:last-child:not(:first-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:not(:first-child):not(:last-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
     ])
     ;
 @endphp

--- a/stubs/resources/views/flux/input/group/index.blade.php
+++ b/stubs/resources/views/flux/input/group/index.blade.php
@@ -58,6 +58,15 @@ $classes = Flux::classes()
         // Borders for sub-children wrapped in tooltips...
         '[&>*:last-child:not(:first-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
         '[&>*:not(:first-child):not(:last-child)>[data-flux-tooltip]>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+
+        // "Weld" borders for sub-children wrapped in time picker triggers...
+        '[&>*:not(:first-child):not(:last-child):not(:only-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-none',
+        '[&>*:first-child:not(:last-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-e-none',
+        '[&>*:last-child:not(:first-child)>ui-time-picker-trigger>[data-flux-group-target]]:rounded-s-none',
+
+        // Borders for sub-children wrapped in time picker triggers...
+        '[&>*:last-child:not(:first-child)>ui-time-picker-trigger>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:not(:first-child):not(:last-child)>ui-time-picker-trigger>[data-flux-group-target]:not([data-invalid])]:border-s-0',
     ])
     ;
 @endphp

--- a/stubs/resources/views/flux/input/group/index.blade.php
+++ b/stubs/resources/views/flux/input/group/index.blade.php
@@ -58,6 +58,7 @@ $classes = Flux::classes()
         // Borders for sub-children wrapped in tooltips or time picker triggers...
         '[&>*:last-child:not(:first-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
         '[&>*:not(:first-child):not(:last-child)>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-s-0',
+        '[&>*:has(+[data-flux-input-group-suffix])>:is([data-flux-tooltip],ui-time-picker-trigger)>[data-flux-group-target]:not([data-invalid])]:border-e-0',
     ])
     ;
 @endphp


### PR DESCRIPTION
# The Scenario

When a time picker is placed beside a prefix or suffix inside an input group, its internal corners and borders are not welded to the adjacent element.

<img width="1682" height="710" alt="CleanShot 2026-07-27 at 16 32 00@2x" src="https://github.com/user-attachments/assets/43838638-1415-4010-b0d3-c32e45152bfd" />

```blade
<flux:input.group>
    <flux:input.group.prefix>
        Start
    </flux:input.group.prefix>

    <flux:time-picker />
</flux:input.group>
```

# The Problem

Input groups adjust the borders and corner radii of elements marked with `data-flux-group-target`.

A button-style time picker's group target is nested beneath an additional `ui-time-picker-trigger` element, so the existing input-group selectors cannot reach it.

The input-style time picker's visible container is not marked with `data-flux-group-target`, so the input group does not recognise it as a target at all.

# The Solution

The existing group styling already handles wrapped targets used by tooltips. The solution has two parts:

- Extend those selectors to recognise `ui-time-picker-trigger`, allowing input groups to adjust the borders and corner radii of button-style time pickers. PR #2705 (this PR)
- Mark the input-style time picker's visible container with `data-flux-group-target` and expose its invalid state there, ensuring collapsed group borders do not hide its validation border. livewire/flux-pro#527

<img width="1692" height="698" alt="CleanShot 2026-07-27 at 17 50 16@2x" src="https://github.com/user-attachments/assets/29f1d604-63da-4192-ab68-03e2dbf80437" />

I also did a check of tooltips, normal buttons, and inputs to make sure they're all the same now.

<img width="1686" height="1928" alt="CleanShot 2026-07-27 at 17 50 39@2x" src="https://github.com/user-attachments/assets/5c5c7e0c-291f-4dfe-b68e-000d442967ea" />


Fixes #2698
