### PR TITLE
Align dropdown triggers in flex layouts

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -144,6 +144,7 @@ Custom element display rules...
 */
 @layer base {
     ui-button { display: block; }
+    ui-dropdown { display: inline-flex; }
     ui-label { display: inline-block; cursor: default; }
     ui-description { display: block; }
     ui-legend { display: block; }


### PR DESCRIPTION
# The scenario

A small dropdown trigger placed alongside other `size="sm"` controls in an `items-center` flex row renders one device pixel higher than its neighbors.

```blade
<div class="flex items-center gap-2">
    <flux:date-picker size="sm" />
    <flux:select size="sm" variant="listbox">...</flux:select>

    <flux:dropdown>
        <flux:button size="sm" icon="ellipsis-horizontal" />
        <flux:menu>...</flux:menu>
    </flux:dropdown>
</div>
```

# The problem

`ui-dropdown` has no default display rule. Its `inline-flex` trigger therefore participates in an inline formatting context inside the host, producing a `32.5px` dropdown wrapper around the `32px` trigger. Flex centering places neighboring `32px` controls at a fractional offset while the dropdown trigger stays aligned to the top of its taller wrapper.

Before the fix:

- dropdown wrapper: `32.5px`
- dropdown trigger: `32px`
- neighboring controls: `32px`, offset by `0.25px`

# The solution

Give `ui-dropdown` an `inline-flex` default in Flux's existing custom-element display rules.

```css
ui-dropdown { display: inline-flex; }
```

This removes the anonymous inline line box while preserving an atomic, styleable host. The rule lives in the base layer, so display utilities such as `hidden`, `block`, and `flex` can still override it.

After the fix, the dropdown wrapper, trigger, date picker, and select are all exactly `32px` tall and share the same top and bottom coordinates.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1084" height="930" alt="Dropdown trigger misaligned before the fix" src="https://github.com/user-attachments/assets/9ad2bb9b-466f-4cab-a6b6-f3fe04a990c9" /> | <img width="1084" height="930" alt="Dropdown trigger aligned after the fix" src="https://github.com/user-attachments/assets/f5607fee-8525-4895-94cd-3090415cb3f6" /> |

## Validation

- Verified the aligned dimensions in the Flux docs analytics demo.
- Verified opening and closing the dropdown.
- Verified the menu remains anchored to the trigger with the expected `5px` gap.
- `git diff --check`
