### PR TITLE
Add table bleed prop

### DIFF
--- a/stubs/resources/views/flux/card/index.blade.php
+++ b/stubs/resources/views/flux/card/index.blade.php
@@ -13,8 +13,8 @@ $classes = Flux::classes()
         default => '[:where(&)]:bg-white [:where(&)]:border-zinc-200 dark:[:where(&)]:bg-white/10 dark:[:where(&)]:border-white/10',
     })
     ->add(match ($size) {
-        default => '[:where(&)]:p-6 [:where(&)]:rounded-xl',
-        'sm' => '[:where(&)]:p-4 [:where(&)]:rounded-lg',
+        default => '[:where(&)]:p-6 [:where(&)]:rounded-xl [--flux-card-padding:1.5rem]',
+        'sm' => '[:where(&)]:p-4 [:where(&)]:rounded-lg [--flux-card-padding:1rem]',
     })
     ;
 @endphp

--- a/stubs/resources/views/flux/card/index.blade.php
+++ b/stubs/resources/views/flux/card/index.blade.php
@@ -13,8 +13,8 @@ $classes = Flux::classes()
         default => '[:where(&)]:bg-white [:where(&)]:border-zinc-200 dark:[:where(&)]:bg-white/10 dark:[:where(&)]:border-white/10',
     })
     ->add(match ($size) {
-        default => '[:where(&)]:p-6 [:where(&)]:rounded-xl [--flux-card-padding:1.5rem]',
-        'sm' => '[:where(&)]:p-4 [:where(&)]:rounded-lg [--flux-card-padding:1rem]',
+        default => '[:where(&)]:p-6 [:where(&)]:rounded-xl [--flux-bleed:1.5rem]',
+        'sm' => '[:where(&)]:p-4 [:where(&)]:rounded-lg [--flux-bleed:1rem]',
     })
     ;
 @endphp

--- a/stubs/resources/views/flux/table/index.blade.php
+++ b/stubs/resources/views/flux/table/index.blade.php
@@ -2,6 +2,7 @@
 
 @props([
     'paginate' => null,
+    'bleed' => false,
 ])
 
 @php
@@ -10,10 +11,17 @@ $classes = Flux::classes()
     ->add('text-zinc-800')
     // We want whitespace-nowrap for the table, but not for modals and dropdowns...
     ->add('whitespace-nowrap [&_dialog]:whitespace-normal [&_[popover]]:whitespace-normal')
+    ->add($bleed ? [
+        '[&_[data-flux-column]:first-child]:ps-[var(--flux-card-padding)]',
+        '[&_[data-flux-cell]:first-child]:ps-[var(--flux-card-padding)]',
+        '[&_[data-flux-column]:last-child]:pe-[var(--flux-card-padding)]',
+        '[&_[data-flux-cell]:last-child]:pe-[var(--flux-card-padding)]',
+    ] : '')
     ;
 
 $containerClasses = Flux::classes()
     ->add('flex flex-col')
+    ->add($bleed ? '-mx-[var(--flux-card-padding)]' : '')
     ->add($attributes->pluck('container:class'))
     ;
 @endphp
@@ -30,7 +38,12 @@ $containerClasses = Flux::classes()
     {{ $footer ?? '' }}
 
     <?php if ($paginate): ?>
-        <?php $paginationAttributes = Flux::attributesAfter('pagination:', $attributes, ['paginator' => $paginate, 'class' => 'shrink-0']); ?>
+        <?php $paginationAttributes = Flux::attributesAfter('pagination:', $attributes, [
+            'paginator' => $paginate,
+            'class' => Flux::classes()
+                ->add('shrink-0')
+                ->add($bleed ? 'px-[var(--flux-card-padding)]' : ''),
+        ]); ?>
         <flux:pagination :attributes="$paginationAttributes" />
     <?php endif; ?>
 </div>

--- a/stubs/resources/views/flux/table/index.blade.php
+++ b/stubs/resources/views/flux/table/index.blade.php
@@ -12,16 +12,16 @@ $classes = Flux::classes()
     // We want whitespace-nowrap for the table, but not for modals and dropdowns...
     ->add('whitespace-nowrap [&_dialog]:whitespace-normal [&_[popover]]:whitespace-normal')
     ->add($bleed ? [
-        '[&_[data-flux-column]:first-child]:ps-[var(--flux-card-padding)]',
-        '[&_[data-flux-cell]:first-child]:ps-[var(--flux-card-padding)]',
-        '[&_[data-flux-column]:last-child]:pe-[var(--flux-card-padding)]',
-        '[&_[data-flux-cell]:last-child]:pe-[var(--flux-card-padding)]',
+        '[&_[data-flux-column]:first-child]:ps-[var(--flux-bleed)]',
+        '[&_[data-flux-cell]:first-child]:ps-[var(--flux-bleed)]',
+        '[&_[data-flux-column]:last-child]:pe-[var(--flux-bleed)]',
+        '[&_[data-flux-cell]:last-child]:pe-[var(--flux-bleed)]',
     ] : '')
     ;
 
 $containerClasses = Flux::classes()
     ->add('flex flex-col')
