### PR TITLE
Allow prefix on select variants

### DIFF
--- a/stubs/resources/views/flux/select/index.blade.php
+++ b/stubs/resources/views/flux/select/index.blade.php
@@ -1,6 +1,6 @@
 @blaze(fold: true, unsafe: [
     // variant props
-    'name', 'placeholder', 'invalid', 'size', 'clear', 'close',
+    'name', 'placeholder', 'prefix', 'invalid', 'size', 'clear', 'close',
     'selectedSuffix', 'searchable', 'clearable', 'button', 'input', 'trigger', 'search', 'empty', 'multiple',
     // flux:with-field props
     'name', 'label', 'badge',


### PR DESCRIPTION
## What changed

Allows the `prefix` prop through the top-level select delegate so a select variant can consume it.

## Why

The Flux Pro listbox implementation renders the persistent prefix inside its existing button trigger, but the public prop is otherwise filtered before reaching the variant.

This companion change does not alter the native select UI or behavior.

Listbox implementation: [livewire/flux-pro#554](https://github.com/livewire/flux-pro/pull/554)

## Screenshots

<img width="1200" height="675" alt="Persistent prefix shown in light and dark listbox select triggers" src="https://github.com/user-attachments/assets/cacc95f5-393c-4b75-8013-0ee59d73be04" />

<img width="1200" height="675" alt="Listbox prefix across trigger sizes, states, and constrained widths" src="https://github.com/user-attachments/assets/a70f7328-2b5d-414c-9fd4-d31a490eec11" />

## Validation

- `git diff --check`
- Flux Pro focused Playwright coverage for prefix persistence and long-value clipping
