### PR TITLE
Add CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer:v2
+          coverage: none
+
+      - name: Validate Composer metadata
+        run: composer validate --strict
+
+      - name: Check PHP syntax
+        run: find src -type f -name '*.php' -print0 | xargs -0 -n1 php -l


### PR DESCRIPTION
## What changed

- add a public GitHub Actions CI workflow
- validate Composer package metadata
- lint every PHP source file using the package's minimum PHP 8.1 runtime

## Why

The public Flux distribution repository had no CI signal, so release preparation could not verify that CI was green for both Flux repositories.

## Validation

- `composer validate --strict`
- PHP syntax checks for every file under `src/`
- `git diff --check`
