### PR TITLE
Add 2xl heading size

### DIFF
--- a/stubs/resources/views/flux/heading.blade.php
+++ b/stubs/resources/views/flux/heading.blade.php
@@ -14,6 +14,7 @@ $classes = Flux::classes()
         default => '[:where(&)]:text-zinc-800 [:where(&)]:dark:text-white',
     })
     ->add(match ($size) {
+        '2xl' => 'text-4xl [&:has(+[data-flux-subheading])]:mb-2 [[data-flux-subheading]+&]:mt-2',
         'xl' => 'text-2xl [&:has(+[data-flux-subheading])]:mb-2 [[data-flux-subheading]+&]:mt-2',
         'lg' => 'text-base [&:has(+[data-flux-subheading])]:mb-2 [[data-flux-subheading]+&]:mt-2',
         default => 'text-sm [&:has(+[data-flux-subheading])]:mb-2 [[data-flux-subheading]+&]:mt-2',


### PR DESCRIPTION
Adds `<flux:heading size="2xl">` using `text-4xl` (2.25rem, or 36px with the default root font size), keeping the existing heading weight and subheading spacing.

Verified on the flux-docs heading page after rebuilding assets: heading sizes compute to 14px, 16px, 24px, and 36px, with a 40px line height for the new size. Visually checked the rendered demo and ran `git diff --check`.

Companion docs: https://github.com/livewire/flux-docs/pull/227.
