### PR TITLE
Pin CI actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.1'
           tools: composer:v2


### PR DESCRIPTION
## What changed

- Pin `actions/checkout` to the commit behind v4.4.0.
- Pin `shivammathur/setup-php` to the commit behind 2.37.2.

## Why

The CI workflow introduced in #2724 used mutable major-version tags. Pinning third-party workflow dependencies to reviewed commit SHAs prevents those tags from silently changing the code executed by CI.

## Impact

CI behavior remains the same while the action source is made deterministic. Version comments preserve Dependabot compatibility and readability.

## Validation

- Parsed `.github/workflows/ci.yml` successfully.
- `git diff --check` passed.
- Confirmed each pinned commit is the current commit behind its documented release tag.
