### PR TITLE
Allow overriding the toggle icon variant

### DIFF
--- a/stubs/resources/views/flux/toggle.blade.php
+++ b/stubs/resources/views/flux/toggle.blade.php
@@ -1,10 +1,11 @@
 @blaze(fold: true, unsafe: [
-    'icon:class', 'on:icon', 'off:icon', 'on:label', 'off:label',
+    'icon:class', 'icon:variant', 'on:icon', 'off:icon', 'on:label', 'off:label',
     'tooltip:position', 'tooltip:kbd', 'tooltip',
 ])
 
 @php $onLabel ??= $attributes->pluck('on:label'); @endphp
 @php $offLabel ??= $attributes->pluck('off:label'); @endphp
+@php $iconVariant ??= $attributes->pluck('icon:variant'); @endphp
 @php $onIcon ??= $attributes->pluck('on:icon'); @endphp
 @php $offIcon ??= $attributes->pluck('off:icon'); @endphp
 
@@ -14,6 +15,7 @@
     'size' => 'base',
     'name' => null,
     'icon' => null,
+    'iconVariant' => 'solid',
     'label' => null,
     'color' => null,
     'inset' => null,
@@ -105,7 +107,7 @@ $classes = Flux::classes()
     <flux:with-tooltip :$attributes>
         <ui-switch {{ $attributes->class($classes) }} @if($showName) name="{{ $name }}" @endif @if($checked) checked data-checked @endif data-flux-control data-flux-toggle>
             <?php if ((is_string($icon) && $icon !== '') || $onIcon): ?>
-                <flux:icon :icon="$onIcon ?? $icon" variant="solid" :class="$iconClasses->add('hidden group-data-checked:block')" />
+                <flux:icon :icon="$onIcon ?? $icon" :variant="$iconVariant" :class="$iconClasses->add('hidden group-data-checked:block')" />
                 <flux:icon :icon="$offIcon ?? $onIcon ?? $icon" variant="outline" :class="$iconClasses->add('group-data-checked:hidden')" />
             <?php elseif ($icon): ?>
                 {{ $icon }}


### PR DESCRIPTION
# The scenario

Passing a Lucide icon to `<flux:toggle>` throws `The "solid" variant is not supported in Lucide.`

```bash
php artisan flux:icon shrink expand
```

```blade
<flux:toggle on:icon="shrink" off:icon="expand" />
```

Heroicons work, and the same Lucide icon renders fine in `flux:button` and `flux:badge`, so this is specific to `flux:toggle`.

# The problem

`stubs/resources/views/flux/toggle.blade.php` hardcodes the `solid` variant for the checked icon:

```blade
<flux:icon :icon="$onIcon ?? $icon" variant="solid" :class="$iconClasses->add('hidden group-data-checked:block')" />
<flux:icon :icon="$offIcon ?? $onIcon ?? $icon" variant="outline" :class="$iconClasses->add('group-data-checked:hidden')" />
```

The stub `flux:icon` generates for Lucide icons throws on any `solid` variant:

```php
if ($variant === 'solid') {
    throw new \Exception('The "solid" variant is not supported in Lucide.');
}
```

`flux:toggle` neither declares an `iconVariant` prop nor plucks `icon:variant`, so there is no way to opt out.

This is the same root cause as #2608 for `flux:file-upload.dropzone`, which was fixed by adding an overridable `iconVariant` prop. That fix never reached `toggle`.

# The solution

Mirror the dropzone fix: add an `iconVariant` prop defaulting to `solid`, overridable via `icon:variant`, and use it for the checked icon.

```blade
@blaze(fold: true, unsafe: [
    'icon:class', 'icon:variant', 'on:icon', 'off:icon', 'on:label', 'off:label',
    ...
])

@php $iconVariant ??= $attributes->pluck('icon:variant'); @endphp

@props([
    'icon' => null,
    'iconVariant' => 'solid',
    ...
])

<flux:icon :icon="$onIcon ?? $icon" :variant="$iconVariant" ... />
```

Lucide icons then work with:

```blade
<flux:toggle on:icon="shrink" off:icon="expand" icon:variant="outline" />
```

The default is unchanged, so Heroicon toggles keep their solid checked icon.

I rendered these through `Blade::render()` on Flux v2.17.0 before and after the change:

| Case | Before | After |
| --- | --- | --- |
| `icon="expand" icon:variant="outline"` (Lucide) | throws | renders, outline |
| `on:icon="shrink" off:icon="expand" icon:variant="outline"` (Lucide) | throws | renders, outline |
| `icon="moon"` (Heroicon, default) | renders, solid | renders, solid |
| `on:icon="moon" off:icon="sun"` (Heroicon) | renders, solid | renders, solid |
| `<flux:toggle>Wi-Fi</flux:toggle>` (label only) | renders | renders |
| `wire:model="x" icon="moon"` | renders, solid | renders, solid |

## Known limitation

This is opt-in, exactly like the dropzone fix: `<flux:toggle icon="shield-check" />` still throws unless `icon:variant="outline"` is passed. Falling back automatically would require knowing which icons lack a solid variant, which the stub can't determine. Happy to take a different approach if you'd prefer the fallback be automatic.

When both icons end up outline, the checked/unchecked distinction is still carried by the background and text color the component already applies.

Fixes livewire/flux#2762
