### PR TITLE
Add contained prop to table

### DIFF
--- a/stubs/resources/views/flux/table/cell.blade.php
+++ b/stubs/resources/views/flux/table/cell.blade.php
@@ -8,7 +8,9 @@
 
 @php
 $classes = Flux::classes()
-    ->add('[:where(&)]:py-3 [:where(&)]:px-3 first:ps-0 last:pe-0 text-sm')
+    ->add('text-sm [:where(&)]:py-3 [:where(&)]:px-3')
+    // Remove outer padding on first and last column unless the table is `contained`...
+    ->add('not-in-data-flux-table-contained:first:[:where(&)]:ps-0 not-in-data-flux-table-contained:last:[:where(&)]:pe-0')
     ->add(match($align) {
         'center' => 'text-center [&>*]:mx-auto',
         'end' => 'text-end [&>*]:ms-auto',

--- a/stubs/resources/views/flux/table/column.blade.php
+++ b/stubs/resources/views/flux/table/column.blade.php
@@ -10,7 +10,9 @@
 
 @php
 $classes = Flux::classes()
-    ->add('py-3 px-3 first:ps-0 last:pe-0')
+    ->add('[:where(&)]:py-3 [:where(&)]:px-3')
+    // Remove outer padding on first and last column unless the table is `contained`...
+    ->add('not-in-data-flux-table-contained:first:[:where(&)]:ps-0 not-in-data-flux-table-contained:last:[:where(&)]:pe-0')
     ->add('text-start text-sm font-medium text-zinc-800 dark:text-white')
     ->add('border-b border-zinc-800/10 dark:border-white/20')
     ->add(match($align) {

--- a/stubs/resources/views/flux/table/index.blade.php
+++ b/stubs/resources/views/flux/table/index.blade.php
@@ -1,6 +1,7 @@
 @blaze(fold: true)
 
 @props([
+    'contained' => false,
     'paginate' => null,
 ])
 
@@ -22,7 +23,7 @@ $containerClasses = Flux::classes()
     {{ $header ?? '' }}
 
     <ui-table-scroll-area class="overflow-auto">
-        <table {{ $attributes->class($classes) }} data-flux-table>
+        <table {{ $attributes->class($classes) }} data-flux-table {{ $contained ? 'data-flux-table-contained' : '' }}>
             {{ $slot }}
         </table>
     </ui-table-scroll-area>


### PR DESCRIPTION
# The scenario

When a table is used inside a bordered container like card, its columns are pushed towards the outer edges:

```blade
<flux:card class="p-0">
    <flux:table>
        ...
    </flux:table>
</flux:card>
```

<img width="764" height="352" alt="SCR-20260820-njbs" src="https://github.com/user-attachments/assets/d15c3a94-28e6-4528-a468-ebb9a13d31d5" />

# The problem

Table columns and cells automatically remove the padding from first and last column:

```
...first:ps-0 last:pe-0...
```

To override this, the the original padding needs to be added back individually with an important modifier:

```blade
<flux:table.columns>
    <flux:table.column class="ps-3!">...</flux:table.column>
    ...
    <flux:table.column class="pe-3!">...</flux:table.column>
</flux:table.column>

<flux:table.rows>
    <flux:table.cell class="ps-3!">...</flux:table.cell>
    ...
    <flux:table.cell class="pe-3!">...</flux:table.cell>
</flux:table.rows>
```

# The solution

1. Add `contained` prop:

<img width="867" height="702" alt="SCR-20260820-nous" src="https://github.com/user-attachments/assets/dfaa9694-eb9d-4ade-b967-711392d22691" />

2. Add `[:where(&)]` to all padding classes to allow overriding them without important modifier

---

Docs: https://github.com/livewire/flux-docs/pull/200