### PR TITLE
Add `-webkit-user-select: none`

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -155,14 +155,14 @@ Custom element display rules...
     ui-empty { display: block; cursor: default; }
     ui-pillbox { display: block; }
     ui-checkbox-group { display: block; }
-    ui-checkbox { display: inline-block; user-select: none; }
-    ui-switch { display: inline-block; user-select: none; }
+    ui-checkbox { display: inline-block; user-select: none; -webkit-user-select: none; }
+    ui-switch { display: inline-block; user-select: none; -webkit-user-select: none; }
     ui-radio-group { display: block; }
-    ui-radio { display: inline-block; user-select: none; }
+    ui-radio { display: inline-block; user-select: none; -webkit-user-select: none; }
     ui-date-picker { display: block; }
     ui-time-picker { display: block; }
     ui-calendar { display: block; }
-    ui-calendar-preset, ui-calendar-previous, ui-calendar-next, ui-calender-next { display: block; user-select: none; }
+    ui-calendar-preset, ui-calendar-previous, ui-calendar-next, ui-calender-next { display: block; user-select: none; -webkit-user-select: none; }
     ui-menu[popover]:popover-open { display: block; }
     ui-menu[popover].\:popover-open { display: block; }
     ui-menu-checkbox, ui-menu-radio { cursor: default; display: contents; }

--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -32,7 +32,7 @@ $iconClasses = Flux::classes()
 
 $classes = Flux::classes()
     ->add('group relative inline-flex items-center font-medium justify-center whitespace-nowrap outline-offset-2')
-    ->add('transition select-none touch-manipulation')
+    ->add('transition touch-manipulation')
     ->add('[&[disabled]]:opacity-75 dark:[&[disabled]]:opacity-75 [&[disabled]]:cursor-default')
     ->add(match ($size) {
         'base' => 'h-10 text-sm rounded-lg gap-2' . ' ' . ($square ? 'w-10' : ($icon ? 'ps-3 pe-4' : 'px-4')),


### PR DESCRIPTION
# The problem

Safari doesn't support `user-select: none` without a `-webkit` prefix.

In https://github.com/livewire/flux/pull/2738 we had to add `select-none` class to force the default cursor on toggle, despite the `ui-switch` already applying `user-select: none` in the default css rules. The reason was that the bug was limited to Safari. Because the `select-none` tailwind class applies the rule with the webkit prefix, this fixed the issue. However the fix really belongs to the css file.

# The solution

1. Add `-webkit-user-select: none` to all default CSS rules where we have `user-select: none`
2. Remove `select-none` from toggle