### PR TITLE
Fix tooltip display

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -174,6 +174,7 @@ Custom element display rules...
     ui-editor-content { display: block; }
     ui-progress { display: block; }
     ui-carousel, ui-carousel-track, ui-carousel-slide { display: block; }
+    ui-tooltip { display: inline-flex; }
 }
 
 /**


### PR DESCRIPTION
**This is a breaking change**

https://github.com/livewire/flux/pull/2743 fixes the `tooltip` prop, this PR fixes `<flux:tooltip>`

# The scenario

```blade
<flux:tooltip content="Fast mode">
    <flux:toggle disabled />
</flux:tooltip>
```

When a disabled toggle or a button is wrapped inside of a tooltip, the trigger area doesn't cover the full height.

https://github.com/user-attachments/assets/6db5e3bc-7332-4106-a15d-199b55d6ed89

# The problem

Because the button is disabled and doesn't receive pointer events, only the area of the tooltip is hoverable.

The problem is that `ui-tooltip` doesn't span the full height because it has no display rules and defaults to `display: inline`. Inline elements get their height based on the line height and do not expand to fit their children.

<img width="804" height="312" alt="SCR-20260816-nmfn" src="https://github.com/user-attachments/assets/88b68209-51b4-4980-8cf2-a96373efaad3" />

# The solution

The solution is to apply `display: inline-flex` to ui-tooltip. This makes the tooltip expand to fit its children while still participating in inline formatting.

https://github.com/user-attachments/assets/8469a5e1-6d14-4d7e-8b13-b361c2da375c

# Breaking change

As we don't control the contents of `<flux:tooltip>` this change might be breaking because:

1. Inline children loose horizontal whitespace
2. Block children stack horizontally
3. Children become stretched vertically
4. Text contents no longer break across new lines

Which assumes a user-land code with multiple elements:

```blade
<flux:tooltip>
    <div>...</div>
    <div>...</div>
    {{-- or --}}
    <span>...</span>
    <span>...</span>
</flux:tooltip>
```

or with a tooltip used inline:

```blade
<p>...<flux:tooltip><span>...</span></flux:tooltip>...</p>
```

# Alternative

I have considered `inline-block` instead of `inline-flex`.

This would fix the height issue without forcing all children to use flex layout, making it less breaking.

However it would still be breaking for inline tooltip as `inline-block` cannot break across new lines, whereas `inline` can. Also, by preserving the inline flow of children, there might be whitespace issues such as https://github.com/livewire/flux/pull/2741. Therefore I believe `inline-flex` is a superior solution for a tooltip that most commonly contains a button.