-    ->add($bleed ? '-mx-[var(--flux-card-padding)]' : '')
+    ->add($bleed ? '-mx-[var(--flux-bleed)]' : '')
     ->add($attributes->pluck('container:class'))
     ;
 @endphp
@@ -42,7 +42,7 @@ $containerClasses = Flux::classes()
             'paginator' => $paginate,
             'class' => Flux::classes()
                 ->add('shrink-0')
-                ->add($bleed ? 'px-[var(--flux-card-padding)]' : ''),
+                ->add($bleed ? 'px-[var(--flux-bleed)]' : ''),
         ]); ?>
         <flux:pagination :attributes="$paginationAttributes" />
     <?php endif; ?>

--- a/stubs/resources/views/flux/table/index.blade.php
+++ b/stubs/resources/views/flux/table/index.blade.php
@@ -12,16 +12,16 @@ $classes = Flux::classes()
     // We want whitespace-nowrap for the table, but not for modals and dropdowns...
     ->add('whitespace-nowrap [&_dialog]:whitespace-normal [&_[popover]]:whitespace-normal')
     ->add($bleed ? [
-        '[&_[data-flux-column]:first-child]:ps-[var(--flux-bleed)]',
-        '[&_[data-flux-cell]:first-child]:ps-[var(--flux-bleed)]',
-        '[&_[data-flux-column]:last-child]:pe-[var(--flux-bleed)]',
-        '[&_[data-flux-cell]:last-child]:pe-[var(--flux-bleed)]',
+        '[&_[data-flux-column]:first-child]:ps-[var(--flux-bleed,1.5rem)]',
+        '[&_[data-flux-cell]:first-child]:ps-[var(--flux-bleed,1.5rem)]',
+        '[&_[data-flux-column]:last-child]:pe-[var(--flux-bleed,1.5rem)]',
+        '[&_[data-flux-cell]:last-child]:pe-[var(--flux-bleed,1.5rem)]',
     ] : '')
     ;
 
 $containerClasses = Flux::classes()
     ->add('flex flex-col')
-    ->add($bleed ? '-mx-[var(--flux-bleed)]' : '')
+    ->add($bleed ? '-mx-[var(--flux-bleed,1.5rem)]' : '')
     ->add($attributes->pluck('container:class'))
     ;
 @endphp
@@ -42,7 +42,7 @@ $containerClasses = Flux::classes()
             'paginator' => $paginate,
             'class' => Flux::classes()
                 ->add('shrink-0')
-                ->add($bleed ? 'px-[var(--flux-bleed)]' : ''),
+                ->add($bleed ? 'px-[var(--flux-bleed,1.5rem)]' : ''),
         ]); ?>
         <flux:pagination :attributes="$paginationAttributes" />
     <?php endif; ?>


### PR DESCRIPTION
# The scenario

Tables are designed to sit inside surrounding page padding, so their first and last cells intentionally remove their outer padding. Inside a card, some layouts instead need full-width dividers while preserving the card gutter for cell content.

# The problem

Achieving that composition currently requires pulling the table container through the parent padding and manually restoring padding on every first and last header and body cell. The required gutter also differs between default cards, small cards, and custom containers.

# The solution

This adds a boolean `bleed` prop to `flux:table`. Cards expose their size-aware horizontal gutter through an inherited `--flux-bleed` CSS variable, and bleeding tables use it to extend their container while restoring the same gutter on edge cells. Paginated tables keep pagination aligned to the gutter as well.

The gutter defaults to `1.5rem`. Default and `size="sm"` cards provide their gutter automatically; custom containers can set the same variable to match their padding, for example `class="p-4 [--flux-bleed:1rem]"`.

Related Flux Pro PR: https://github.com/livewire/flux-pro/pull/568
Docs PR: https://github.com/livewire/flux-docs/pull/210

## Verification

- `composer validate --no-check-publish`
- Linked Laravel playground: `npm run build`; 2 tests passed
- Flux docs: `npm run build`; 426 tests passed, 8 skipped
- Browser-verified default card (24px), small card (16px), and custom `p-4` container (16px): dividers reach the inner border and edge-cell content remains aligned