### PR TITLE
Support interactive sidebar brands

### DIFF
--- a/stubs/resources/views/flux/menu/item.blade.php
+++ b/stubs/resources/views/flux/menu/item.blade.php
@@ -29,7 +29,7 @@ $trailingIconClasses = Flux::classes()
     ;
 
 $classes = Flux::classes()
-    ->add('flex items-center px-2 py-1.5 w-full focus:outline-hidden')
+    ->add('flex items-center px-2 py-1.5 w-full focus:outline-hidden select-none')
     ->add('rounded-md')
     ->add('text-start text-sm font-medium')
     ->add('[&[disabled]]:opacity-50')

--- a/stubs/resources/views/flux/sidebar/brand.blade.php
+++ b/stubs/resources/views/flux/sidebar/brand.blade.php
@@ -1,29 +1,43 @@
-@blaze(fold: true, unsafe: ['logo:dark'])
+@blaze(fold: true, unsafe: ['logo:dark', 'icon:trailing', 'icon:variant'])
 
 @php $logoDark ??= $attributes->pluck('logo:dark'); @endphp
+@php $iconTrailing ??= $attributes->pluck('icon:trailing'); @endphp
+@php $iconVariant ??= $attributes->pluck('icon:variant'); @endphp
 
 @props([
+    'iconTrailing' => null,
+    'iconVariant' => 'micro',
     'name' => null,
     'logo' => null,
     'logoDark' => null,
     'alt' => null,
     'href' => '/',
+    'as' => null,
 ])
 
 @php
+$href = $as === 'button' ? null : $href;
+
 $classes = Flux::classes()
     ->add('h-10 min-w-0 flex items-center px-2 in-data-flux-sidebar-collapsed-desktop:w-10 in-data-flux-sidebar-collapsed-desktop:px-0 in-data-flux-sidebar-collapsed-desktop:justify-center')
     ->add('in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:absolute')
     ->add('in-data-flux-sidebar-collapsed-desktop:in-data-flux-sidebar-active:opacity-0')
+    ->add($as === 'button' ? 'group select-none rounded-lg hover:bg-zinc-800/5 in-data-open:bg-zinc-800/5 dark:hover:bg-white/15 dark:in-data-open:bg-white/15' : '')
     ;
 
 $textClasses = Flux::classes()
     ->add('min-w-0 text-sm font-medium truncate [:where(&)]:text-zinc-800 dark:[:where(&)]:text-zinc-100')
     ;
+
+$iconClasses = Flux::classes()
+    ->add('shrink-0 text-zinc-400 group-hover:text-zinc-800 in-data-open:text-zinc-800 dark:text-white/80 dark:group-hover:text-white dark:in-data-open:text-white')
+    ->add('in-data-flux-sidebar-collapsed-desktop:hidden')
+    ->add($iconVariant === 'outline' ? 'size-4' : '')
+    ;
 @endphp
 
 <?php if ($name): ?>
-    <a href="{{ $href }}" {{ $attributes->class([ $classes, 'gap-2' ]) }} data-flux-sidebar-brand>
+    <flux:button-or-link-pure :$as :$href :attributes="$attributes->class([ $classes, 'gap-2' ])" data-flux-sidebar-brand>
         <?php if ($logo instanceof \Illuminate\View\ComponentSlot): ?>
             <div {{ $logo->attributes->class('flex items-center justify-center [:where(&)]:h-6 [:where(&)]:min-w-6 [:where(&)]:rounded-sm overflow-hidden shrink-0') }}>
                 {{ $logo }}
@@ -42,9 +56,15 @@ $textClasses = Flux::classes()
         <?php endif; ?>
 
         <div class="{{ $textClasses }} in-data-flux-sidebar-collapsed-desktop:hidden">{{ $name }}</div>
-    </a>
+
+        <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
+            <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$iconClasses" />
+        <?php elseif ($iconTrailing): ?>
+            {{ $iconTrailing }}
+        <?php endif; ?>
+    </flux:button-or-link-pure>
 <?php else: ?>
-    <a href="{{ $href }}" {{ $attributes->class($classes) }} data-flux-sidebar-brand>
+    <flux:button-or-link-pure :$as :$href :attributes="$attributes->class($classes)" data-flux-sidebar-brand>
         <?php if ($logo instanceof \Illuminate\View\ComponentSlot): ?>
             <div {{ $logo->attributes->class('flex items-center justify-center [:where(&)]:h-6 [:where(&)]:min-w-6 [:where(&)]:rounded-sm overflow-hidden shrink-0') }}>
                 {{ $logo }}
@@ -61,5 +81,11 @@ $textClasses = Flux::classes()
                 <?php endif; ?>
             </div>
         <?php endif; ?>
-    </a>
+
+        <?php if (is_string($iconTrailing) && $iconTrailing !== ''): ?>
+            <flux:icon :icon="$iconTrailing" :variant="$iconVariant" :class="$iconClasses" />
+        <?php elseif ($iconTrailing): ?>
+            {{ $iconTrailing }}
+        <?php endif; ?>
+    </flux:button-or-link-pure>
 <?php endif; ?>


### PR DESCRIPTION
## Summary

- allow `flux:sidebar.brand` to render as a button via `as="button"`
- add trailing icon support for dropdown indicators
- give button brands hover and dropdown-open treatments while preserving the existing link default
- prevent text selection on interactive brands and menu items

## Why

Analytics and multi-property apps commonly use the sidebar brand as a property switcher. Previously the brand always rendered an anchor, so composing it as a dropdown trigger caused unwanted navigation and provided no trailing indicator or persistent open state. Rapid clicks could also select trigger or menu-item text.

The component can now be composed directly:

```blade
<flux:dropdown>
    <flux:sidebar.brand
        as="button"
        :name="$property"
        logo="/logo.png"
        icon:trailing="chevron-down"
    />

    <flux:menu>...</flux:menu>
</flux:dropdown>
```

## Validation

- `php -l stubs/resources/views/flux/sidebar/brand.blade.php`
- `php -l stubs/resources/views/flux/menu/item.blade.php`
- `git diff --check`
- exercised in the local analytics demo: button semantics, hover/open styling, menu navigation, and repeated toggling without text selection
