### PR TITLE
Add soft card variant

### DIFF
--- a/stubs/resources/views/flux/card/index.blade.php
+++ b/stubs/resources/views/flux/card/index.blade.php
@@ -1,13 +1,17 @@
 @blaze(fold: true)
 
 @props([
+    'variant' => 'outline',
     'size' => null,
 ])
 
 @php
 $classes = Flux::classes()
-    ->add('[:where(&)]:bg-white dark:[:where(&)]:bg-white/10')
-    ->add('border border-zinc-200 dark:border-white/10')
+    ->add('border')
+    ->add(match ($variant) {
+        'soft' => '[:where(&)]:bg-black/[0.02] border-black/[0.025] dark:[:where(&)]:bg-white/[0.06] dark:border-white/[0.065]',
+        default => '[:where(&)]:bg-white border-zinc-200 dark:[:where(&)]:bg-white/10 dark:border-white/10',
+    })
     ->add(match ($size) {
         default => '[:where(&)]:p-6 [:where(&)]:rounded-xl',
         'sm' => '[:where(&)]:p-4 [:where(&)]:rounded-lg',


### PR DESCRIPTION
## Summary

- add a `soft` Card variant for a lower-emphasis surface
- preserve `outline` as the default Card treatment
- use translucent neutral overlays so the surface adapts to light, dark, and tinted backdrops

## Why

An opaque `zinc-50/100` treatment looks right on a white page, but can disappear when it is placed on the same zinc surface and can become visually inverted on darker zinc backgrounds.

The `soft` variant uses translucent black overlays in light mode and white overlays in dark mode. On the base background, these are tuned to visually match the original opaque treatment; on other backgrounds, they retain the backdrop hue while maintaining a consistent surface relationship.

## Screenshots

| Light | Dark |
| --- | --- |
| <img width="495" height="272" alt="Outline, opaque reference, and soft cards across light backdrops" src="https://github.com/user-attachments/assets/fd996984-cb38-46a8-843c-f7e67980cb0c" /> | <img width="495" height="272" alt="Outline, opaque reference, and soft cards across dark backdrops" src="https://github.com/user-attachments/assets/2a12ec63-7847-4e98-b2db-8f58f2b4d176" /> |

## Validation

- `composer validate --no-check-publish`
- interactively verified `outline`, the opaque reference treatment, and `soft` across white/zinc/blue backdrops in light and dark mode
- compared rendered screenshot pixels on the base backdrop: exact light fill/border match, exact dark border match, and a one-value dark fill difference
