### PR TITLE
Fix wire:click inside flux:modal after the dialog is shown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Check PHP syntax
         run: find src -type f -name '*.php' -print0 | xargs -0 -n1 php -l
+
+      - name: Run modal Livewire id regression
+        run: php tests/ModalDialogPreservesLivewireIdTest.php

--- a/stubs/resources/views/flux/modal/index.blade.php
+++ b/stubs/resources/views/flux/modal/index.blade.php
@@ -120,6 +120,10 @@ if (! $overflow) {
         <?php if ($flyout): ?> data-flux-flyout <?php endif; ?>
         <?php if ($overflow): ?> data-flux-modal-overflow <?php endif; ?>
         @unblaze(scope: ['name' => $name])
+        {{-- Stamp the owner Livewire id on the dialog so wire:click still resolves after showModal() (top layer / polyfill move). Nested Livewire roots in the slot still win via closest(). Keep this in @unblaze so Blaze does not fold a stale id. --}}
+        <?php if (isset($__livewire)): ?>
+            wire:id="{{ $__livewire->getId() }}"
+        <?php endif; ?>
         x-data="fluxModal(@js($scope['name']), @js(isset($__livewire) ? $__livewire->getId() : null))"
         @endunblaze
         x-on:modal-show.document="handleShow($event)"

--- a/tests/ModalDialogPreservesLivewireIdTest.php
+++ b/tests/ModalDialogPreservesLivewireIdTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Regression: wire:click inside flux:modal must still resolve the Livewire
+ * component that owns the modal after <dialog> enters the top layer.
+ *
+ * Livewire looks up the nearest [wire:id] from the click target. showModal()
+ * (and dialog polyfills that move the node) leave the slot outside that
+ * ancestor. The owner id is already passed into fluxModal(); it also has to
+ * be stamped on the <dialog> itself, inside @unblaze so Blaze does not fold it.
+ *
+ * Livewire::test()->call() never hits this path — it invokes PHP directly.
+ */
+
+$stubPath = dirname(__DIR__).'/stubs/resources/views/flux/modal/index.blade.php';
+$stub = file_get_contents($stubPath);
+
+if ($stub === false) {
+    fwrite(STDERR, "FAIL: unable to read modal stub\n");
+    exit(1);
+}
+
+$failures = 0;
+
+function assertTrue($condition, $message)
+{
+    global $failures;
+
+    if ($condition) {
+        fwrite(STDOUT, "PASS: {$message}\n");
+
+        return;
+    }
+
+    fwrite(STDERR, "FAIL: {$message}\n");
+    $failures++;
+}
+
+assertTrue(str_contains($stub, '<dialog'), 'modal stub renders a <dialog>');
+
+assertTrue(
+    (bool) preg_match('/@unblaze\b.*?@endunblaze/s', $stub, $unblazeMatch),
+    'dialog Livewire id is inside @unblaze (not Blaze-folded)'
+);
+
+$unblaze = $unblazeMatch[0] ?? '';
+
+assertTrue(
+    str_contains($unblaze, 'wire:id="{{ $__livewire->getId() }}"'),
+    '<dialog> stamps wire:id with the owning Livewire component id'
+);
+
+assertTrue(
+    (bool) preg_match(
+        '/if \(isset\(\$__livewire\)\):.*?wire:id="\{\{ \$__livewire->getId\(\) \}\}"/s',
+        $unblaze
+    ),
+    'wire:id is omitted when the modal is rendered outside a Livewire component'
+);
+
+$dialogPos = strpos($stub, '<dialog');
+$unblazePos = strpos($stub, '@unblaze');
+$slotPos = strpos($stub, '{{ $slot }}');
+
+assertTrue(
+    $dialogPos !== false && $unblazePos !== false && $slotPos !== false
+        && $dialogPos < $unblazePos && $unblazePos < $slotPos,
+    'owner wire:id is on the <dialog>, which is what leaves the Livewire root'
+);
+
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
- `wire:click` (and Alpine `$wire`) inside `flux:modal` do not call the Livewire component that owns `wire:model.self` after the native dialog is shown.
- This PR stamps the owner component id on that dialog (inside `@unblaze`) so Livewire's nearest `[wire:id]` lookup still finds that owner. Nested Livewire roots in the slot still win via `closest()`.

# The scenario

A Livewire page owns `flux:modal` with `wire:model.self`. A button in the slot uses `wire:click` to call a method on that same component (or on a nested Livewire child in the slot). After the modal opens, the click never reaches the owner, or it hits the parent instead of the child.

# The problem

`ui-modal` shows the native dialog with `showModal()`. That puts the dialog in the top layer (DevTools looks like a teleport; some dialog polyfills actually move the node). The action HTML is no longer under the page component's `[wire:id]` root.

`wire:click` / `$wire` then:
- do not find the owner, or
- find another Livewire component (layout / page), or
- with a nested child in the slot, find the **parent** instead of the child (`MethodNotFoundException` on the parent).

`fluxModal()` already received the Livewire id for show/close scoping, but `wire:*` directives in the slot were not bound to that id.

# The solution

Stamp the owner Livewire id on the dialog when a Livewire component owns the modal:

```blade
wire:id="{{ $__livewire->getId() }}"
```

Keep it inside `@unblaze` so Blaze does not fold a stale id. A nested Livewire root in the slot is closer in the DOM, so `closest()` still targets the child.

## Issue details
### Expected behavior
A control inside the `flux:modal` slot with `wire:click="deleteNote(...)"` should call `deleteNote` on the same Livewire component that has `wire:model.self` for the modal.

If a Livewire child is rendered in the slot, `wire:click="childMethod"` should call the child, not the parent.

### Actual behavior
After `showModal()`, `wire:click` does not resolve the owner. Nested child actions can be dispatched to the parent instead.

### Environment
| Item | Value |
|---|---|
| Livewire | v4.4.0 |
| Flux | v2.16.0 |
| Markup | `flux:modal` / `ui-modal` + `dialog wire:ignore.self` + `x-data="fluxModal(name, livewireId)"` |

### Steps to reproduce
Use a full-page Livewire component with Flux.

**Case 1 — method on the modal owner**

```blade
<flux:modal wire:model.self="showDetailModal">
    <button type="button" wire:click="deleteNote({{ $note->id }})">
        Delete note
    </button>
</flux:modal>
```

1. Open the page and open the modal.
2. Click the button.
3. Failed result: the method never runs (no Livewire request), or the overlay shows `Unable to call component method`.
4. Inspect the DOM: dialog contents are not under the page element with `wire:id`.

The same method works if invoked with `Livewire.find(<owner id>).deleteNote(...)`.

**Case 2 — Livewire child inside the modal**

Parent owns `flux:modal`. Child inside the slot has `wire:click="deleteNote"`.

1. Open the modal and click delete on the child.
2. Result: `MethodNotFoundException` on the **parent** component, not the child.

### Reproduction checklist
- [ ] Modal is `flux:modal` (contents are outside the `wire:id` tree in DevTools)
- [ ] The action is a click (`wire:click`), not only `Livewire::test()->call()`
- [ ] The same method works via `Livewire.find(componentId)`
- [ ] With a Livewire child in the slot, any error names the **parent**, not the child

### Testing traps
`Livewire::test(Component::class)->call('deleteNote')` invokes PHP directly and never goes through the dialog DOM. It does not prove the button works.

## Test plan
- [ ] Before this change, `php tests/ModalDialogPreservesLivewireIdTest.php` fails because the dialog has no owner `wire:id`
- [ ] After this change, that test passes (id is on the dialog inside `@unblaze`, omitted when there is no Livewire component)
- [ ] Full suite (same as CI): `composer validate --strict`, `php -l` on `src/`, and the modal regression test
- [ ] In the browser: `wire:click` on a native button inside `flux:modal` calls the owner; a nested Livewire child in the slot still receives its own `wire:click`