### PR TITLE
Restore navbar action height

### DIFF
--- a/stubs/resources/views/flux/navbar/item.blade.php
+++ b/stubs/resources/views/flux/navbar/item.blade.php
@@ -26,7 +26,7 @@ $iconClasses = Flux::classes('size-5');
 $classes = Flux::classes()
     ->add('px-3 h-8 flex items-center rounded-lg')
     ->add('relative') // This is here for the "active" bar at the bottom to be positioned correctly...
-    ->add($square ? 'h-10! px-2.5!' : '')
+    ->add($square ? 'px-2.5!' : '')
     ->add('text-zinc-500 dark:text-white/80 ')
     // Styles for when this link is the "current" one...
     ->add('data-current:after:absolute data-current:after:-bottom-3 data-current:after:inset-x-0 data-current:after:h-[2px]')


### PR DESCRIPTION
## Summary

- restore icon-only navbar actions to 40×32
- keep the 20px icon and 2px navbar gap from #2753
- preserve the navbar's intrinsic height and existing indicator positioning

## Why

#2753 restored the original 40×40 design proportions, but the taller item combines with the navbar's vertical padding to create a 64px navbar beside 56px labeled navbars. That expands mixed headers and leaves the existing active indicator above the shared edge.

This restores the earlier 32px item height without undoing the corrected icon size or horizontal proportions. Both labeled and icon-only navbars are intrinsically 56px again, so no fixed navbar or header height is needed.

This supersedes #2761 with the narrower compatibility fix.

## Browser measurements

| Specimen | Action | Icon | Navbar | Indicator gap |
| --- | ---: | ---: | ---: | ---: |
| Icon-only | 40×32px | 20×20px | 56px | 0px |
| Mixed sibling navbars | 40×32px | 20×20px | 56px each | 0.5–1px |

## Validation

- `php -l stubs/resources/views/flux/navbar/item.blade.php`
- `git diff --check`
- local Laravel app tests: 2 passed
- local Vite production build
- real-browser verification of labeled-only, icon-only, and mixed sibling navbars
- browser console: no errors

Fixes #2760
