### PR TITLE
Add silent modal close option

### DIFF
--- a/src/Concerns/InteractsWithComponents.php
+++ b/src/Concerns/InteractsWithComponents.php
@@ -25,11 +25,11 @@ trait InteractsWithComponents
                     $component->dispatch('modal-show', name: $this->name, scope: $component->getId());
                 }
 
-                public function close()
+                public function close(bool $silent = false)
                 {
                     $component = app('livewire')->current();
 
-                    $component->dispatch('modal-close', name: $this->name, scope: $component->getId());
+                    $component->dispatch('modal-close', name: $this->name, scope: $component->getId(), silent: $silent);
                 }
             };
         });
@@ -45,9 +45,9 @@ trait InteractsWithComponents
                 app('livewire')->current()->dispatch('modal-show', name: $this->name);
             }
 
-            public function close()
+            public function close(bool $silent = false)
             {
-                app('livewire')->current()->dispatch('modal-close', name: $this->name);
+                app('livewire')->current()->dispatch('modal-close', name: $this->name, silent: $silent);
             }
         };
     }
@@ -55,9 +55,9 @@ trait InteractsWithComponents
     public function modals()
     {
         return new class {
-            public function close()
+            public function close(bool $silent = false)
             {
-                app('livewire')->current()->dispatch('modal-close');
+                app('livewire')->current()->dispatch('modal-close', silent: $silent);
             }
         };
     }


### PR DESCRIPTION
# The scenario

A backend `Flux::modal()->close()` emits the native dialog close event, so a modal with `wire:close` starts a second Livewire request. See #2770.

# The problem

There is no way for an action that already performed its cleanup to close the modal without invoking the close handler again from the browser.

# The solution

This draft spike adds an opt-in named argument:

```php
Flux::modal("confirm")->close(silent: true);
```

Normal `close()` calls keep their current behavior. The silent flag is forwarded with the browser event; livewire/flux-pro#563 suppresses the resulting close handlers for that one programmatic close.

This also keeps the component-scoped modal macro and `Flux::modals()` API consistent.

## Verification

- `php -l src/Concerns/InteractsWithComponents.php`
- End-to-end browser coverage in livewire/flux-pro#563: 17 focused/neighboring modal tests passed.
- Real Laravel playground confirmed one action request and no follow-up `wire:close` request.

Companion: livewire/flux-pro#563
Refs #2770