### PR TITLE
Tweak toggle colors

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -63,7 +63,7 @@ if ($loading && $type !== 'submit' && ! $isJsMethod) {
 
 $classes = Flux::classes()
     ->add('relative items-center font-medium justify-center whitespace-nowrap')
-    ->add('disabled:opacity-50 dark:disabled:opacity-50 disabled:cursor-default disabled:pointer-events-none')
+    ->add('disabled:opacity-50 dark:disabled:opacity-50 disabled:cursor-default disabled:pointer-events-none disabled:shadow-none')
     ->add(match ($align) {
         'start' => 'justify-start',
         'center' => 'justify-center',
@@ -128,7 +128,7 @@ $classes = Flux::classes()
             'sm' => 'shadow-xs',
             'xs' => 'shadow-none',
         },
-        default => 'disabled:shadow-none',
+        default => '',
     })
     ->add(match ($variant) { // Grouped border treatments...
         'ghost' => '',

--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -63,7 +63,7 @@ if ($loading && $type !== 'submit' && ! $isJsMethod) {
 
 $classes = Flux::classes()
     ->add('relative items-center font-medium justify-center whitespace-nowrap')
-    ->add('disabled:opacity-75 dark:disabled:opacity-75 disabled:cursor-default disabled:pointer-events-none')
+    ->add('disabled:opacity-50 dark:disabled:opacity-50 disabled:cursor-default disabled:pointer-events-none')
     ->add(match ($align) {
         'start' => 'justify-start',
         'center' => 'justify-center',
@@ -117,7 +117,7 @@ $classes = Flux::classes()
     })
     ->add(match ($variant) { // Border color...
         'primary' => 'border border-black/10 dark:border-0',
-        'outline' => 'border border-zinc-200 hover:border-zinc-200 border-b-zinc-300/80 dark:border-zinc-600 dark:hover:border-zinc-600',
+        'outline' => 'border border-zinc-200 hover:border-zinc-200 disabled:border-zinc-200 border-b-zinc-300/80 dark:border-zinc-600 dark:hover:border-zinc-600 dark:disabled:border-zinc-600',
          default => '',
     })
     ->add(match ($variant) { // Shadows...
@@ -128,7 +128,7 @@ $classes = Flux::classes()
             'sm' => 'shadow-xs',
             'xs' => 'shadow-none',
         },
-        default => '',
+        default => 'disabled:shadow-none',
     })
     ->add(match ($variant) { // Grouped border treatments...
         'ghost' => '',

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -27,12 +27,16 @@ $square = $slot->isEmpty();
 
 $iconClasses = Flux::classes()
     ->add(match ($variant) {
+        'outline' => 'text-zinc-500 dark:text-white',
+        'filled' => 'text-zinc-500 dark:text-white',
+        'ghost' => 'text-zinc-500 dark:text-white',
         'subtle' => 'text-zinc-500 dark:text-zinc-400',
-        default => 'text-zinc-500 dark:text-white',
     })
     ->add(match ($variant) {
+        'outline' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'filled' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'ghost' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => 'in-data-checked:text-zinc-600 in-data-checked:dark:text-white',
-        default => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
     })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')
     ->add($attributes->pluck('icon:class'))
@@ -59,14 +63,14 @@ $classes = Flux::classes()
             : Flux::applyInset($inset, top: '-mt-1', right: '-me-2', bottom: '-mb-1', left: ($icon ? '-ms-1' : '-ms-2')),
     } : '')
     ->add(match ($variant) {
-        'filled' => 'bg-zinc-800/5 hover:bg-zinc-800/10 dark:bg-white/10 dark:hover:bg-white/20',
         'outline' => 'bg-white hover:bg-zinc-50 dark:bg-zinc-700 dark:hover:bg-zinc-600/75',
+        'filled' => 'bg-zinc-800/5 hover:bg-zinc-800/10 dark:bg-white/10 dark:hover:bg-white/20',
         'ghost' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'filled' => 'text-zinc-800 dark:text-white',
         'outline' => 'text-zinc-800 dark:text-white',
+        'filled' => 'text-zinc-800 dark:text-white',
         'ghost' => 'text-zinc-800 dark:text-white',
         'subtle' => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-white',
     })

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -36,7 +36,10 @@ $iconClasses = Flux::classes()
         'outline' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'filled' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'ghost' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'subtle' => 'group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800 in-data-checked:dark:text-white',
+        'subtle' => join(' ', [
+            'group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
+            'dark:group-hover:text-white dark:in-data-checked:text-white dark:in-data-checked:group-hover:text-white',
+        ]),
     })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')
     ->add($attributes->pluck('icon:class'))
