### PR TITLE
Restore navbar action proportions

### DIFF
--- a/stubs/resources/views/flux/navbar/index.blade.php
+++ b/stubs/resources/views/flux/navbar/index.blade.php
@@ -7,7 +7,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('flex items-center gap-1 py-3')
+    ->add('flex items-center gap-0.5 py-3')
     ->add($scrollable ? ['overflow-x-auto overflow-y-hidden'] : [])
     ;
 @endphp

--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -21,13 +21,12 @@
 // Button should be a square if it has no text contents...
 $square ??= $slot->isEmpty();
 
-// Size-up icons in square/icon-only buttons...
-$iconClasses = Flux::classes($square ? 'size-6' : 'size-5');
+$iconClasses = Flux::classes('size-5');
 
 $classes = Flux::classes()
     ->add('px-3 h-8 flex items-center rounded-lg')
     ->add('relative') // This is here for the "active" bar at the bottom to be positioned correctly...
-    ->add($square ? 'px-2!' : '')
+    ->add($square ? 'h-10! px-2.5!' : '')
     ->add('text-zinc-500 dark:text-white/80 ')
     // Styles for when this link is the "current" one...
     ->add('data-current:after:absolute data-current:after:-bottom-3 data-current:after:inset-x-0 data-current:after:h-[2px]')


### PR DESCRIPTION
## Summary

- render icon-only navbar actions as 40px squares
- use 20px icons instead of enlarging them to 24px
- reduce the gap between navbar items from 4px to 2px

## Why

[#2694](https://github.com/livewire/flux/pull/2694) corrected icon-only navbar items from 48px to 40px wide, but intentionally retained the enlarged 24px icon and the existing 32px height. That fixes the width without restoring the proportions of the original Flux design.

Hugo's original Flux demo is the clearest design-system reference: [Figma node 2208:138391](https://www.figma.com/design/jNmtbQkGIt9xYwcBc5FL2o/Flux--With-Filip-?node-id=2208-138391).

| Measurement | Current | This PR | Original design |
| --- | ---: | ---: | ---: |
| Icon | 24px | 20px | 20px |
| Icon-only action | 40×32px | 40×40px | 40×40px |
| Item gap | 4px | 2px | 2px |

Navbar items containing text keep their existing 20px icons and 32px height.

## Validation

- `php -l stubs/resources/views/flux/navbar/item.blade.php`
- `php -l stubs/resources/views/flux/navbar/index.blade.php`
- `git diff --check`
- rendered the local analytics demo and confirmed the three icon-only actions emit the 20px icon, 40px action, and 2px gap classes
