### PR TITLE
Fix truncation of sidebar group headings and items

### DIFF
--- a/stubs/resources/views/flux/sidebar/group.blade.php
+++ b/stubs/resources/views/flux/sidebar/group.blade.php
@@ -15,7 +15,7 @@
 <?php if ($expandable && $heading): ?>
     <?php if ($icon): ?>
         <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} @if ($expanded === true) open @endif data-flux-sidebar-group>
-            <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button my-px rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
+            <button type="button" class="border-1 border-transparent w-full min-w-0 h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button my-px rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
                 <div class="px-3">
                     <?php if (is_string($icon) && $icon !== ''): ?>
                         <flux:icon :icon="$icon" :variant="$iconVariant" class="size-4" />
@@ -24,7 +24,7 @@
                     <?php endif; ?>
                 </div>
 
-                <span class="flex-1 text-left rtl:text-right text-sm font-medium leading-none">{{ $heading }}</span>
+                <span class="flex-1 text-left rtl:text-right text-sm font-medium truncate">{{ $heading }}</span>
 
                 <div class="ps-3 pe-2.5">
                     <flux:icon.chevron-down class="size-3! hidden group-data-open/disclosure-button:block" />
@@ -32,7 +32,7 @@
                 </div>
             </button>
 
-            <div class="relative hidden data-open:block ps-7" @if ($expanded === true) data-open @endif>
+            <div class="relative min-w-0 hidden data-open:block ps-7" @if ($expanded === true) data-open @endif>
                 <div class="absolute inset-y-[3px] w-px bg-zinc-200 dark:bg-white/30 start-0 ms-5"></div>
 
                 <div class="flex flex-col">
@@ -69,16 +69,16 @@
         </flux:dropdown>
     <?php else: ?>
         <ui-disclosure {{ $attributes->class('group/disclosure in-data-flux-sidebar-collapsed-desktop:hidden') }} @if ($expanded === true) open @endif data-flux-sidebar-group>
-            <button type="button" class="border-1 border-transparent w-full h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button my-px rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
+            <button type="button" class="border-1 border-transparent w-full min-w-0 h-8 in-data-flux-sidebar-on-mobile:h-10 flex items-center group/disclosure-button my-px rounded-lg hover:bg-zinc-800/5 dark:hover:bg-white/[7%] text-zinc-500 hover:text-zinc-800 dark:text-white/80 dark:hover:text-white">
                 <div class="ps-3.5 pe-3.5">
                     <flux:icon.chevron-down class="size-3! hidden group-data-open/disclosure-button:block" />
                     <flux:icon.chevron-right class="size-3! block group-data-open/disclosure-button:hidden rtl:rotate-180" />
                 </div>
 
-                <span class="text-sm font-medium leading-none">{{ $heading }}</span>
+                <span class="text-sm font-medium truncate">{{ $heading }}</span>
             </button>
 
-            <div class="relative hidden data-open:block ps-7" @if ($expanded === true) data-open @endif>
+            <div class="relative min-w-0 hidden data-open:block ps-7" @if ($expanded === true) data-open @endif>
                 <div class="absolute inset-y-[3px] w-px bg-zinc-200 dark:bg-white/30 start-0 ms-5"></div>
 
                 <div class="flex flex-col">
@@ -90,11 +90,9 @@
 
 <?php elseif ($heading): ?>
     <div {{ $attributes->class('flex flex-col in-data-flux-sidebar-collapsed-desktop:hidden') }} data-flux-sidebar-group>
-        <div class="px-3 py-2">
-            <div class="text-sm text-zinc-400 font-medium leading-none">{{ $heading }}</div>
-        </div>
+        <div class="px-3 py-2 text-sm text-zinc-400 font-medium leading-none truncate">{{ $heading }}</div>
 
-        <div class="flex flex-col">
+        <div class="flex flex-col min-w-0">
             {{ $slot }}
         </div>
     </div>

--- a/stubs/resources/views/flux/sidebar/item.blade.php
+++ b/stubs/resources/views/flux/sidebar/item.blade.php
@@ -59,7 +59,7 @@ $classes = Flux::classes()
     ;
 @endphp
 
-<flux:tooltip :position="$tooltipPosition" class="block">
+<flux:tooltip :position="$tooltipPosition" class="block min-w-0">
     <flux:button-or-link :attributes="$attributes->class($classes)" data-flux-sidebar-item>
         <?php if ($icon): ?>
             <div class="relative">


### PR DESCRIPTION
Fixes #2802.

## The problem

`flux:sidebar.item` gained `truncate` on its label in #2340, but that only works when every ancestor lets the item shrink. The docs render every `flux:sidebar.group` example with `class="grid"`, and in a grid the group's children (the header `<button>`, the expanded content wrapper, and the items themselves) default to `min-width: auto`. The single implicit column therefore grows to the widest `nowrap` item, the `w-full` items inherit that width, and the labels get clipped by the sidebar's edge instead of showing an ellipsis. It's also why hovered items visibly extend past the sidebar in the issue's second screenshot.

Long group headings had a separate problem: they wrapped onto a second line inside the fixed-height `h-8` button.

## The fix

- `sidebar/group.blade.php`
  - `min-w-0` on the expandable header buttons and the expanded content wrapper so they can shrink inside a grid.
  - Group headings now `truncate` instead of wrapping. The expandable headings drop `leading-none` in favour of the default `text-sm` line height (the same as the item label) so the overflow clip can't shave descenders. The button is a fixed `h-8` with `items-center`, so the rendered position is unchanged.
  - The non-expandable heading is collapsed into a single padded element with `truncate`, so the clip happens at the padding edge and `leading-none` still governs the row height (30px, as before).
  - `min-w-0` on the non-expandable group's item wrapper.
- `sidebar/item.blade.php`
  - `min-w-0` on the tooltip wrapper from #2804 so an item placed directly in a grid group (no heading) shrinks too.

## Validation

Reproduced against the issue's exact markup plus an icon group, a non-grid expandable group, a non-expandable heading group and a heading-less grid group, all with long labels, in a Laravel app linked to this branch.

Before, in a 223px nav, the grid groups' rows measured 355 to 484px wide and their labels were clipped with no ellipsis. After, every row is at most 223px, every long label reports `scrollWidth > clientWidth` (truncated), headings sit on one line, and the badge and chevron stay visible at the right edge. The non-expandable heading row is still 30px tall.

Also collapsed the sidebar and hovered the icon group: the flyout menu still renders the heading and each item as its own vertical row, so #2804 is unaffected.

`git diff --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNnAHUKD1vQSfUijmauqSn
