### PR TITLE
Give file uploads a block-level host

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -154,6 +154,7 @@ Custom element display rules...
     ui-option-empty { display: block; cursor: default; }
     ui-empty { display: block; cursor: default; }
     ui-pillbox { display: block; }
+    ui-file-upload { display: block; }
     ui-checkbox-group { display: block; }
     ui-checkbox { display: inline-block; user-select: none; }
     ui-switch { display: inline-block; user-select: none; }


### PR DESCRIPTION
## What

Define ui-file-upload as a block-level custom-element host in the shared base layer.

## Why

flux:file-upload is a structural field root: it receives consumer attributes and classes, and owns a hidden native input plus a full-width dropzone. Without an explicit display it falls back to inline, so the rendered child can look correct while the public host does not provide a reliable structural box for width, padding, background, containment, or measurement.

Keeping the rule in @layer base establishes the semantic default without preventing consumer utilities from overriding it.

This is the structural-root counterpart to the ui-tooltip inline-flex classification already proposed in #2746.

## Verification

- Rebuilt the Flux docs display-policy playground against this branch.
- Confirmed the live host audit changes ui-file-upload from inline to block.
- Confirmed the host has a non-zero, non-fractional box around the dropzone.
- Confirmed a consumer inline-block utility overrides the base-layer default.
- composer validate --no-check-publish --no-interaction
- git diff --check