### PR TITLE
Fix button with icons but empty slot rendered as square button

### DIFF
--- a/stubs/resources/views/flux/button/index.blade.php
+++ b/stubs/resources/views/flux/button/index.blade.php
@@ -24,7 +24,7 @@
 $iconLeading = $icon ??= $iconLeading;
 
 // Button should be a square if it has no text contents...
-$square ??= $slot->isEmpty();
+$square ??= $slot->isEmpty() && ! ($iconLeading && $iconTrailing);
 
 // Size-up icons in square/icon-only buttons... (xs buttons just get micro size/style...)
 $iconVariant ??= ($size === 'xs')


### PR DESCRIPTION
## Summary

Fix flux button with icons but no slot content rendered as square button

## Problem

Buttons with both `icon` and `icon:trailing` but no text content were incorrectly rendered as square buttons when Blaze was disabled/enabled.

This happens because an empty/whitespace-only slot is treated as empty by the compiled view, causing `$square` to default to `true`. As a result, the button receives the square styling (`w-8` for small button) and the two icons lose their expected spacing and overlap.

## Solution

Only default the button to square when the slot is empty **and the button does not contain both a leading and trailing icon**.

This preserves the existing square-button behavior for icon-only buttons while ensuring buttons containing two icons are rendered with the correct spacing, regardless of whether Blaze is enabled.

**Before**
```php
$square ??= $slot->isEmpty();
```
**After**
```php
$square ??= $slot->isEmpty() && ! ($iconLeading && $iconTrailing);
```

## Setup

```blade
<flux:main class="flex gap-6">
    <flux:button wire:click="save" variant="outline" icon="briefcase" icon:trailing="chevron-down"> </flux:button>
    <flux:button wire:click="save" variant="outline" icon="briefcase" icon:trailing="chevron-down" :square="false" />
    <flux:button wire:click="save" variant="outline" icon="briefcase" icon:trailing="chevron-down" />
    <flux:button wire:click="save" variant="outline" icon="briefcase" icon:trailing="chevron-down">Test</flux:button>
    <flux:button.group>
        <flux:button>Save</flux:button>
        <flux:button icon="chevron-down" />
    </flux:button.group>
    <flux:button.group>
        <flux:button icon="pencil-square" />
        <flux:button>Edit</flux:button>
    </flux:button.group>
    <flux:button.group>
        <flux:button icon="magnifying-glass" />
        <flux:button>Options</flux:button>
        <flux:button icon="chevron-down" />
    </flux:button.group>
</flux:main>
```

> [!NOTE]
> Notice that the first button with whitespace slot rendered slightly different when Blaze disabled and enabled. It seems Blaze treat whitespace differently therefore I'll just keep it as it is.

### Blaze Off
Before:
<img width="776" height="64" alt="image" src="https://github.com/user-attachments/assets/ea732329-d8c8-4f80-8cc4-db3bffa5267a" />

After:
<img width="831" height="69" alt="image" src="https://github.com/user-attachments/assets/5f91d847-765c-4320-acde-80f3d6cb4c2e" />

### Blaze On
Before: 
<img width="810" height="67" alt="image" src="https://github.com/user-attachments/assets/da48f3ce-3dda-4561-9414-ba664385a641" />

After: 
<img width="837" height="67" alt="image" src="https://github.com/user-attachments/assets/dc54dfd2-efdd-469a-bd60-dac2b75205d3" />

Related PR: https://github.com/livewire/blaze/pull/209
Fixes #2816