### PR TITLE
Prevent hover when toggle is disabled

### DIFF
--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -33,7 +33,7 @@ $iconClasses = Flux::classes()
 $classes = Flux::classes()
     ->add('group relative inline-flex items-center font-medium justify-center whitespace-nowrap outline-offset-2')
     ->add('transition select-none touch-manipulation')
-    ->add('[&[disabled]]:opacity-75 dark:[&[disabled]]:opacity-75 [&[disabled]]:cursor-default')
+    ->add('[&[disabled]]:opacity-75 dark:[&[disabled]]:opacity-75 [&[disabled]]:cursor-default [&[disabled]]:pointer-events-none')
     ->add(match ($size) {
         'base' => 'h-10 text-sm rounded-lg gap-2' . ' ' . ($square ? 'w-10' : ($icon ? 'ps-3 pe-4' : 'px-4')),
         'sm' => 'h-8 text-sm rounded-md gap-2' . ' ' . ($square ? 'w-8' : ($icon ? 'ps-2 pe-3' : 'px-3')),


### PR DESCRIPTION
# The scenario

Disabled toggle still receives hover:

https://github.com/user-attachments/assets/423656f2-0e1d-45cf-9584-d03b40829500

# The problem

Wasn't implemented

# The solution

Add `pointer-events-none` when disabled (matching button) 

_Tooltip will continue to work even when disabled_

https://github.com/user-attachments/assets/71c67a9f-daf0-4f34-a93a-ba18d34bdf85

