### PR TITLE
Add inset and fix padding in toggle

### DIFF
--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -42,13 +42,13 @@ $classes = Flux::classes()
     ->add($inset ? match ($size) {
         'base' => $square
             ? Flux::applyInset($inset, top: '-mt-2.5', right: '-me-2.5', bottom: '-mb-2.5', left: '-ms-2.5')
-            : Flux::applyInset($inset, top: '-mt-2.5', right: '-me-4', bottom: '-mb-3', left: '-ms-4'),
+            : Flux::applyInset($inset, top: '-mt-2.5', right: '-me-4', bottom: '-mb-3', left: ($icon ? '-ms-3' : '-ms-4')),
         'sm' => $square
             ? Flux::applyInset($inset, top: '-mt-1.5', right: '-me-1.5', bottom: '-mb-1.5', left: '-ms-1.5')
-            : Flux::applyInset($inset, top: '-mt-1.5', right: '-me-3', bottom: '-mb-1.5', left: '-ms-3'),
+            : Flux::applyInset($inset, top: '-mt-1.5', right: '-me-3', bottom: '-mb-1.5', left: ($icon ? '-ms-2' : '-ms-3')),
         'xs' => $square
             ? Flux::applyInset($inset, top: '-mt-1', right: '-me-1', bottom: '-mb-1', left: '-ms-1')
-            : Flux::applyInset($inset, top: '-mt-1', right: '-me-2', bottom: '-mb-1', left: '-ms-2'),
+            : Flux::applyInset($inset, top: '-mt-1', right: '-me-2', bottom: '-mb-1', left: ($icon ? '-ms-1' : '-ms-2')),
     } : '')
     ->add(match ($variant) {
         'filled' => 'bg-zinc-800/5 hover:bg-zinc-800/10 dark:bg-white/10 dark:hover:bg-white/20',

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -10,6 +10,7 @@
     'name' => null,
     'icon' => null,
     'color' => null,
+    'inset' => null,
 ])
 
 @php
@@ -30,14 +31,25 @@ $iconClasses = Flux::classes()
     ;
 
 $classes = Flux::classes()
-    ->add('group relative inline-flex items-center font-medium justify-center gap-2 whitespace-nowrap outline-offset-2')
+    ->add('group relative inline-flex items-center font-medium justify-center whitespace-nowrap outline-offset-2')
     ->add('transition')
     ->add('[&[disabled]]:opacity-75 dark:[&[disabled]]:opacity-75 [&[disabled]]:cursor-default')
     ->add(match ($size) {
-        'base' => 'h-10 text-sm rounded-lg' . ' ' . ($square ? 'w-10' : ($icon ? 'ps-3 pe-4' : 'px-4')),
-        'sm' => 'h-8 text-sm rounded-md' . ' ' . ($square ? 'w-8' : 'px-3'),
-        'xs' => 'h-6 text-xs rounded-md' . ' ' . ($square ? 'w-6' : 'px-2'),
+        'base' => 'h-10 text-sm rounded-lg gap-2' . ' ' . ($square ? 'w-10' : ($icon ? 'ps-3 pe-4' : 'px-4')),
+        'sm' => 'h-8 text-sm rounded-md gap-2' . ' ' . ($square ? 'w-8' : ($icon ? 'ps-2 pe-3' : 'px-3')),
+        'xs' => 'h-6 text-xs rounded-md gap-1' . ' ' . ($square ? 'w-6' : ($icon ? 'ps-1 pe-2' : 'px-2')),
     })
+    ->add($inset ? match ($size) {
+        'base' => $square
+            ? Flux::applyInset($inset, top: '-mt-2.5', right: '-me-2.5', bottom: '-mb-2.5', left: '-ms-2.5')
+            : Flux::applyInset($inset, top: '-mt-2.5', right: '-me-4', bottom: '-mb-3', left: '-ms-4'),
+        'sm' => $square
+            ? Flux::applyInset($inset, top: '-mt-1.5', right: '-me-1.5', bottom: '-mb-1.5', left: '-ms-1.5')
+            : Flux::applyInset($inset, top: '-mt-1.5', right: '-me-3', bottom: '-mb-1.5', left: '-ms-3'),
+        'xs' => $square
+            ? Flux::applyInset($inset, top: '-mt-1', right: '-me-1', bottom: '-mb-1', left: '-ms-1')
+            : Flux::applyInset($inset, top: '-mt-1', right: '-me-2', bottom: '-mb-1', left: '-ms-2'),
+    } : '')
     ->add(match ($variant) {
         'filled' => 'bg-zinc-800/5 hover:bg-zinc-800/10 dark:bg-white/10 dark:hover:bg-white/20',
         'outline' => 'bg-white hover:bg-zinc-50 dark:bg-zinc-700 dark:hover:bg-zinc-600/75',


### PR DESCRIPTION
# The scenario

The toggle doesn't support inset and padding / gap don't match the button

<img width="1840" height="900" alt="SCR-20260814-luiu" src="https://github.com/user-attachments/assets/6e0282cd-1b08-4511-b8a8-fd6e805c0bca" />

# The problem

Inset was never implemented and the padding / gap was likely based on older version of button before https://github.com/livewire/flux/pull/2695 was merged

# The solution

Adjust padding and gap to match the button and add support for inset

<img width="1723" height="855" alt="SCR-20260814-lvjh" src="https://github.com/user-attachments/assets/dd551350-1bde-4356-b3cd-29be658f2c69" />

<img width="1641" height="599" alt="SCR-20260814-mcqq" src="https://github.com/user-attachments/assets/55d613f0-b5e8-4ec7-953b-9b61de49c5d1" />
