### PR TITLE
Fix navbar active indicator alignment

### DIFF
--- a/stubs/resources/views/flux/navbar/index.blade.php
+++ b/stubs/resources/views/flux/navbar/index.blade.php
@@ -7,7 +7,7 @@
 
 @php
 $classes = Flux::classes()
-    ->add('flex items-center gap-0.5 py-3')
+    ->add('flex h-14 items-center gap-0.5 py-3')
     ->add($scrollable ? ['overflow-x-auto overflow-y-hidden'] : [])
     ;
 @endphp

--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -29,7 +29,8 @@ $classes = Flux::classes()
     ->add($square ? 'h-10! px-2.5!' : '')
     ->add('text-zinc-500 dark:text-white/80 ')
     // Styles for when this link is the "current" one...
-    ->add('data-current:after:absolute data-current:after:-bottom-3 data-current:after:inset-x-0 data-current:after:h-[2px]')
+    ->add('data-current:after:absolute data-current:after:inset-x-0 data-current:after:h-[2px]')
+    ->add($square ? 'data-current:after:-bottom-2' : 'data-current:after:-bottom-3')
     ->add([
         '[--hover-fill:color-mix(in_oklab,_var(--color-accent-content),_transparent_90%)]',
 


### PR DESCRIPTION
# The scenario

A labeled navbar placed beside icon-only navbar actions can leave the active indicator floating above the header's bottom border.

```blade
<flux:header class="border-b border-zinc-200 dark:border-zinc-700">
    <flux:navbar class="-mb-px">
        <flux:navbar.item icon="home" href="#home" :current="true">
            Home
        </flux:navbar.item>
    </flux:navbar>

    <flux:spacer />

    <flux:navbar>
        <flux:navbar.item icon="cog-6-tooth" href="#settings" label="Settings" />
    </flux:navbar>
</flux:header>
```

# The problem

[#2753](https://github.com/livewire/flux/pull/2753) restored icon-only navbar items to `40×40`, while labeled items remain `32px` tall. With `py-3`, sibling navbars become `64px` and `56px` tall. The taller track also expands the header beyond its existing `56px` minimum.

The header centers the shorter navbar beside the taller one, leaving a measured `3.5px` gap between its `-bottom-3` active indicator and the header border at 100% zoom and DPR 2.

# The solution

Restore the `56px` navbar track in the reproduced header layouts:

```php
->add('flex h-14 items-center gap-0.5 py-3')
```

Then match the indicator offset to the item geometry:

```php
->add($square ? 'data-current:after:-bottom-2' : 'data-current:after:-bottom-3')
```

After a clean rebuild, the navbar tracks in the reproduced separate and mixed layouts measured `56px`, with indicator gaps within `1px` at 100% zoom and DPR 2. This preserves `40×40` icon-only items while aligning labeled and square indicators in those layouts.

## Screenshots

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/cb80c482-9185-486e-95ee-d403d99a4af3) | ![After](https://github.com/user-attachments/assets/38adbcf3-0acb-4fa6-817c-b9f275e19b62) |

## Validation

- Verified separate and mixed layouts in light and dark modes, plus the responsive state at a `900px` viewport.
- Verified vertical separators retain `my-2` and render at `16px`, while hover and keyboard focus remain visible.
- `git diff --check`

Fixes livewire/flux#2760
