### PR TITLE
`flux:sidebar.item` defaults the tooltip to the slot, which may contain html

### DIFF
--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -20,7 +20,7 @@
 ])
 
 @php
-$tooltip ??= $slot->isNotEmpty() ? (string) $slot : null;
+$tooltip ??= $slot->isNotEmpty() ? strip_tags((string) $slot) : null;
 
 // Size-up icons in square/icon-only buttons...
 $iconClasses = Flux::classes('size-4')

--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -20,7 +20,11 @@
 ])
 
 @php
-$tooltip ??= $slot->isNotEmpty() ? strip_tags((string) $slot) : null;
+// Slots contain rendered HTML (including conditional comments) and encoded entities.
+// Tooltips should mirror only the visible text.
+$tooltip ??= $slot->isNotEmpty()
+    ? trim(html_entity_decode(strip_tags((string) $slot), ENT_QUOTES | ENT_HTML5, 'UTF-8'))
+    : null;
 
 // Size-up icons in square/icon-only buttons...
 $iconClasses = Flux::classes('size-4')


### PR DESCRIPTION
# The scenario

I'm using conditions in the slot of a `flux:sidebar.item`. When collapsing the sidebar the tooltip is shown. And when I don't set an explicit tooltip, it falls back to the slot. But since a tooltip is text-only it can't render html so well.

# The problem

```blade
@php($foo = 'bar')
<flux:sidebar.item icon="question-mark-circle" href="...">
    Support
    @if ($foo)
        {{ $foo }}
    @endif
</flux:sidebar.item>
```

With conditions Livewire actually outputs html comments, which end up in the tooltip.

<img width="458" height="80" alt="image" src="https://github.com/user-attachments/assets/3f951f01-12be-4f22-af0b-02c859428518" />

But other html would also break this.

<img width="243" height="80" alt="image" src="https://github.com/user-attachments/assets/a137dcf4-bf18-455c-a8f1-795d2ef0423d" />

# The solution

I've been trying to avoid using conditions in this way, e.g. `{{ 'Support ' . ($foo ?? '') }}`, but that feels a bit annoying.

Stripping html sounds like a good addition which prevents stuff which we should anyway never render in a tooltip because it is at least ugly.