### PR TITLE
Fix input keyboard shortcut padding

### DIFF
--- a/stubs/resources/views/flux/input/index.blade.php
+++ b/stubs/resources/views/flux/input/index.blade.php
@@ -178,7 +178,7 @@ $classes = Flux::classes()
                     <?php endif; ?>
 
                     <?php if ($kbd): ?>
-                        <span class="pointer-events-none">{{ $kbd }}</span>
+                        <span class="pointer-events-none last:pe-2">{{ $kbd }}</span>
                     <?php endif; ?>
 
                     <?php if ($expandable): ?>


### PR DESCRIPTION
# The Scenario

When rendering an input with a keyboard shortcut, the shortcut sits too close to the end edge, making the input padding look unbalanced. (see 3rd and 4th inputs below in comparison to the button with shortcut at the bottom).

<img width="1048" height="1406" alt="CleanShot 2026-07-27 at 16 48 28@2x" src="https://github.com/user-attachments/assets/894e95da-1a3e-402d-a502-dcbb0291785e" />


```blade
<flux:input icon="magnifying-glass" placeholder="Search media..." kbd="⌘K" />
```

# The Problem

Keyboard shortcuts originally had their own `pe-4` wrapper.

In #1357, trailing controls were moved into a shared flex container to support loading alongside multiple icons and actions. This changed the keyboard shortcut from its dedicated `pe-4` wrapper to the container’s `pe-3`.

In #2158, the shared container was shifted towards the edge to align input icons with other controls. Because the keyboard shortcut shared that container, it was shifted as well.

In #2237, the negative margin used for that alignment was replaced with `pe-2` to prevent overflow while preserving the icon position.

These changes were intended for trailing icons and icon buttons, but they also affected the keyboard shortcut, which is the only built-in trailing control containing text.

# The Solution

Add `pe-2` to the keyboard shortcut only when it is the final trailing control. Combined with the container’s existing `pe-2`, this restores the original `pe-4` text inset.

When an icon or action follows the shortcut, the additional padding does not apply. The final icon therefore retains its existing `pe-2` alignment.

This keeps the shared container unchanged and preserves the icon alignment and overflow fixes from the earlier pull requests.

<img width="1056" height="1400" alt="CleanShot 2026-07-27 at 20 47 19@2x" src="https://github.com/user-attachments/assets/fa2a47ab-a2d7-40b9-9773-daf28ae1bedd" />

Fixes #2696
