### PR TITLE
Allow utility classes to override Card and Progress defaults

### DIFF
--- a/stubs/resources/views/flux/card/index.blade.php
+++ b/stubs/resources/views/flux/card/index.blade.php
@@ -7,7 +7,7 @@
 @php
 $classes = Flux::classes()
     ->add('[:where(&)]:bg-white dark:[:where(&)]:bg-white/10')
-    ->add('border border-zinc-200 dark:border-white/10')
+    ->add('border [:where(&)]:border-zinc-200 dark:[:where(&)]:border-white/10')
     ->add(match ($size) {
         default => '[:where(&)]:p-6 [:where(&)]:rounded-xl',
         'sm' => '[:where(&)]:p-4 [:where(&)]:rounded-lg',

--- a/stubs/resources/views/flux/progress.blade.php
+++ b/stubs/resources/views/flux/progress.blade.php
@@ -6,7 +6,7 @@
 
 @php
 $trackClasses = Flux::classes()
-    ->add('h-1.5 relative w-full overflow-hidden bg-zinc-200 dark:bg-white/10')
+    ->add('[:where(&)]:h-1.5 relative w-full overflow-hidden [:where(&)]:bg-zinc-200 dark:[:where(&)]:bg-white/10')
     ->add('[print-color-adjust:exact]')
     ->add('rounded-full')
     ->add(match ($color) {


### PR DESCRIPTION
## Summary

- lower the specificity of Card’s default border colors
- lower the specificity of Progress’s default height and track colors
- keep structural classes such as `border`, `relative`, `w-full`, and `overflow-hidden` at normal specificity

## Why

These are presentational defaults, so consumers should be able to replace them with ordinary Tailwind utilities instead of reaching for the important modifier. This follows the existing `[:where(&)]` pattern already used by Card backgrounds, padding, and other overridable Flux defaults.

## Testing

- rendered the analytics demo against this checkout
- verified Card border/background overrides and 4px Progress track overrides in computed styles
- visually checked the demo at 1200px and 320px