### PR TITLE
Fix collapsed sidebar group item layout

### DIFF
--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -59,7 +59,7 @@ $classes = Flux::classes()
     ;
 @endphp
 
-<flux:tooltip :position="$tooltipPosition">
+<flux:tooltip :position="$tooltipPosition" class="block">
     <flux:button-or-link :attributes="$attributes->class($classes)" data-flux-sidebar-item>
         <?php if ($icon): ?>
             <div class="relative">


### PR DESCRIPTION
Fixes #2801.

## The problem

`flux:sidebar.item` is wrapped in `flux:tooltip`. Since #2746 made `ui-tooltip` an `inline-flex` element, sidebar items reused inside a collapsed group's flyout render beside each other instead of as separate menu rows.

## The fix

Make the sidebar item's internal tooltip wrapper block-level. This keeps each item on its own row without changing the global `ui-tooltip` display rule or ordinary tooltip behavior.

## Validation

- Reproduced the regression against the current collapsible-sidebar demo.
- Verified the fix in a fresh Laravel app using the issue's four-item expandable sidebar group.
- Confirmed all four flyout wrappers share the same x-coordinate and have increasing y-coordinates.
- Confirmed a disabled toggle's tooltip host remains the same 40×40 size as its control and still opens on hover.
- `composer validate --strict --no-check-publish`
- `git diff --check`
- Fresh Laravel app build via `npm run build`
- Fresh Laravel app tests: 2 passed
