### PR TITLE
Fix button vertical alignment in table cells

### DIFF
--- a/stubs/resources/views/flux/table/cell.blade.php
+++ b/stubs/resources/views/flux/table/cell.blade.php
@@ -8,7 +8,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('[:where(&)]:py-3 [:where(&)]:px-3 first:ps-0 last:pe-0 text-sm')
+    ->add('[:where(&)]:py-3 [:where(&)]:px-3 first:ps-0 last:pe-0 text-sm [&:has(>[data-flux-button])]:leading-[0] [&:has(>[data-flux-tooltip]>[data-flux-button])]:leading-[0]')
     ->add(match($align) {
         'center' => 'text-center [&>*]:mx-auto',
         'end' => 'text-end [&>*]:ms-auto',


### PR DESCRIPTION
# The Scenario

When an inset button with an icon and tooltip is rendered inside a table cell, it can appear vertically offset compared with equivalent buttons without the tooltip or icon.

<img width="4484" height="732" alt="CleanShot 2026-08-04 at 12 41 00@2x" src="https://github.com/user-attachments/assets/606d67c7-2d92-41d7-bb0a-e4a92a4119a8" />

```blade
<flux:table>
    <flux:table.columns>
        <flux:table.column>Case</flux:table.column>
        <flux:table.column>Icon, no tooltip</flux:table.column>
        <flux:table.column>Icon and tooltip</flux:table.column>
        <flux:table.column>Tooltip, no icon</flux:table.column>
        <flux:table.column>No icon or tooltip</flux:table.column>
    </flux:table.columns>

    <flux:table.rows>
        <flux:table.row>
            <flux:table.cell variant="strong">With inset</flux:table.cell>
            <flux:table.cell>
                <flux:button inset="top bottom" variant="filled" icon="bell" size="xs">Button text</flux:button>
            </flux:table.cell>
            <flux:table.cell>
                <flux:button tooltip="Tooltip text" inset="top bottom" variant="filled" icon="bell" size="xs">Button text</flux:button>
            </flux:table.cell>
            <flux:table.cell>
                <flux:button tooltip="Tooltip text" inset="top bottom" variant="filled" size="xs">Button text</flux:button>
            </flux:table.cell>
            <flux:table.cell>
                <flux:button inset="top bottom" variant="filled" size="xs">Button text</flux:button>
            </flux:table.cell>
        </flux:table.row>

        <flux:table.row>
            <flux:table.cell variant="strong">Without inset</flux:table.cell>
            <flux:table.cell>
                <flux:button variant="filled" icon="bell" size="xs">Button text</flux:button>
            </flux:table.cell>
            <flux:table.cell>
                <flux:button tooltip="Tooltip text" variant="filled" icon="bell" size="xs">Button text</flux:button>
            </flux:table.cell>
            <flux:table.cell>
                <flux:button tooltip="Tooltip text" variant="filled" size="xs">Button text</flux:button>
            </flux:table.cell>
            <flux:table.cell>
                <flux:button variant="filled" size="xs">Button text</flux:button>
            </flux:table.cell>
        </flux:table.row>
    </flux:table.rows>
</flux:table>
```

# The Problem

Table cells use `text-sm`, which creates an inline line box. Buttons use `inline-flex`, while buttons with tooltips receive an additional inline tooltip wrapper.

When vertical inset applies equal negative margins to the button, the cell's line box continues to use typographic baseline alignment. This causes the remaining vertical space to be distributed unevenly around the button.

# The Solution

The solution is to remove the table cell's line-height contribution when it directly contains a button or a tooltip-wrapped button.

The button continues to provide its own height and line height. This allows equal vertical inset margins to reduce the surrounding space symmetrically without changing button width, display behaviour, or ordinary text-only table cells.

This complements #2645, which corrected horizontal alignment for standalone icons in table cells. This change addresses vertical button alignment in those cells.

<img width="4488" height="722" alt="CleanShot 2026-08-04 at 12 42 36@2x" src="https://github.com/user-attachments/assets/26d8f792-e558-437e-9e5c-5d72991cfb68" />

Fixes #2715
