### PR TITLE
Fix flag URLs when the application is served from a subdirectory

### DIFF
--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -66,7 +66,7 @@ class AssetManager
 
         if (! $hash) return null;
 
-        return route('__flux.flag', ['country' => $country], false).'?id='.$hash;
+        return url(route('__flux.flag', ['country' => $country], false)).'?id='.$hash;
     }
 
     public static function hasFlag(string $country): bool

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -66,7 +66,9 @@ class AssetManager
 
         if (! $hash) return null;
 
-        return url(route('__flux.flag', ['country' => $country], false)).'?id='.$hash;
+        // Following scripts(), editorScripts(), and editorStyles()
+        // Related: https://github.com/livewire/flux/pull/2183
+        return url(route('__flux.flag', ['country' => $country], false).'?id='.$hash);
     }
 
     public static function hasFlag(string $country): bool

--- a/stubs/resources/views/flux/flag.blade.php
+++ b/stubs/resources/views/flux/flag.blade.php
@@ -36,7 +36,7 @@ $classes = Flux::classes()
         ]) }}
     >
         <img
-            src="{{ $country ? $src : url($src) }}"
+            src="{{ $src }}"
             alt="{{ $alt }}"
             loading="lazy"
             decoding="async"

--- a/stubs/resources/views/flux/flag.blade.php
+++ b/stubs/resources/views/flux/flag.blade.php
@@ -36,7 +36,7 @@ $classes = Flux::classes()
         ]) }}
     >
         <img
-            src="{{ $src }}"
+            src="{{ $country ? $src : url($src) }}"
             alt="{{ $alt }}"
             loading="lazy"
             decoding="async"


### PR DESCRIPTION
## Problem
`AssetManager::flagUrl()` (used by the `<flux:flag>` component) generated a root-relative path via:

```php
route('__flux.flag', ['country' => $country], false)
```

When the Laravel app lives under a path prefix / subdirectory, the browser resolves `/flux/flags/XX` against the domain root instead of the application base. This results in 404s for flag SVGs.

Reported in https://github.com/livewire/flux/issues/2793.
Related PR: https://github.com/livewire/flux/pull/2183

## Solution

Wrap the relative route result with Laravel’s `url()` helper so the generated URL respects the application’s base path `/ APP_URL /`:

```php
return url(route('__flux.flag', ['country' => $country], false).'?id='.$hash);
```

Fixes: https://github.com/livewire/flux/issues/2793