### PR TITLE
Add non-blocking modals

### DIFF
--- a/dist/flux.css
+++ b/dist/flux.css
@@ -50,7 +50,7 @@ Transition dialogs with fade a slight scale effect...
     transition: all 0.075s allow-discrete;
 }
 
-[data-flux-modal] > dialog:not([open]) {
+[data-flux-modal] > dialog:not([open]):not([data-open]) {
     display: none;
 }
 
@@ -58,26 +58,31 @@ Transition dialogs with fade a slight scale effect...
 
 [data-flux-modal] > dialog[data-flux-flyout] { transform: scale(1) var(--flux-flyout-translate, var(--fx-flyout-translate, translateX(50px))); }
 
-[data-flux-modal] > dialog[open], [data-flux-modal] > dialog[open]::backdrop {
+[data-flux-modal] > dialog[open], [data-flux-modal] > dialog[data-open], [data-flux-modal] > dialog[open]::backdrop, [data-flux-modal] > dialog[data-open]::backdrop {
     opacity: 1;
     transform: translateX(0) scale(1);
     transition: all 0.15s allow-discrete;
 }
 
 @starting-style {
-    [data-flux-modal] > dialog[open], [data-flux-modal] > dialog[open]::backdrop {
+    [data-flux-modal] > dialog[open], [data-flux-modal] > dialog[data-open], [data-flux-modal] > dialog[open]::backdrop, [data-flux-modal] > dialog[data-open]::backdrop {
         opacity: 0;
     }
 
-    [data-flux-modal] > dialog[open] {
+    [data-flux-modal] > dialog[open], [data-flux-modal] > dialog[data-open] {
         transform: scale(0.95);
     }
 
-    [data-flux-modal] > dialog[open][data-flux-flyout] { transform: scale(1) var(--flux-flyout-translate, var(--fx-flyout-translate, translateX(50px))); }
+    [data-flux-modal] > dialog[open][data-flux-flyout], [data-flux-modal] > dialog[data-open][data-flux-flyout] { transform: scale(1) var(--flux-flyout-translate, var(--fx-flyout-translate, translateX(50px))); }
 }
 
 [data-flux-modal] > dialog::backdrop {
     background-color: rgba(0, 0, 0, 0.10);
+}
+
+[data-flux-modal] > dialog[data-flux-nonblocking]::backdrop {
+    background-color: transparent;
+    pointer-events: none;
 }
 
 /*

--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -9,6 +9,7 @@
     'variant' => null,
     'scroll' => null,
     'flyout' => null,
+    'blocking' => true,
     'name' => null,
 ])
 
@@ -108,7 +109,7 @@ if (! $overflow) {
 }
 @endphp
 
-<ui-modal {{ $attributes }} data-flux-modal>
+<ui-modal {{ $attributes }} data-flux-modal <?php if (! $blocking): ?> nonblocking <?php endif; ?>>
     <?php if ($trigger): ?>
         {{ $trigger }}
     <?php endif; ?>
@@ -118,6 +119,7 @@ if (! $overflow) {
         {{ $dialogAttributes->class($classes) }}
         <?php if ($name): ?> data-modal="{{ $name }}" <?php endif; ?>
         <?php if ($flyout): ?> data-flux-flyout <?php endif; ?>
+        <?php if (! $blocking): ?> popover="manual" data-flux-nonblocking role="dialog" aria-modal="false" <?php endif; ?>
         <?php if ($overflow): ?> data-flux-modal-overflow <?php endif; ?>
         @unblaze(scope: ['name' => $name])
         x-data="fluxModal(@js($scope['name']), @js(isset($__livewire) ? $__livewire->getId() : null))"

--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -46,7 +46,8 @@ if ($flyout) {
             default => 'bg-white dark:bg-zinc-800 border-transparent dark:border-zinc-700',
             'floating' => 'bg-white dark:bg-zinc-800 ring ring-black/5 dark:ring-zinc-700 shadow-lg rounded-xl',
             'bare' => 'bg-transparent',
-        });
+        })
+        ->add(! $blocking && ! $variant ? 'ring ring-black/5 dark:ring-zinc-700 shadow-lg' : '');
 } elseif ($overflow) {
     $classes = Flux::classes();
 

--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -103,7 +103,7 @@ if ($escapable === false) {
 }
 
 [ $contentAttributes, $attributes ] = Flux::splitAttributes($attributes, ['autofocus', 'class', 'style']);
-[ $dialogAttributes, $attributes ] = Flux::splitAttributes($attributes, ['wire:close', 'x-on:close', 'wire:cancel', 'x-on:cancel']);
+[ $dialogAttributes, $attributes ] = Flux::splitAttributes($attributes, ['aria-label', 'aria-labelledby', 'aria-describedby', 'wire:close', 'x-on:close', 'wire:cancel', 'x-on:cancel']);
 
 if (! $overflow) {
     $dialogAttributes = $dialogAttributes->merge($contentAttributes->getAttributes());


### PR DESCRIPTION
# The scenario

Flyout inspectors sometimes need to remain open while users interact with the page behind them. A common example is selecting rows in a table and updating the details shown in the flyout.

Today, Flux modals always use the blocking dialog mode, which makes the document inert and prevents that interaction.

# The proposal

Add a `blocking` prop that defaults to `true` and can be disabled independently from dismissal behavior:

```blade
<flux:modal flyout :blocking="false" :dismissible="false" aria-label="Customer details">
    <!-- Selected item details... -->
</flux:modal>
```

`blocking` describes whether the rest of the page is interactive. `dismissible` continues to describe whether an outside interaction closes the modal.

# The solution

When `blocking` is false, the component renders its dialog as a manual popover with `role="dialog"` and `aria-modal="false"`. This keeps the flyout in the browser top layer without making the rest of the document inert.

The modal CSS now keys its visibility and transitions from either the native dialog `open` attribute or Flux state, gives non-blocking dialogs a transparent pointer-transparent backdrop, and adds the normal modal ring and shadow when there is no dimmed backdrop.

Accessible-name and description attributes are forwarded to the actual dialog element.

Companion PRs:

- Flux Pro behavior and browser coverage: https://github.com/livewire/flux-pro/pull/566
- Documentation and working inspector example: https://github.com/livewire/flux-docs/pull/209