### PR TITLE
Fix toggle/button tooltip trigger area

### DIFF
--- a/stubs/resources/views/flux/with-tooltip.blade.php
+++ b/stubs/resources/views/flux/with-tooltip.blade.php
@@ -19,7 +19,7 @@ extract(Flux::forwardedAttributes($attributes, [
 ])
 
 <?php if ($tooltip): ?>
-    <flux:tooltip :content="$tooltip" :position="$tooltipPosition" :kbd="$tooltipKbd">
+    <flux:tooltip class="inline-flex" :content="$tooltip" :position="$tooltipPosition" :kbd="$tooltipKbd">
         {{ $slot }}
     </flux:tooltip>
 <?php else: ?>


### PR DESCRIPTION
# The scenario

```blade
<flux:toggle tooltip="Fast mode" disabled />
```

When a toggle or a button with a `tooltip` prop is disabled, the tooltip trigger area doesn't cover the full height.

https://github.com/user-attachments/assets/6db5e3bc-7332-4106-a15d-199b55d6ed89

# The problem

Because the button is disabled and doesn't receive pointer events, only the area of the tooltip is hoverable.

The problem is that `ui-tooltip` doesn't span the full height because it has no display rules and defaults to `display: inline`. Inline elements get their height based on the line height and do not expand to fit their children.

<img width="804" height="312" alt="SCR-20260816-nmfn" src="https://github.com/user-attachments/assets/88b68209-51b4-4980-8cf2-a96373efaad3" />

# The solution

The solution is to apply `display: inline-flex` to `ui-tooltip`. This makes the tooltip expand to fit its children while still participating in inline formatting.

https://github.com/user-attachments/assets/8469a5e1-6d14-4d7e-8b13-b361c2da375c

# Notes

This PR only fixes `<flux:with-tooltip>` and not `<flux:tooltip>` to avoid breaking changes