@@ -69,9 +72,9 @@ $classes = Flux::classes()
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'outline' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white',
-        'filled' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white',
-        'ghost' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white',
+        'outline' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white dark:data-checked:text-white',
+        'filled' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white dark:data-checked:text-white',
+        'ghost' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white dark:data-checked:text-white',
         'subtle' => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-white',
     })
     ->add(match ($variant) {

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -29,7 +29,7 @@ $iconClasses = Flux::classes()
     ->add(match ($variant) {
         'outline' => 'text-zinc-500/85 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'filled' => 'text-zinc-500/85 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'ghost' => 'text-zinc-500/80 dark:text-zinc-400/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'ghost' => 'text-zinc-500/85 dark:text-zinc-400/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => join(' ', [
             'text-zinc-500/75 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
             'dark:text-zinc-500 dark:group-hover:text-zinc-400 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
@@ -66,9 +66,9 @@ $classes = Flux::classes()
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'outline' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/95 dark:data-checked:text-white',
+        'outline' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
         'filled' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
-        'ghost' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/80 dark:data-checked:text-white',
+        'ghost' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
         'subtle' => join(' ', [
             'text-zinc-500 hover:text-zinc-500 data-checked:text-zinc-600 data-checked:hover:text-zinc-800',
             'dark:text-zinc-400/80 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -30,13 +30,13 @@ $iconClasses = Flux::classes()
         'outline' => 'text-zinc-500 dark:text-white',
         'filled' => 'text-zinc-500 dark:text-white',
         'ghost' => 'text-zinc-500 dark:text-white',
-        'subtle' => 'text-zinc-500 dark:text-zinc-400',
+        'subtle' => 'text-zinc-400 dark:text-zinc-400',
     })
     ->add(match ($variant) {
         'outline' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'filled' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'ghost' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'subtle' => 'in-data-checked:text-zinc-600 in-data-checked:dark:text-white',
+        'subtle' => 'group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800 in-data-checked:dark:text-white',
     })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')
     ->add($attributes->pluck('icon:class'))
@@ -69,9 +69,9 @@ $classes = Flux::classes()
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'outline' => 'text-zinc-800 dark:text-white',
-        'filled' => 'text-zinc-800 dark:text-white',
-        'ghost' => 'text-zinc-800 dark:text-white',
+        'outline' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white',
+        'filled' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white',
+        'ghost' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white',
         'subtle' => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-white',
     })
     ->add(match ($variant) {

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -32,7 +32,7 @@ $iconClasses = Flux::classes()
         'ghost' => 'text-zinc-500 dark:text-zinc-300 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => join(' ', [
             'text-zinc-400 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
-            'dark:text-zinc-500 dark:group-hover:text-zinc-300 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
+            'dark:text-zinc-400/85 dark:group-hover:text-zinc-300 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
         ])
     })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -29,10 +29,10 @@ $iconClasses = Flux::classes()
     ->add(match ($variant) {
         'outline' => 'text-zinc-500/85 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'filled' => 'text-zinc-500/85 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'ghost' => 'text-zinc-500/85 dark:text-zinc-400/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'ghost' => 'text-zinc-500/85 dark:text-zinc-400/90 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => join(' ', [
-            'text-zinc-500/75 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
-            'dark:text-zinc-500 dark:group-hover:text-zinc-400 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
+            'text-zinc-400/90 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
+            'dark:text-zinc-500/90 dark:group-hover:text-zinc-400 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
         ])
     })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')
@@ -66,11 +66,11 @@ $classes = Flux::classes()
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'outline' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
-        'filled' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
-        'ghost' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
+        'outline' => 'text-zinc-600/85 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
+        'filled' => 'text-zinc-600/85 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
+        'ghost' => 'text-zinc-600/85 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
         'subtle' => join(' ', [
-            'text-zinc-500 hover:text-zinc-500 data-checked:text-zinc-600 data-checked:hover:text-zinc-800',
+            'text-zinc-500/85 hover:text-zinc-500 data-checked:text-zinc-500 data-checked:hover:text-zinc-800',
             'dark:text-zinc-400/80 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',
         ])
     })

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -26,6 +26,14 @@ if (! isset($name)) {
 $square = $slot->isEmpty();
 
 $iconClasses = Flux::classes()
+    ->add(match ($variant) {
+        'subtle' => 'text-zinc-500 dark:text-zinc-400',
+        default => 'text-zinc-500 dark:text-white',
+    })
+    ->add(match ($variant) {
+        'subtle' => 'in-data-checked:text-zinc-600 in-data-checked:dark:text-white',
+        default => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+    })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')
     ->add($attributes->pluck('icon:class'))
     ;
@@ -56,11 +64,12 @@ $classes = Flux::classes()
         'ghost' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
-    ->add(match ($variant) {
-        'subtle' => 'text-zinc-400 hover:text-zinc-800 dark:text-zinc-500 dark:hover:text-white',
-        default => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-white',
+    ->add(match ($variant) { // Text color...
+        'filled' => 'text-zinc-800 dark:text-white',
+        'outline' => 'text-zinc-800 dark:text-white',
+        'ghost' => 'text-zinc-800 dark:text-white',
+        'subtle' => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-white',
     })
-    ->add('data-checked:text-(--color-accent-content) data-checked:hover:text-(--color-accent-content) dark:data-checked:text-(--color-accent-content) dark:data-checked:hover:text-(--color-accent-content)')
     ->add(match ($variant) {
         'outline' => 'border border-zinc-200 hover:border-zinc-200 border-b-zinc-300/80 dark:border-zinc-600 dark:hover:border-zinc-600',
         default => '',
@@ -88,7 +97,7 @@ $classes = Flux::classes()
             <?php endif; ?>
 
             <?php if (! $slot->isEmpty()): ?>
-                <span class="text-zinc-600 dark:text-zinc-300">{{ $slot }}</span>
+                <span>{{ $slot }}</span>
             <?php endif; ?>
         </ui-switch>
     </flux:with-tooltip>

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -32,7 +32,7 @@ $iconClasses = Flux::classes()
         'ghost' => 'text-zinc-500 dark:text-zinc-300 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => join(' ', [
             'text-zinc-400 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
-            'dark:text-zinc-400/85 dark:group-hover:text-zinc-300 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
+            'dark:text-zinc-500 dark:group-hover:text-zinc-300 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
         ])
     })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')
@@ -66,10 +66,10 @@ $classes = Flux::classes()
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'outline' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-zinc-200 dark:data-checked:text-white',
-        'filled' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-zinc-200 dark:data-checked:text-white',
-        'ghost' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-zinc-200 dark:data-checked:text-white',
-        'subtle' => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',
+        'outline' => 'text-zinc-500 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
+        'filled' => 'text-zinc-500 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
+        'ghost' => 'text-zinc-500 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
+        'subtle' => 'text-zinc-400 hover:text-zinc-500 data-checked:text-zinc-500 data-checked:hover:text-zinc-800 dark:text-zinc-500 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',
     })
     ->add(match ($variant) {
         'outline' => 'border border-zinc-200 hover:border-zinc-200 border-b-zinc-300/80 dark:border-zinc-600 dark:hover:border-zinc-600',

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -27,12 +27,12 @@ $square = $slot->isEmpty();
 
 $iconClasses = Flux::classes()
     ->add(match ($variant) {
-        'outline' => 'text-zinc-500 dark:text-zinc-400 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'filled' => 'text-zinc-500 dark:text-zinc-400 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'ghost' => 'text-zinc-500 dark:text-zinc-400 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'outline' => 'text-zinc-500 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'filled' => 'text-zinc-500 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'ghost' => 'text-zinc-500 dark:text-zinc-400/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => join(' ', [
             'text-zinc-400 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
-            'dark:text-zinc-500 dark:group-hover:text-zinc-300 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
+            'dark:text-zinc-500 dark:group-hover:text-zinc-400 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
         ])
     })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')
@@ -42,7 +42,7 @@ $iconClasses = Flux::classes()
 $classes = Flux::classes()
     ->add('group relative inline-flex items-center font-medium justify-center whitespace-nowrap outline-offset-2')
     ->add('transition touch-manipulation')
-    ->add('[&[disabled]]:opacity-75 dark:[&[disabled]]:opacity-75 [&[disabled]]:cursor-default [&[disabled]]:pointer-events-none')
+    ->add('[&[disabled]]:opacity-50 dark:[&[disabled]]:opacity-50 [&[disabled]]:shadow-none [&[disabled]]:cursor-default [&[disabled]]:pointer-events-none')
     ->add(match ($size) {
         'base' => 'h-10 text-sm rounded-lg gap-2' . ' ' . ($square ? 'w-10' : ($icon ? 'ps-3 pe-4' : 'px-4')),
         'sm' => 'h-8 text-sm rounded-md gap-2' . ' ' . ($square ? 'w-8' : ($icon ? 'ps-2 pe-3' : 'px-3')),
@@ -66,10 +66,13 @@ $classes = Flux::classes()
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'outline' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
-        'filled' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
-        'ghost' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
-        'subtle' => 'text-zinc-400 hover:text-zinc-500 data-checked:text-zinc-500 data-checked:hover:text-zinc-800 dark:text-zinc-500 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',
+        'outline' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300/95 dark:data-checked:text-white',
+        'filled' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
+        'ghost' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300/80 dark:data-checked:text-white',
+        'subtle' => join(' ', [
+            'text-zinc-400 hover:text-zinc-500 data-checked:text-zinc-500 data-checked:hover:text-zinc-800',
+            'dark:text-zinc-400/80 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',
+        ])
     })
     ->add(match ($variant) {
         'outline' => 'border border-zinc-200 hover:border-zinc-200 border-b-zinc-300/80 dark:border-zinc-600 dark:hover:border-zinc-600',

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -27,9 +27,9 @@ $square = $slot->isEmpty();
 
 $iconClasses = Flux::classes()
     ->add(match ($variant) {
-        'outline' => 'text-zinc-500 dark:text-zinc-300 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'filled' => 'text-zinc-500 dark:text-zinc-300 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'ghost' => 'text-zinc-500 dark:text-zinc-300 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'outline' => 'text-zinc-500 dark:text-zinc-400 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'filled' => 'text-zinc-500 dark:text-zinc-400 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'ghost' => 'text-zinc-500 dark:text-zinc-400 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => join(' ', [
             'text-zinc-400 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
             'dark:text-zinc-500 dark:group-hover:text-zinc-300 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -66,9 +66,9 @@ $classes = Flux::classes()
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'outline' => 'text-zinc-500 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
-        'filled' => 'text-zinc-500 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
-        'ghost' => 'text-zinc-500 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
+        'outline' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
+        'filled' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
+        'ghost' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300 dark:data-checked:text-white',
         'subtle' => 'text-zinc-400 hover:text-zinc-500 data-checked:text-zinc-500 data-checked:hover:text-zinc-800 dark:text-zinc-500 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',
     })
     ->add(match ($variant) {

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -68,7 +68,7 @@ $classes = Flux::classes()
     ->add(match ($variant) { // Text color...
         'outline' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/95 dark:data-checked:text-white',
         'filled' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
-        'ghost' => 'text-zinc-600/80 data-checked:text-zinc-800 dark:text-zinc-300/80 dark:data-checked:text-white',
+        'ghost' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/80 dark:data-checked:text-white',
         'subtle' => join(' ', [
             'text-zinc-500 hover:text-zinc-500 data-checked:text-zinc-600 data-checked:hover:text-zinc-800',
             'dark:text-zinc-400/80 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -27,18 +27,12 @@ $square = $slot->isEmpty();
 
 $iconClasses = Flux::classes()
     ->add(match ($variant) {
-        'outline' => 'text-zinc-500 dark:text-white',
-        'filled' => 'text-zinc-500 dark:text-white',
-        'ghost' => 'text-zinc-500 dark:text-white',
-        'subtle' => 'text-zinc-400 dark:text-zinc-400',
-    })
-    ->add(match ($variant) {
-        'outline' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'filled' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'ghost' => 'in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'outline' => 'text-zinc-500 dark:text-white in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'filled' => 'text-zinc-500 dark:text-white in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'ghost' => 'text-zinc-500 dark:text-white in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => join(' ', [
-            'group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
-            'dark:group-hover:text-white dark:in-data-checked:text-white dark:in-data-checked:group-hover:text-white',
+            'text-zinc-400 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
+            'dark:text-zinc-400 dark:group-hover:text-white dark:in-data-checked:text-white dark:in-data-checked:group-hover:text-white',
         ]),
     })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -27,11 +27,11 @@ $square = $slot->isEmpty();
 
 $iconClasses = Flux::classes()
     ->add(match ($variant) {
-        'outline' => 'text-zinc-500 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'filled' => 'text-zinc-500 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'ghost' => 'text-zinc-500 dark:text-zinc-400/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'outline' => 'text-zinc-500/85 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'filled' => 'text-zinc-500/85 dark:text-zinc-300/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'ghost' => 'text-zinc-500/80 dark:text-zinc-400/80 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => join(' ', [
-            'text-zinc-400 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
+            'text-zinc-500/75 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
             'dark:text-zinc-500 dark:group-hover:text-zinc-400 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
         ])
     })
@@ -66,11 +66,11 @@ $classes = Flux::classes()
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'outline' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300/95 dark:data-checked:text-white',
-        'filled' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
-        'ghost' => 'text-zinc-600 data-checked:text-zinc-800 dark:text-zinc-300/80 dark:data-checked:text-white',
+        'outline' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/95 dark:data-checked:text-white',
+        'filled' => 'text-zinc-600/90 data-checked:text-zinc-800 dark:text-zinc-300/90 dark:data-checked:text-white',
+        'ghost' => 'text-zinc-600/80 data-checked:text-zinc-800 dark:text-zinc-300/80 dark:data-checked:text-white',
         'subtle' => join(' ', [
-            'text-zinc-400 hover:text-zinc-500 data-checked:text-zinc-500 data-checked:hover:text-zinc-800',
+            'text-zinc-500 hover:text-zinc-500 data-checked:text-zinc-600 data-checked:hover:text-zinc-800',
             'dark:text-zinc-400/80 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',
         ])
     })

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -27,13 +27,13 @@ $square = $slot->isEmpty();
 
 $iconClasses = Flux::classes()
     ->add(match ($variant) {
-        'outline' => 'text-zinc-500 dark:text-white in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'filled' => 'text-zinc-500 dark:text-white in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
-        'ghost' => 'text-zinc-500 dark:text-white in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'outline' => 'text-zinc-500 dark:text-zinc-300 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'filled' => 'text-zinc-500 dark:text-zinc-300 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
+        'ghost' => 'text-zinc-500 dark:text-zinc-300 in-data-checked:text-(--color-accent-content) dark:in-data-checked:text-(--color-accent-content)',
         'subtle' => join(' ', [
             'text-zinc-400 group-hover:text-zinc-500 in-data-checked:text-zinc-500 in-data-checked:group-hover:text-zinc-800',
-            'dark:text-zinc-400 dark:group-hover:text-white dark:in-data-checked:text-white dark:in-data-checked:group-hover:text-white',
-        ]),
+            'dark:text-zinc-500 dark:group-hover:text-zinc-300 dark:in-data-checked:text-zinc-400 dark:in-data-checked:group-hover:text-white',
+        ])
     })
     ->add($square && $size !== 'xs' ? 'size-5' : 'size-4')
     ->add($attributes->pluck('icon:class'))
@@ -66,10 +66,10 @@ $classes = Flux::classes()
         'subtle' => 'bg-transparent hover:bg-zinc-800/5 dark:hover:bg-white/15',
     })
     ->add(match ($variant) { // Text color...
-        'outline' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white dark:data-checked:text-white',
-        'filled' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white dark:data-checked:text-white',
-        'ghost' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-white dark:data-checked:text-white',
-        'subtle' => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-white',
+        'outline' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-zinc-200 dark:data-checked:text-white',
+        'filled' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-zinc-200 dark:data-checked:text-white',
+        'ghost' => 'text-zinc-700 data-checked:text-zinc-800 dark:text-zinc-200 dark:data-checked:text-white',
+        'subtle' => 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-300 dark:data-checked:text-zinc-400 dark:data-checked:hover:text-white',
     })
     ->add(match ($variant) {
         'outline' => 'border border-zinc-200 hover:border-zinc-200 border-b-zinc-300/80 dark:border-zinc-600 dark:hover:border-zinc-600',


### PR DESCRIPTION
# The scenario

1. Text colors don't match button

<img width="1458" height="446" alt="SCR-20260814-rler" src="https://github.com/user-attachments/assets/e3e16cc2-1062-42c9-b2b2-b2ce6bda1b57" />

2. No indication of toggle during hover on outline icons

https://github.com/user-attachments/assets/d937e1b9-d559-40f0-8cfc-d4a72a116965

# The problem

1. Toggle applies different text color from button

| Variant | Toggle | Button |
|---|---|---|
| Filled | `text-zinc-600`<br>`dark:text-zinc-300` | `text-zinc-800`<br>`dark:text-white` |
| Outline | `text-zinc-600`<br>`dark:text-zinc-300` | `text-zinc-800`<br>`dark:text-white` |
| Ghost | `text-zinc-600`<br>`dark:text-zinc-300` | `text-zinc-800`<br>`dark:text-white` |
| Subtle | `text-zinc-600`<br>`dark:text-zinc-300`<br><br><br> | `text-zinc-500`<br>`dark:text-zinc-400`<br>`hover:text-zinc-800`<br>`dark:hover:text-white` |

2. When the toggle is hovered, it applies the same color to the icon as when it's checked

```
data-checked:text-(--color-accent-content)
data-checked:hover:text-(--color-accent-content)
```

# The solution

 https://flux-toggle-comparison-production-wlmfyz.laravel.cloud

<img width="891" height="549" alt="SCR-20260814-rtas" src="https://github.com/user-attachments/assets/c0b2219a-20a3-43b4-ab16-e6aa67db24b5" />
