### PR TITLE
Fix toggle interactions

### DIFF
--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -31,7 +31,7 @@ $iconClasses = Flux::classes()
 
 $classes = Flux::classes()
     ->add('group relative inline-flex items-center font-medium justify-center gap-2 whitespace-nowrap outline-offset-2')
-    ->add('transition cursor-default select-none touch-manipulation')
+    ->add('transition select-none touch-manipulation')
     ->add('[&[disabled]]:opacity-75 dark:[&[disabled]]:opacity-75 [&[disabled]]:cursor-default')
     ->add(match ($size) {
         'base' => 'h-10 text-sm rounded-lg' . ' ' . ($square ? 'w-10' : ($icon ? 'ps-3 pe-4' : 'px-4')),

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -31,7 +31,7 @@ $iconClasses = Flux::classes()
 
 $classes = Flux::classes()
     ->add('group relative inline-flex items-center font-medium justify-center gap-2 whitespace-nowrap outline-offset-2')
-    ->add('transition cursor-default')
+    ->add('transition cursor-default select-none touch-manipulation')
     ->add('[&[disabled]]:opacity-75 dark:[&[disabled]]:opacity-75 [&[disabled]]:cursor-default')
     ->add(match ($size) {
         'base' => 'h-10 text-sm rounded-lg' . ' ' . ($square ? 'w-10' : ($icon ? 'ps-3 pe-4' : 'px-4')),

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -31,7 +31,7 @@ $iconClasses = Flux::classes()
 
 $classes = Flux::classes()
     ->add('group relative inline-flex items-center font-medium justify-center gap-2 whitespace-nowrap outline-offset-2')
-    ->add('transition')
+    ->add('transition cursor-default')
     ->add('[&[disabled]]:opacity-75 dark:[&[disabled]]:opacity-75 [&[disabled]]:cursor-default')
     ->add(match ($size) {
         'base' => 'h-10 text-sm rounded-lg' . ' ' . ($square ? 'w-10' : ($icon ? 'ps-3 pe-4' : 'px-4')),


### PR DESCRIPTION
# The scenario

The toggle shows selection cursor and allows text selection, which is inconsistent with button

Additionally, clicking the toggle repeatedly causes zoom on mobile

https://github.com/user-attachments/assets/b2ac43b2-045c-437e-8f91-006d4d47bc88

# The problem

HTML button displays the default cursor and prevents selection / zoom by default.

The toggle is composed of `ui-switch` which does not have these properties.

# The solution

Add `select-none` and `touch-manipulation` classes to mimic button behavior.